### PR TITLE
MAHOUT-1615 test and keyclass helper property on checkpoints

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/CheckpointedDrm.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/CheckpointedDrm.scala
@@ -18,6 +18,7 @@
 package org.apache.mahout.math.drm
 
 import org.apache.mahout.math.Matrix
+import scala.reflect.ClassTag
 
 /**
  * Checkpointed DRM API. This is a matrix that has optimized RDD lineage behind it and can be
@@ -32,5 +33,12 @@ trait CheckpointedDrm[K] extends DrmLike[K] {
 
   /** If this checkpoint is already declared cached, uncache. */
   def uncache(): this.type
+
+  /**
+   * Explicit extraction of key class Tag since traits don't support context bound access; but actual
+   * implementation knows it
+   */
+  def keyClassTag: ClassTag[K]
+
 
 }

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/DrmLike.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/DrmLike.scala
@@ -17,6 +17,8 @@
 
 package org.apache.mahout.math.drm
 
+import scala.reflect.ClassTag
+
 
 /**
  *

--- a/math-scala/src/test/scala/org/apache/mahout/math/drm/DrmLikeSuiteBase.scala
+++ b/math-scala/src/test/scala/org/apache/mahout/math/drm/DrmLikeSuiteBase.scala
@@ -23,6 +23,7 @@ import org.apache.mahout.math._
 import scalabindings._
 import RLikeOps._
 import RLikeDrmOps._
+import scala.reflect.ClassTag
 
 /** Common DRM tests to be run by all distributed engines. */
 trait DrmLikeSuiteBase extends DistributedMahoutSuite with Matchers {
@@ -41,6 +42,9 @@ trait DrmLikeSuiteBase extends DistributedMahoutSuite with Matchers {
 
     // Load back from hdfs
     val drmB = drmFromHDFS(path = uploadPath)
+
+    // Make sure keys are correctly identified as ints
+    drmB.checkpoint(CacheHint.NONE).keyClassTag shouldBe ClassTag.Int
 
     // Collect back into in-core
     val inCoreB = drmB.collect

--- a/pom.xml
+++ b/pom.xml
@@ -701,7 +701,7 @@
     <module>math-scala</module>
     <module>spark</module>
     <module>spark-shell</module>
-    <module>h2o</module>
+    <!-- module>h2o</module -->
   </modules>
   <profiles>
     <profile>

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/CheckpointedDrmSpark.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/CheckpointedDrmSpark.scala
@@ -65,6 +65,9 @@ class CheckpointedDrmSpark[K: ClassTag](
   private var cached: Boolean = false
   override val context: DistributedContext = rdd.context
 
+  /** Explicit extraction of key class Tag   */
+  def keyClassTag: ClassTag[K] = implicitly[ClassTag[K]]
+
   /**
    * Action operator -- does not necessary means Spark action; but does mean running BLAS optimizer
    * and writing down Spark graph lineage since last checkpointed DRM.


### PR DESCRIPTION
adding assert to `DRM DFS i/o (local)` test to fail if key class tag is incorrectly loaded.

temporarily commented h20 module out since it doesn't compile
