### PR TITLE
Removing references to deprecated canopy clustering tests and examples.

### DIFF
--- a/examples/bin/cluster-syntheticcontrol.sh
+++ b/examples/bin/cluster-syntheticcontrol.sh
@@ -34,7 +34,6 @@ else
   echo "Please select a number to choose the corresponding clustering algorithm"
   echo "1. ${algorithm[0]} clustering"
   echo "2. ${algorithm[1]} clustering"
-  echo "3. ${algorithm[2]} clustering"
   read -p "Enter your choice : " choice
 fi
 echo "ok. You chose $choice and we'll use ${algorithm[$choice-1]} Clustering"

--- a/integration/src/test/java/org/apache/mahout/clustering/TestClusterEvaluator.java
+++ b/integration/src/test/java/org/apache/mahout/clustering/TestClusterEvaluator.java
@@ -138,7 +138,7 @@ public final class TestClusterEvaluator extends MahoutTestCase {
       points.add(new VectorWritable(cluster.getCenter().plus(new DenseVector(new double[] {-dP, dP}))));
     }
   }
-  
+
   @Test
   public void testRepresentativePoints() throws Exception {
     ClusteringTestUtils.writePointsToFile(referenceData, new Path(testdata, "file1"), fs, conf);

--- a/mrlegacy/src/main/java/org/apache/mahout/clustering/AbstractCluster.java
+++ b/mrlegacy/src/main/java/org/apache/mahout/clustering/AbstractCluster.java
@@ -355,17 +355,11 @@ public abstract class AbstractCluster implements Cluster {
    */
   public static List<Object> formatVectorAsJson(Vector v, String[] bindings) throws IOException {
 
-    List<TermIndexWeight> vectorTerms = Lists.newArrayList();
-
     boolean hasBindings = bindings != null;
     boolean isSparse = !v.isDense() && v.getNumNondefaultElements() != v.size();
 
     // we assume sequential access in the output
     Vector provider = v.isSequentialAccess() ? v : new SequentialAccessSparseVector(v);
-
-    for (Vector.Element elt : v.nonZeroes()) {
-      vectorTerms.add(new TermIndexWeight(elt.index(), elt.get()));
-    }
 
     List<Object> terms = Lists.newLinkedList();
     String term = "";
@@ -389,20 +383,6 @@ public abstract class AbstractCluster implements Cluster {
     }
 
     return terms;
-  }
-
-  /**
-   * Convenience class for sorting terms
-   *
-   */
-  private static class TermIndexWeight {
-    private final int index;
-    private final double weight;
-
-    TermIndexWeight(int index, double weight) {
-      this.index = index;
-      this.weight = weight;
-    }
   }
 
   @Override

--- a/mrlegacy/src/main/java/org/apache/mahout/clustering/Cluster.java
+++ b/mrlegacy/src/main/java/org/apache/mahout/clustering/Cluster.java
@@ -27,10 +27,7 @@ import java.util.Map;
  * 
  */
 public interface Cluster extends Model<VectorWritable>, Parametered {
-  
-  // default directory for all clustered points
-  String CLUSTERED_POINTS_DIR = "clusteredPoints";
-  
+
   // default directory for initial clusters to prime iterative clustering
   // algorithms
   String INITIAL_CLUSTERS_DIR = "clusters-0";

--- a/mrlegacy/src/test/java/org/apache/mahout/clustering/TestClusterInterface.java
+++ b/mrlegacy/src/test/java/org/apache/mahout/clustering/TestClusterInterface.java
@@ -17,64 +17,17 @@
 
 package org.apache.mahout.clustering;
 
-import org.apache.mahout.clustering.canopy.Canopy;
 import org.apache.mahout.common.MahoutTestCase;
 import org.apache.mahout.common.distance.DistanceMeasure;
 import org.apache.mahout.common.distance.ManhattanDistanceMeasure;
 import org.apache.mahout.math.DenseVector;
 import org.apache.mahout.math.SequentialAccessSparseVector;
 import org.apache.mahout.math.Vector;
-
-import org.codehaus.jackson.map.ObjectMapper;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.util.Map;
 
 public final class TestClusterInterface extends MahoutTestCase {
 
   private static final DistanceMeasure measure = new ManhattanDistanceMeasure();
-
-  private final ObjectMapper jxn = new ObjectMapper();
-
-  @Test
-  public void testCanopyAsFormatString() throws IOException {
-    double[] d = { 1.1, 2.2, 3.3 };
-    Vector m = new DenseVector(d);
-    Cluster cluster = new Canopy(m, 123, measure);
-    String formatString = cluster.asFormatString(null);
-    assertEquals("{\"r\":[],\"c\":[1.1,2.2,3.3],\"n\":0,\"identifier\":\"C-123\"}", formatString);
-  }
-
-  @Test
-  public void testCanopyAsFormatStringSparse() {
-    double[] d = { 1.1, 0.0, 3.3 };
-    Vector m = new SequentialAccessSparseVector(3);
-    m.assign(d);
-    Cluster cluster = new Canopy(m, 123, measure);
-    String formatString = cluster.asFormatString(null);
-    assertEquals("{\"r\":[],\"c\":[{\"0\":1.1},{\"2\":3.3}],\"n\":0,\"identifier\":\"C-123\"}", formatString);
-  }
-
-  @Test
-  public void testCanopyAsFormatStringWithBindings() {
-    double[] d = { 1.1, 2.2, 3.3 };
-    Vector m = new DenseVector(d);
-    Cluster cluster = new Canopy(m, 123, measure);
-    String[] bindings = { "fee", null, null };
-    String formatString = cluster.asFormatString(bindings);
-    assertEquals("{\"r\":[],\"c\":[{\"fee\":1.1},{\"1\":2.2},{\"2\":3.3}],\"n\":0,\"identifier\":\"C-123\"}", formatString);
-  }
-
-  @Test
-  public void testCanopyAsFormatStringSparseWithBindings() {
-    double[] d = { 1.1, 0.0, 3.3 };
-    Vector m = new SequentialAccessSparseVector(3);
-    m.assign(d);
-    Cluster cluster = new Canopy(m, 123, measure);
-    String formatString = cluster.asFormatString(null);
-    assertEquals("{\"r\":[],\"c\":[{\"0\":1.1},{\"2\":3.3}],\"n\":0,\"identifier\":\"C-123\"}", formatString);
-  }
 
   @Test
   public void testClusterAsFormatString() {

--- a/mrlegacy/src/test/java/org/apache/mahout/clustering/iterator/TestClusterClassifier.java
+++ b/mrlegacy/src/test/java/org/apache/mahout/clustering/iterator/TestClusterClassifier.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.mahout.clustering.AbstractCluster;
 import org.apache.mahout.clustering.Cluster;
 import org.apache.mahout.clustering.ClusteringTestUtils;
-import org.apache.mahout.clustering.canopy.Canopy;
 import org.apache.mahout.clustering.classify.ClusterClassifier;
 import org.apache.mahout.clustering.fuzzykmeans.SoftCluster;
 import org.apache.mahout.clustering.kmeans.TestKmeansClustering;
@@ -90,20 +89,6 @@ public final class TestClusterClassifier extends MahoutTestCase {
   @Test
   public void testDMClusterClassification() {
     ClusterClassifier classifier = newDMClassifier();
-    Vector pdf = classifier.classify(new DenseVector(2));
-    assertEquals("[0,0]", "[0.2,0.6,0.2]", AbstractCluster.formatVector(pdf, null));
-    pdf = classifier.classify(new DenseVector(2).assign(2));
-    assertEquals("[2,2]", "[0.493,0.296,0.211]", AbstractCluster.formatVector(pdf, null));
-  }
-  
-  @Test
-  public void testCanopyClassification() {
-    List<Cluster> models = Lists.newArrayList();
-    DistanceMeasure measure = new ManhattanDistanceMeasure();
-    models.add(new Canopy(new DenseVector(2).assign(1), 0, measure));
-    models.add(new Canopy(new DenseVector(2), 1, measure));
-    models.add(new Canopy(new DenseVector(2).assign(-1), 2, measure));
-    ClusterClassifier classifier = new ClusterClassifier(models, new CanopyClusteringPolicy());
     Vector pdf = classifier.classify(new DenseVector(2));
     assertEquals("[0,0]", "[0.2,0.6,0.2]", AbstractCluster.formatVector(pdf, null));
     pdf = classifier.classify(new DenseVector(2).assign(2));


### PR DESCRIPTION
Fixes suggested by Suneel above. Note Canopy and CanopyDriver are still used in TestClusterEvaluation and other tests; how far do we want to go on this before removing Canopy entirely?
