### PR TITLE
MAHOUT-1529: Move dense/sparse matrix test in mapBlock into spark/

### DIFF
--- a/math-scala/src/test/scala/org/apache/mahout/math/drm/DrmLikeSuiteBase.scala
+++ b/math-scala/src/test/scala/org/apache/mahout/math/drm/DrmLikeSuiteBase.scala
@@ -50,35 +50,6 @@ trait DrmLikeSuiteBase extends DistributedMahoutSuite with Matchers {
 
   }
 
-  test("DRM blockify dense") {
-
-    val inCoreA = dense((1, 2, 3), (3, 4, 5))
-    val drmA = drmParallelize(inCoreA, numPartitions = 2)
-
-    (inCoreA - drmA.mapBlock() {
-      case (keys, block) =>
-        if (!block.isInstanceOf[DenseMatrix])
-          throw new AssertionError("Block must be dense.")
-        keys -> block
-    }).norm should be < 1e-4
-  }
-
-  test("DRM blockify sparse -> SRM") {
-
-    val inCoreA = sparse(
-      (1, 2, 3),
-      0 -> 3 :: 2 -> 5 :: Nil
-    )
-    val drmA = drmParallelize(inCoreA, numPartitions = 2)
-
-    (inCoreA - drmA.mapBlock() {
-      case (keys, block) =>
-        if (!block.isInstanceOf[SparseRowMatrix])
-          throw new AssertionError("Block must be dense.")
-        keys -> block
-    }).norm should be < 1e-4
-  }
-
   test("DRM parallelizeEmpty") {
 
     val drmEmpty = drmParallelizeEmpty(100, 50)

--- a/spark/src/test/scala/org/apache/mahout/sparkbindings/drm/DrmLikeSuite.scala
+++ b/spark/src/test/scala/org/apache/mahout/sparkbindings/drm/DrmLikeSuite.scala
@@ -27,4 +27,33 @@ import org.apache.mahout.sparkbindings.test.DistributedSparkSuite
 
 
 /** DRMLike tests -- just run common DRM tests in Spark. */
-class DrmLikeSuite extends FunSuite with DistributedSparkSuite with DrmLikeSuiteBase
+class DrmLikeSuite extends FunSuite with DistributedSparkSuite with DrmLikeSuiteBase {
+  test("DRM blockify dense") {
+
+    val inCoreA = dense((1, 2, 3), (3, 4, 5))
+    val drmA = drmParallelize(inCoreA, numPartitions = 2)
+
+    (inCoreA - drmA.mapBlock() {
+      case (keys, block) =>
+        if (!block.isInstanceOf[DenseMatrix])
+          throw new AssertionError("Block must be dense.")
+        keys -> block
+    }).norm should be < 1e-4
+  }
+
+  test("DRM blockify sparse -> SRM") {
+
+    val inCoreA = sparse(
+      (1, 2, 3),
+      0 -> 3 :: 2 -> 5 :: Nil
+    )
+    val drmA = drmParallelize(inCoreA, numPartitions = 2)
+
+    (inCoreA - drmA.mapBlock() {
+      case (keys, block) =>
+        if (!block.isInstanceOf[SparseRowMatrix])
+          throw new AssertionError("Block must be dense.")
+        keys -> block
+    }).norm should be < 1e-4
+  }
+}


### PR DESCRIPTION
In h2o engine, the Matrix provided to mapBlock() is an instance of
"H2OBlockMatrix extends AbstractMatrix", and neither a DenseMatrix
nor SparseMatrix. H2OBlockMatrix is a 0-copy virtual Matrix exposing
just the partition's data (created at almost no expense), and creates
a copy-on-write Matrix only if modified by the blockmapfunction.

So these two tests are failing with h2obindings. Hence moving these two
tests into spark module.

Signed-off-by: Anand Avati avati@redhat.com
