### PR TITLE
MAHOUT-1636

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/drivers/MahoutDriver.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/drivers/MahoutDriver.scala
@@ -25,7 +25,7 @@ abstract class MahoutDriver {
 
 
   implicit protected var mc: DistributedContext = _
-  protected var parser: MahoutOptionParser = _
+  implicit protected var parser: MahoutOptionParser = _
 
   var _useExistingContext: Boolean = false // used in the test suite to reuse one context per suite
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -157,8 +157,8 @@
         </executions>
       </plugin>
 
-      <!-- create job jar to include CLI driver deps-->
-      <!-- leave this in even though there are no hadoop mapreduce jobs in this module -->
+      <!-- create an all dependencies job.jar -->
+      <!-- todo: before release we need a better way to do this MAHOUT-1636 -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
@@ -171,12 +171,13 @@
             </goals>
             <configuration>
               <descriptors>
-                <descriptor>src/main/assembly/job.xml</descriptor>
+                <descriptor>../spark/src/main/assembly/job.xml</descriptor>
               </descriptors>
             </configuration>
           </execution>
         </executions>
       </plugin>
+
 
     </plugins>
   </build>
@@ -318,12 +319,6 @@
 
 
     <!--  3rd-party -->
-
-    <dependency>
-      <groupId>com.github.scopt</groupId>
-      <artifactId>scopt_2.10</artifactId>
-      <version>3.2.0</version>
-    </dependency>
 
     <!-- scala stuff -->
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -171,7 +171,7 @@
             </goals>
             <configuration>
               <descriptors>
-                <descriptor>../spark/src/main/assembly/job.xml</descriptor>
+                <descriptor>src/main/assembly/dependencies.xml</descriptor>
               </descriptors>
             </configuration>
           </execution>

--- a/spark/src/main/assembly/dependencies.xml
+++ b/spark/src/main/assembly/dependencies.xml
@@ -38,10 +38,17 @@
       <outputDirectory>/</outputDirectory>
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <excludes>
-        <exclude>org.apache.hadoop:hadoop-core</exclude>
         <!-- MAHOUT-1636 -->
+        <!-- add any projects that are included in the spark environment or are in mrlegacy
+        but not used in spark drivers -->
+        <exclude>org.apache.hadoop:hadoop-core</exclude>
         <exclude>org.apache.spark:spark-core_${scala.major}</exclude>
         <exclude>org.scala-lang:scala-library</exclude>
+        <exclude>jackson-core-asl</exclude>
+        <exclude>jackson-mapper-asl</exclude>
+        <exclude>xstream</exclude>
+        <exclude>lucene-core</exclude>
+        <exclude>lucene-analyzers-common</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/spark/src/main/assembly/dependencies.xml
+++ b/spark/src/main/assembly/dependencies.xml
@@ -20,7 +20,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0
     http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-  <id>job</id>
+  <id>dependencies</id>
   <formats>
    <format>jar</format>
   </formats>
@@ -39,6 +39,9 @@
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <excludes>
         <exclude>org.apache.hadoop:hadoop-core</exclude>
+        <!-- MAHOUT-1636 -->
+        <exclude>org.apache.spark:spark-core_${scala.major}</exclude>
+        <exclude>org.scala-lang:scala-library</exclude>
       </excludes>
     </dependencySet>
   </dependencySets>

--- a/spark/src/main/assembly/job.xml
+++ b/spark/src/main/assembly/job.xml
@@ -42,5 +42,20 @@
       </excludes>
     </dependencySet>
   </dependencySets>
+  <fileSets>
+    <fileSet>
+      <directory>${basedir}/target/classes</directory>
+      <outputDirectory>/</outputDirectory>
+      <excludes>
+        <exclude>*.jar</exclude>
+      </excludes>
+    </fileSet>
+    <fileSet>
+      <directory>${basedir}/target/classes</directory>
+      <outputDirectory>/</outputDirectory>
+      <includes>
+        <include>driver.classes.default.props</include>
+      </includes>
+    </fileSet>
+  </fileSets>
 </assembly>
-  

--- a/spark/src/main/scala/org/apache/mahout/drivers/ItemSimilarityDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/ItemSimilarityDriver.scala
@@ -117,15 +117,9 @@ object ItemSimilarityDriver extends MahoutSparkDriver {
     }
   }
 
