### PR TITLE
MAHOUT-1493f  Spark NB CLI Driver cleanup

### DIFF
--- a/examples/bin/classify-20newsgroups.sh
+++ b/examples/bin/classify-20newsgroups.sh
@@ -42,7 +42,7 @@ if [ "$HADOOP_HOME" != "" ] && [ "$MAHOUT_LOCAL" == "" ] ; then
 fi
 
 WORK_DIR=/tmp/mahout-work-${USER}
-algorithm=( cnaivebayes-MapReduce naivebayes-MapReduce cnaivebayes-Spark naivebayes-Spark sgd-MapReduce clean)
+algorithm=( cnaivebayes-MapReduce naivebayes-MapReduce cnaivebayes-Spark naivebayes-Spark sgd clean)
 if [ -n "$1" ]; then
   choice=$1
 else
@@ -165,7 +165,6 @@ if  ( [ "x$alg" == "xnaivebayes-MapReduce" ] ||  [ "x$alg" == "xcnaivebayes-MapR
       echo "Testing on holdout set"
       ./bin/mahout spark-testnb \
         -i ${WORK_DIR}/20news-test-vectors\
-        -o ${WORK_DIR}\
         -m ${WORK_DIR}/spark-model $c -ma $MASTER
     fi
 elif [ "x$alg" == "xsgd-MapReduce" ]; then

--- a/examples/bin/classify-20newsgroups.sh
+++ b/examples/bin/classify-20newsgroups.sh
@@ -59,6 +59,17 @@ fi
 echo "ok. You chose $choice and we'll use ${algorithm[$choice-1]}"
 alg=${algorithm[$choice-1]}
 
+# Spark specific check and work 
+if [ "x$alg" == "xnaivebayes-Spark" -o "x$alg" == "xcnaivebayes-Spark" ]; then
+  if [ "$MASTER" == "" ] ; then
+    echo "Plese set your MASTER env variable to point to your Spark Master URL. exiting..."
+    exit 1
+  fi
+  set +e
+     $HADOOP dfs -rmr ${WORK_DIR}/spark-model
+  set -e
+fi
+
 if [ "x$alg" != "xclean" ]; then
   echo "creating work directory at ${WORK_DIR}"
 
@@ -98,7 +109,6 @@ if  ( [ "x$alg" == "xnaivebayes-MapReduce" ] ||  [ "x$alg" == "xcnaivebayes-MapR
     echo "Copying 20newsgroups data to HDFS"
     set +e
     $HADOOP dfs -rmr ${WORK_DIR}/20news-all
-    $HADOOP dfs -rmr ${WORK_DIR}/spark-model
     $HADOOP dfs -mkdir ${WORK_DIR}
     set -e
     $HADOOP dfs -put ${WORK_DIR}/20news-all ${WORK_DIR}/20news-all
@@ -147,9 +157,6 @@ if  ( [ "x$alg" == "xnaivebayes-MapReduce" ] ||  [ "x$alg" == "xcnaivebayes-MapR
         -ow -o ${WORK_DIR}/20news-testing $c
 
     elif [ "x$alg" == "xnaivebayes-Spark" -o "x$alg" == "xcnaivebayes-Spark" ]; then
-       set +e
-           $HADOOP dfs -rmr ${WORK_DIR}/spark-model
-       set -e
 
       echo "Training Naive Bayes model"
       ./bin/mahout spark-trainnb \
@@ -159,15 +166,15 @@ if  ( [ "x$alg" == "xnaivebayes-MapReduce" ] ||  [ "x$alg" == "xcnaivebayes-MapR
       echo "Self testing on training set"
       ./bin/mahout spark-testnb \
         -i ${WORK_DIR}/20news-train-vectors\
-        -o ${WORK_DIR}\
         -m ${WORK_DIR}/spark-model $c -ma $MASTER
 
       echo "Testing on holdout set"
       ./bin/mahout spark-testnb \
         -i ${WORK_DIR}/20news-test-vectors\
         -m ${WORK_DIR}/spark-model $c -ma $MASTER
+        
     fi
-elif [ "x$alg" == "xsgd-MapReduce" ]; then
+elif [ "x$alg" == "xsgd" ]; then
   if [ ! -e "/tmp/news-group.model" ]; then
     echo "Training on ${WORK_DIR}/20news-bydate/20news-bydate-train/"
     ./bin/mahout org.apache.mahout.classifier.sgd.TrainNewsGroups ${WORK_DIR}/20news-bydate/20news-bydate-train/

--- a/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
@@ -18,7 +18,6 @@
 package org.apache.mahout.drivers
 
 import org.apache.mahout.classifier.naivebayes.{NBModel, NaiveBayes}
-import org.apache.mahout.classifier.stats.ConfusionMatrix
 import org.apache.mahout.math.drm
 import org.apache.mahout.math.drm.DrmLike
 import scala.collection.immutable.HashMap
@@ -37,37 +36,26 @@ object TestNBDriver extends MahoutSparkDriver {
     parser = new MahoutSparkOptionParser(programName = "spark-testnb") {
       head("spark-testnb", "Mahout 0.10.0")
 
-      //Input output options, non-driver specific
+      // Input output options, non-driver specific
       parseIOOptions(numInputs = 1)
 
-      //Algorithm control options--driver specific
+      // Algorithm control options--driver specific
       opts = opts ++ testNBOptipns
       note("\nAlgorithm control options:")
 
-      //default testComplementary is false
+      // default testComplementary is false
       opts = opts + ("testComplementary" -> false)
       opt[Unit]("testComplementary") abbr ("c") action { (_, options) =>
         options + ("testComplementary" -> true)
       } text ("Test a complementary model, Default: false.")
 
 
-
       opt[String]("pathToModel") abbr ("m") action { (x, options) =>
         options + ("pathToModel" -> x)
       } text ("Path to the Trained Model")
 
-
-      //How to search for input
-      parseFileDiscoveryOptions()
-
-      //IndexedDataset output schema--not driver specific, IndexedDataset specific
-      parseIndexedDatasetFormatOptions()
-
-      //Spark config options--not driver specific
+      // Spark config options--not driver specific
       parseSparkOptions()
-
-      //Jar inclusion, this option can be set when executing the driver from compiled code, not when from CLI
-      parseGenericOptions()
 
       help("help") abbr ("h") text ("prints this usage text\n")
 
@@ -96,7 +84,6 @@ object TestNBDriver extends MahoutSparkDriver {
     start()
 
     val testComplementary = parser.opts("testComplementary").asInstanceOf[Boolean]
-    val outputPath = parser.opts("output").asInstanceOf[String]
 
     // todo:  get the -ow option in to check for a model in the path and overwrite if flagged.
 

--- a/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
@@ -36,8 +36,15 @@ object TestNBDriver extends MahoutSparkDriver {
     parser = new MahoutSparkOptionParser(programName = "spark-testnb") {
       head("spark-testnb", "Mahout 0.10.0")
 
-      // Input output options, non-driver specific
-      parseIOOptions(numInputs = 1)
+      // Input options, non-driver specific
+      // we have no output except the confusion matrix to stdout so we don't need an
+      // output option
+
+      note("Input, option")
+      opt[String]('i', "input") required() action { (x, options) =>
+        options + ("input" -> x)
+      } text ("Input: path to test data " +
+        " (required)")
 
       // Algorithm control options--driver specific
       opts = opts ++ testNBOptipns

--- a/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
@@ -76,6 +76,7 @@ object TrainNBDriver extends MahoutSparkDriver {
     val outputPath = parser.opts("output").asInstanceOf[String]
 
     val trainingSet = readTrainingSet
+    // Use Spark-Optimized Naive Bayes here to extract labels and aggregate options
     val (labelIndex, aggregatedObservations) = SparkNaiveBayes.extractLabelsAndAggregateObservations(trainingSet)
     val model = NaiveBayes.train(aggregatedObservations, labelIndex, complementary)
 

--- a/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
@@ -37,31 +37,21 @@ object TrainNBDriver extends MahoutSparkDriver {
     parser = new MahoutSparkOptionParser(programName = "spark-trainnb") {
       head("spark-trainnb", "Mahout 0.10.0")
 
-      //Input output options, non-driver specific
+      // Input output options, non-driver specific
       parseIOOptions(numInputs = 1)
 
-      //Algorithm control options--driver specific
+      // Algorithm control options--driver specific
       opts = opts ++ trainNBOptipns
       note("\nAlgorithm control options:")
 
-      //default trainComplementary is false
+      // default trainComplementary is false
       opts = opts + ("trainComplementary" -> false)
       opt[Unit]("trainComplementary") abbr ("c") action { (_, options) =>
         options + ("trainComplementary" -> true)
       } text ("Train a complementary model, Default: false.")
-      
 
-      //How to search for input
-      parseFileDiscoveryOptions()
-
-      //IndexedDataset output schema--not driver specific, IndexedDataset specific
-      parseIndexedDatasetFormatOptions()
-
-      //Spark config options--not driver specific
+      // Spark config options--not driver specific
       parseSparkOptions()
-
-      //Jar inclusion, this option can be set when executing the driver from compiled code, not when from CLI
-      parseGenericOptions()
 
       help("help") abbr ("h") text ("prints this usage text\n")
 
@@ -87,7 +77,7 @@ object TrainNBDriver extends MahoutSparkDriver {
 
     val trainingSet = readTrainingSet
     val (labelIndex, aggregatedObservations) = SparkNaiveBayes.extractLabelsAndAggregateObservations(trainingSet)
-    val model = NaiveBayes.train(aggregatedObservations, labelIndex)
+    val model = NaiveBayes.train(aggregatedObservations, labelIndex, complementary)
 
     model.dfsWrite(outputPath)
 


### PR DESCRIPTION
removes unnecessary option parsers and `-o` option trom `TestNBDriver`  on a new branch.  Adresses comments made in comments made in #78