### PR TITLE
Spark 1.2.1 upgrade

### DIFF
--- a/h2o/pom.xml
+++ b/h2o/pom.xml
@@ -206,7 +206,7 @@
 
     <dependency>
       <groupId>org.apache.mahout</groupId>
-      <artifactId>mahout-math-scala_2.10</artifactId>
+      <artifactId>mahout-math-scala_${scala.major}</artifactId>
       <version>${project.version}</version>
     </dependency>
 
@@ -219,7 +219,7 @@
 
    <dependency>
       <groupId>org.apache.mahout</groupId>
-      <artifactId>mahout-math-scala_2.10</artifactId>
+      <artifactId>mahout-math-scala_${scala.major}</artifactId>
       <classifier>tests</classifier>
       <scope>test</scope>
    </dependency>
@@ -249,8 +249,8 @@
     <!-- scala stuff -->
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
-      <version>2.0</version>
+      <artifactId>scalatest_${scala.major}</artifactId>
+      <version>2.2.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/math-scala/pom.xml
+++ b/math-scala/pom.xml
@@ -175,7 +175,7 @@
       
     <dependency>
       <groupId>com.github.scopt</groupId>
-      <artifactId>scopt_2.10</artifactId>
+      <artifactId>scopt_${scala.major}</artifactId>
       <version>3.2.0</version>
     </dependency>
 
@@ -189,7 +189,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.major}</artifactId>
-      <version>2.0</version>
+      <version>2.2.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/RLikeDrmOps.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/RLikeDrmOps.scala
@@ -134,8 +134,6 @@ object RLikeDrmOps {
 
   implicit def ops2Drm[K: ClassTag](ops: DrmLikeOps[K]): DrmLike[K] = ops.drm
 
-  implicit def cp2cpops[K: ClassTag](cp: CheckpointedDrm[K]): CheckpointedOps[K] = new CheckpointedOps(cp)
-
   /**
    * This is probably dangerous since it triggers implicit checkpointing with default storage level
    * setting.

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/package.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/package.scala
@@ -80,9 +80,6 @@ package object drm {
   /** Just throw all engine operations into context as well. */
   implicit def ctx2engine(ctx: DistributedContext): DistributedEngine = ctx.engine
 
-  implicit def drm2drmCpOps[K: ClassTag](drm: CheckpointedDrm[K]): CheckpointedOps[K] =
-    new CheckpointedOps[K](drm)
-
   /**
    * We assume that whenever computational action is invoked without explicit checkpoint, the user
    * doesn't imply caching

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/package.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/package.scala
@@ -80,6 +80,9 @@ package object drm {
   /** Just throw all engine operations into context as well. */
   implicit def ctx2engine(ctx: DistributedContext): DistributedEngine = ctx.engine
 
+  implicit def drm2drmCpOps[K: ClassTag](drm: CheckpointedDrm[K]): CheckpointedOps[K] =
+    new CheckpointedOps[K](drm)
+
   /**
    * We assume that whenever computational action is invoked without explicit checkpoint, the user
    * doesn't imply caching

--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
     <slf4j.version>1.7.5</slf4j.version>
     <scala.major>2.10</scala.major>
     <scala.version>2.10.4</scala.version>
-    <spark.version>1.1.0</spark.version>
+    <spark.version>1.2.1</spark.version>
     <h2o.version>0.1.16</h2o.version>
   </properties>
   <issueManagement>

--- a/spark-shell/pom.xml
+++ b/spark-shell/pom.xml
@@ -188,8 +188,8 @@
     <!-- scala stuff -->
     <dependency>
       <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_2.10</artifactId>
-      <version>2.0</version>
+      <artifactId>scalatest_${scala.major}</artifactId>
+      <version>2.2.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -321,8 +321,8 @@
 
     <dependency>
       <groupId>com.github.scopt</groupId>
-      <artifactId>scopt_2.10</artifactId>
-      <version>3.2.0</version>
+      <artifactId>scopt_${scala.major}</artifactId>
+      <version>3.3.0</version>
     </dependency>
 
     <!-- scala stuff -->
@@ -330,7 +330,7 @@
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.major}</artifactId>
-      <version>2.0</version>
+      <version>2.2.4</version>
       <scope>test</scope>
     </dependency>
 

--- a/spark/src/test/scala/org/apache/mahout/sparkbindings/test/DistributedSparkSuite.scala
+++ b/spark/src/test/scala/org/apache/mahout/sparkbindings/test/DistributedSparkSuite.scala
@@ -58,6 +58,11 @@ trait DistributedSparkSuite extends DistributedMahoutSuite with LoggerConfigurat
   }
 
 
+  override protected def afterAll(configMap: ConfigMap): Unit = {
+    super.afterAll(configMap)
+    resetContext()
+  }
+
   override protected def beforeAll(configMap: ConfigMap): Unit = {
     super.beforeAll(configMap)
     initContext()


### PR DESCRIPTION
o Bumped some versions to get ready for Scala 2.11.
o Changed some references to include scala.major so we can upgrade easier
o Removed a duplicated implicit so we dont get errors in 2.11
o Fixed cleanup of tests.