### PR TITLE
MAHOUT-1635: Remove -l option to set a csv file of labels in TrainNaiveBayesJob

### DIFF
--- a/examples/bin/classify-20newsgroups.sh
+++ b/examples/bin/classify-20newsgroups.sh
@@ -135,7 +135,7 @@ if  ( [ "x$alg" == "xnaivebayes-MapReduce" ] ||  [ "x$alg" == "xcnaivebayes-MapR
 
       echo "Training Naive Bayes model"
       ./bin/mahout trainnb \
-        -i ${WORK_DIR}/20news-train-vectors -el \
+        -i ${WORK_DIR}/20news-train-vectors \
         -o ${WORK_DIR}/model \
         -li ${WORK_DIR}/labelindex \
         -ow $c

--- a/examples/bin/classify-wikipedia.sh
+++ b/examples/bin/classify-wikipedia.sh
@@ -156,7 +156,6 @@ if [ "x$alg" == "xCBayes" ] || [ "x$alg" == "xBinaryCBayes" ] ; then
 
   echo "Training Naive Bayes model"
   $MAHOUT_HOME/bin/mahout trainnb -i ${WORK_DIR}/training \
-                                  -el \
                                   -o ${WORK_DIR}/model \
                                   -li ${WORK_DIR}/labelindex \
                                   -ow \

--- a/mr/src/main/java/org/apache/mahout/classifier/naivebayes/training/TrainNaiveBayesJob.java
+++ b/mr/src/main/java/org/apache/mahout/classifier/naivebayes/training/TrainNaiveBayesJob.java
@@ -48,8 +48,6 @@ public final class TrainNaiveBayesJob extends AbstractJob {
   private static final String TRAIN_COMPLEMENTARY = "trainComplementary";
   private static final String ALPHA_I = "alphaI";
   private static final String LABEL_INDEX = "labelIndex";
-  private static final String EXTRACT_LABELS = "extractLabels";
-  private static final String LABELS = "labels";
   public static final String WEIGHTS_PER_FEATURE = "__SPF";
   public static final String WEIGHTS_PER_LABEL = "__SPL";
   public static final String LABEL_THETA_NORMALIZER = "_LTN";
@@ -67,9 +65,7 @@ public final class TrainNaiveBayesJob extends AbstractJob {
 
     addInputOption();
     addOutputOption();
-    addOption(LABELS, "l", "comma-separated list of labels to include in training", false);
 
-    addOption(buildOption(EXTRACT_LABELS, "el", "Extract the labels from the input", false, false, ""));
     addOption(ALPHA_I, "a", "smoothing parameter", String.valueOf(1.0f));
     addOption(buildOption(TRAIN_COMPLEMENTARY, "c", "train complementary?", false, false, String.valueOf(false)));
     addOption(LABEL_INDEX, "li", "The path to store the label index in", false);
@@ -170,17 +166,12 @@ public final class TrainNaiveBayesJob extends AbstractJob {
 
   private long createLabelIndex(Path labPath) throws IOException {
     long labelSize = 0;
-    if (hasOption(LABELS)) {
-      Iterable<String> labels = Splitter.on(",").split(getOption(LABELS));
-      labelSize = BayesUtils.writeLabelIndex(getConf(), labels, labPath);
-    } else if (hasOption(EXTRACT_LABELS)) {
-      Iterable<Pair<Text,IntWritable>> iterable =
-          new SequenceFileDirIterable<Text, IntWritable>(getInputPath(),
-                                                         PathType.LIST,
-                                                         PathFilters.logsCRCFilter(),
-                                                         getConf());
-      labelSize = BayesUtils.writeLabelIndex(getConf(), labPath, iterable);
-    }
+    Iterable<Pair<Text,IntWritable>> iterable =
+      new SequenceFileDirIterable<Text, IntWritable>(getInputPath(),
+                                                     PathType.LIST,
+                                                     PathFilters.logsCRCFilter(),
+                                                     getConf());
+    labelSize = BayesUtils.writeLabelIndex(getConf(), labPath, iterable);
     return labelSize;
   }
 }

--- a/mr/src/main/java/org/apache/mahout/classifier/naivebayes/training/TrainNaiveBayesJob.java
+++ b/mr/src/main/java/org/apache/mahout/classifier/naivebayes/training/TrainNaiveBayesJob.java
@@ -51,7 +51,6 @@ public final class TrainNaiveBayesJob extends AbstractJob {
   public static final String WEIGHTS_PER_FEATURE = "__SPF";
   public static final String WEIGHTS_PER_LABEL = "__SPL";
   public static final String LABEL_THETA_NORMALIZER = "_LTN";
-
   public static final String SUMMED_OBSERVATIONS = "summedObservations";
   public static final String WEIGHTS = "weights";
   public static final String THETAS = "thetas";
@@ -70,6 +69,7 @@ public final class TrainNaiveBayesJob extends AbstractJob {
     addOption(buildOption(TRAIN_COMPLEMENTARY, "c", "train complementary?", false, false, String.valueOf(false)));
     addOption(LABEL_INDEX, "li", "The path to store the label index in", false);
     addOption(DefaultOptionCreator.overwriteOption().create());
+
     Map<String, List<String>> parsedArgs = parseArguments(args);
     if (parsedArgs == null) {
       return -1;

--- a/mr/src/test/java/org/apache/mahout/classifier/naivebayes/NaiveBayesTest.java
+++ b/mr/src/test/java/org/apache/mahout/classifier/naivebayes/NaiveBayesTest.java
@@ -108,7 +108,7 @@ public class NaiveBayesTest extends MahoutTestCase {
     TrainNaiveBayesJob trainNaiveBayes = new TrainNaiveBayesJob();
     trainNaiveBayes.setConf(conf);
     trainNaiveBayes.run(new String[] { "--input", inputFile.getAbsolutePath(), "--output", outputDir.getAbsolutePath(),
-        "-el", "--trainComplementary",
+        "--trainComplementary",
         "--tempDir", tempDir.getAbsolutePath() });
 
     NaiveBayesModel naiveBayesModel = NaiveBayesModel.materialize(new Path(outputDir.getAbsolutePath()), conf);

--- a/mr/src/test/java/org/apache/mahout/classifier/naivebayes/NaiveBayesTest.java
+++ b/mr/src/test/java/org/apache/mahout/classifier/naivebayes/NaiveBayesTest.java
@@ -89,7 +89,7 @@ public class NaiveBayesTest extends MahoutTestCase {
     TrainNaiveBayesJob trainNaiveBayes = new TrainNaiveBayesJob();
     trainNaiveBayes.setConf(conf);
     trainNaiveBayes.run(new String[] { "--input", inputFile.getAbsolutePath(), "--output", outputDir.getAbsolutePath(),
-        "-el", "--tempDir", tempDir.getAbsolutePath() });
+        "--tempDir", tempDir.getAbsolutePath() });
 
     NaiveBayesModel naiveBayesModel = NaiveBayesModel.materialize(new Path(outputDir.getAbsolutePath()), conf);
 


### PR DESCRIPTION
This patch removes the unimplemented `--labels` option from the TrainNaiveBayesJob.  As well removes   the `--extractLabels` option and now runs as default.

Example scripts are modified accordingly.