### PR TITLE
spark-shell: set implicit sc

### DIFF
--- a/spark-shell/src/main/scala/org/apache/mahout/sparkbindings/shell/MahoutSparkILoop.scala
+++ b/spark-shell/src/main/scala/org/apache/mahout/sparkbindings/shell/MahoutSparkILoop.scala
@@ -67,6 +67,13 @@ class MahoutSparkILoop extends SparkILoop {
     }
   }
 
+  override def sparkCleanUp() {
+    echo("Stopping Spark context.")
+    intp.beQuietDuring {
+      command("sdc.stop()")
+    }
+  }
+
   override def prompt: String = "mahout> "
 
   override def printWelcome(): Unit = {


### PR DESCRIPTION
Renaming @sc to @sdc has left open the shutdown part. Spark
depends on 'implicit sc' to be set by the shell invoker.

  mahout> Stopping spark context.
  <console>:29: error: not found: value sc
                sc.stop()
                ^

Signed-off-by: Anand Avati avati@redhat.com
