### PR TITLE
This is to ease use of mahout with eclipse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ output-asf-email-examples/
 .checkstyle
 .ruleset
 .pmd
+.cache
 .classpath
 .project
 .settings/

--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -52,6 +52,16 @@
           <skipDeploy>true</skipDeploy>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <encoding>UTF-8</encoding>
+          <source>1.6</source>
+          <target>1.6</target>
+          <optimize>true</optimize>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/math-scala/pom.xml
+++ b/math-scala/pom.xml
@@ -49,7 +49,16 @@
 
   <build>
     <defaultGoal>install</defaultGoal>
-
+    
+    <resources>
+      <resource>
+        <directory>src/main/scala</directory>
+      </resource>
+      <resource>
+        <directory>src/test/scala</directory>
+      </resource>    
+    </resources>
+    
     <plugins>
 
       <plugin>


### PR DESCRIPTION
- add .cache to .gitignore

- change buildtools pom to override java 1.4, to prevent eclipse warning

- change math-scala pom to include scala source folders, to prevent
build error in mahout-h2o & allow correct building by scala-ide plugin

- There is still one vexing error in using eclipse, in mahout-mrlegacy, a
source folder points outside the project (root mahout/src/conf).  Mvn
creates a source entry but eclipse doesn't recognize it.  (not sure how to fix this)