### PR TITLE
NOJIRA: fix artifact names to follow Scala convention

### DIFF
--- a/math-scala/pom.xml
+++ b/math-scala/pom.xml
@@ -27,7 +27,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>mahout-math-scala</artifactId>
+  <artifactId>mahout-math-scala_2.10</artifactId>
   <name>Mahout Math/Scala wrappers</name>
   <description>High performance scientific and technical computing data structures and methods,
     mostly based on CERN's

--- a/pom.xml
+++ b/pom.xml
@@ -183,19 +183,19 @@
       </dependency>
 
       <dependency>
-        <artifactId>mahout-math-scala</artifactId>
+        <artifactId>mahout-math-scala_${scala.major}</artifactId>
         <groupId>${project.groupId}</groupId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
         <version>${project.version}</version>
-        <artifactId>mahout-math-scala</artifactId>
+        <artifactId>mahout-math-scala_${scala.major}</artifactId>
         <classifier>tests</classifier>
       </dependency>
 
       <dependency>
-        <artifactId>mahout-spark</artifactId>
+        <artifactId>mahout-spark_${scala.major}</artifactId>
         <groupId>${project.groupId}</groupId>
         <version>${project.version}</version>
       </dependency>

--- a/spark-shell/pom.xml
+++ b/spark-shell/pom.xml
@@ -28,7 +28,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>mahout-spark-shell</artifactId>
+  <artifactId>mahout-spark-shell_2.10</artifactId>
   <name>Mahout Spark bindings shell</name>
   <description>
     Mahout Bindings for Apache Spark
@@ -165,12 +165,12 @@
 
     <dependency>
       <groupId>org.apache.mahout</groupId>
-      <artifactId>mahout-spark</artifactId>
+      <artifactId>mahout-spark_${scala.major}</artifactId>
     </dependency>
 
     <dependency>
       <groupId>org.apache.mahout</groupId>
-      <artifactId>mahout-math-scala</artifactId>
+      <artifactId>mahout-math-scala_${scala.major}</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -28,7 +28,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>mahout-spark</artifactId>
+  <artifactId>mahout-spark_2.10</artifactId>
   <name>Mahout Spark bindings</name>
   <description>
     Mahout Bindings for Apache Spark
@@ -294,7 +294,7 @@
 
     <dependency>
       <groupId>org.apache.mahout</groupId>
-      <artifactId>mahout-math-scala</artifactId>
+      <artifactId>mahout-math-scala_${scala.major}</artifactId>
     </dependency>
 
     <dependency>
@@ -310,7 +310,7 @@
 
     <dependency>
       <groupId>org.apache.mahout</groupId>
-      <artifactId>mahout-math-scala</artifactId>
+      <artifactId>mahout-math-scala_${scala.major}</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
@@ -322,14 +322,6 @@
       <groupId>com.github.scopt</groupId>
       <artifactId>scopt_2.10</artifactId>
       <version>3.2.0</version>
-    </dependency>
-
-    <!-- spark stuff -->
-    
-    <dependency>
-      <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.major}</artifactId>
-      <version>${spark.version}</version>
     </dependency>
 
     <!-- scala stuff -->


### PR DESCRIPTION
Scala maven artifacts follow convention of appending Scala
compiler version number to the name. This is necessary
as binaries across Scala major version are not compatible.

Signed-off-by: Anand Avati avati@redhat.com