-  override def start(masterUrl: String = parser.opts("master").asInstanceOf[String],
-      appName: String = parser.opts("appName").asInstanceOf[String]):
-    Unit = {
+  override protected def start() : Unit = {
 
-    if (parser.opts("sparkExecutorMem").asInstanceOf[String] != "")
-      sparkConf.set("spark.executor.memory", parser.opts("sparkExecutorMem").asInstanceOf[String])
-    //else leave as set in Spark config
-
-    super.start(masterUrl, appName)
+    super.start
 
     readSchema1 = new Schema("delim" -> parser.opts("inDelim").asInstanceOf[String],
       "filter" -> parser.opts("filter1").asInstanceOf[String],
@@ -208,7 +202,7 @@ object ItemSimilarityDriver extends MahoutSparkDriver {
   }
 
   override def process: Unit = {
-    start()
+    start
 
     val indexedDatasets = readIndexedDatasets
     val idss = SimilarityAnalysis.cooccurrencesIDSs(indexedDatasets, parser.opts("randomSeed").asInstanceOf[Int],

--- a/spark/src/main/scala/org/apache/mahout/drivers/RowSimilarityDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/RowSimilarityDriver.scala
@@ -106,11 +106,9 @@ object RowSimilarityDriver extends MahoutSparkDriver {
     }
   }
 
-  override def start(masterUrl: String = parser.opts("master").asInstanceOf[String],
-      appName: String = parser.opts("appName").asInstanceOf[String]):
-    Unit = {
+  override protected def start() : Unit = {
 
-    super.start(masterUrl, appName)
+    super.start
 
     readWriteSchema = new Schema(
       "rowKeyDelim" -> parser.opts("rowKeyDelim").asInstanceOf[String],
@@ -135,7 +133,7 @@ object RowSimilarityDriver extends MahoutSparkDriver {
   }
 
   override def process: Unit = {
-    start()
+    start
 
     val indexedDataset = readIndexedDataset
 

--- a/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
@@ -72,24 +72,6 @@ object TrainNBDriver extends MahoutSparkDriver {
     }
   }
 
-  override def start(masterUrl: String = parser.opts("master").asInstanceOf[String],
-      appName: String = parser.opts("appName").asInstanceOf[String]):
-    Unit = {
-
-    // will be only specific to this job.
-    // Note: set a large spark.kryoserializer.buffer.mb if using DSL MapBlock else leave as default
-
-    if (parser.opts("sparkExecutorMem").asInstanceOf[String] != "")
-      sparkConf.set("spark.executor.memory", parser.opts("sparkExecutorMem").asInstanceOf[String])
-
-    // Note: set a large akka frame size for DSL NB (20)
-    // sparkConf.set("spark.akka.frameSize","20") // don't need this for Spark optimized NaiveBayes..
-    // else leave as set in Spark config
-
-    super.start(masterUrl, appName)
-
-    }
-
   /** Read the training set from inputPath/part-x-00000 sequence file of form <Text,VectorWritable> */
   private def readTrainingSet: DrmLike[_]= {
     val inputPath = parser.opts("input").asInstanceOf[String]


### PR DESCRIPTION
Started out simplifying driver code and making changes to all drivers to support that. Then ran into the fat job.jar issue of MAHOUT-1636 so created a slimmed down version of the old job.jar by adding excludes to job.xml and changing the name to "dependencies.jar"

The new jar works for spark-itemsimilarity and spark-row-similarity but needs to be tested for the naive bayes drivers. 

The dependencies.jar still contains a lot of stuff from mrlegacy, some is in external projects, like jackson that can be excluded with this mechanism but also a lot of mahout code that is unneeded in this jar. This later case would require some other mechanism than a simple <exclude> clause in the assembly xml file.

I believe the new dependencies.jar is the only thing that needs to be on the classpath when running spark drivers or the spark-shell. I haven't changed this but it is a further refinement we can try.