### PR TITLE
MAHOUT-1493h: Bypass the writer interface for string values

### DIFF
--- a/h2o/src/main/java/org/apache/mahout/h2obindings/H2OHelper.java
+++ b/h2o/src/main/java/org/apache/mahout/h2obindings/H2OHelper.java
@@ -329,7 +329,7 @@ public class H2OHelper {
       Map<Integer,String> rmap = reverseMap(map);
 
       for (long r = 0; r < m.rowSize(); r++) {
-        writer.set(r, rmap.get(r));
+        labels.chunkForRow(r).set(r, rmap.get(r));
       }
 
       writer.close(closer);


### PR DESCRIPTION
Set the string directly on the vector, but retain the writer
for doing a close()

Signed-off-by: Anand Avati <avati@redhat.com>