### PR TITLE
MAHOUT-1493 parallelize SparkNaiveBayes.test(...)

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/classifier/naivebayes/NBModel.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/classifier/naivebayes/NBModel.scala
@@ -98,11 +98,15 @@ class NBModel(val weightsPerLabelAndFeature: Matrix = null,
   def dfsWrite(pathToModel: String)(implicit ctx: DistributedContext): Unit = {
     //todo:  write out as smaller partitions or possibly use reader and writers to
     //todo:  write something other than a DRM for label Index, is Complementary, alphaI.
-    drmParallelize(weightsPerLabelAndFeature).dfsWrite(pathToModel + "/weightsPerLabelAndFeatureDrm.drm")
-    drmParallelize(sparse(weightsPerFeature)).dfsWrite(pathToModel + "/weightsPerFeatureDrm.drm")
-    drmParallelize(sparse(weightsPerLabel)).dfsWrite(pathToModel + "/weightsPerLabelDrm.drm")
-    drmParallelize(sparse(perlabelThetaNormalizer)).dfsWrite(pathToModel + "/perlabelThetaNormalizerDrm.drm")
-    drmParallelize(sparse(svec((0,alphaI)::Nil))).dfsWrite(pathToModel + "/alphaIDrm.drm")
+
+    // add a directory to put all of the DRMs in
+    val fullPathToModel = pathToModel + "/naiveBayesModel"
+
+    drmParallelize(weightsPerLabelAndFeature).dfsWrite(fullPathToModel + "/weightsPerLabelAndFeatureDrm.drm")
+    drmParallelize(sparse(weightsPerFeature)).dfsWrite(fullPathToModel + "/weightsPerFeatureDrm.drm")
+    drmParallelize(sparse(weightsPerLabel)).dfsWrite(fullPathToModel + "/weightsPerLabelDrm.drm")
+    drmParallelize(sparse(perlabelThetaNormalizer)).dfsWrite(fullPathToModel + "/perlabelThetaNormalizerDrm.drm")
+    drmParallelize(sparse(svec((0,alphaI)::Nil))).dfsWrite(fullPathToModel + "/alphaIDrm.drm")
 
     // isComplementry is true if isComplementaryDrm(0,0) == 1 else false
     val isComplementaryDrm = sparse(0 to 1, 0 to 1)
@@ -111,7 +115,7 @@ class NBModel(val weightsPerLabelAndFeature: Matrix = null,
     } else {
       isComplementaryDrm(0,0) = 0.0
     }
-    drmParallelize(isComplementaryDrm).dfsWrite(pathToModel + "/isComplementaryDrm.drm")
+    drmParallelize(isComplementaryDrm).dfsWrite(fullPathToModel + "/isComplementaryDrm.drm")
 
     // write the label index as a String-Keyed DRM.
     val labelIndexDummyDrm = weightsPerLabelAndFeature.like()
@@ -123,7 +127,7 @@ class NBModel(val weightsPerLabelAndFeature: Matrix = null,
       labelIndexDummyDrm.set(labelIndex(revMap(i)), 0, i.toDouble)
     }
 
-    drmParallelizeWithRowLabels(labelIndexDummyDrm).dfsWrite(pathToModel + "/labelIndex.drm")
+    drmParallelizeWithRowLabels(labelIndexDummyDrm).dfsWrite(fullPathToModel + "/labelIndex.drm")
   }
 
   /** Model Validation */
@@ -154,31 +158,34 @@ object NBModel extends java.io.Serializable {
   def dfsRead(pathToModel: String)(implicit ctx: DistributedContext): NBModel = {
     //todo:  Takes forever to read we need a more practical method of writing models. Readers/Writers?
 
-    val weightsPerFeatureDrm = drmDfsRead(pathToModel + "/weightsPerFeatureDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
+    // read from a base directory for all drms
+    val fullPathToModel = pathToModel + "/naiveBayesModel"
+
+    val weightsPerFeatureDrm = drmDfsRead(fullPathToModel + "/weightsPerFeatureDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
     val weightsPerFeature = weightsPerFeatureDrm.collect(0, ::)
     weightsPerFeatureDrm.uncache()
 
-    val weightsPerLabelDrm = drmDfsRead(pathToModel + "/weightsPerLabelDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
+    val weightsPerLabelDrm = drmDfsRead(fullPathToModel + "/weightsPerLabelDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
     val weightsPerLabel = weightsPerLabelDrm.collect(0, ::)
     weightsPerLabelDrm.uncache()
 
-    val alphaIDrm = drmDfsRead(pathToModel + "/alphaIDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
+    val alphaIDrm = drmDfsRead(fullPathToModel + "/alphaIDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
     val alphaI: Float = alphaIDrm.collect(0, 0).toFloat
     alphaIDrm.uncache()
 
     // isComplementry is true if isComplementaryDrm(0,0) == 1 else false
-    val isComplementaryDrm = drmDfsRead(pathToModel + "/isComplementaryDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
+    val isComplementaryDrm = drmDfsRead(fullPathToModel + "/isComplementaryDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
     val isComplementary = isComplementaryDrm.collect(0, 0).toInt == 1
     isComplementaryDrm.uncache()
 
     var perLabelThetaNormalizer= weightsPerFeature.like()
     if (isComplementary) {
-      val perLabelThetaNormalizerDrm = drm.drmDfsRead(pathToModel + "/perlabelThetaNormalizerDrm.drm")
+      val perLabelThetaNormalizerDrm = drm.drmDfsRead(fullPathToModel + "/perlabelThetaNormalizerDrm.drm")
                                              .checkpoint(CacheHint.MEMORY_ONLY)
       perLabelThetaNormalizer = perLabelThetaNormalizerDrm.collect(0, ::)
     }
 
-    val dummyLabelDrm= drmDfsRead(pathToModel + "/labelIndex.drm")
+    val dummyLabelDrm= drmDfsRead(fullPathToModel + "/labelIndex.drm")
                          .checkpoint(CacheHint.MEMORY_ONLY)
     val labelIndexMap:java.util.Map[String, Integer] = dummyLabelDrm.getRowLabelBindings
     dummyLabelDrm.uncache()
@@ -189,7 +196,7 @@ object NBModel extends java.io.Serializable {
         .toInt
         .asInstanceOf[Integer])
 
-    val weightsPerLabelAndFeatureDrm = drmDfsRead(pathToModel + "/weightsPerLabelAndFeatureDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
+    val weightsPerLabelAndFeatureDrm = drmDfsRead(fullPathToModel + "/weightsPerLabelAndFeatureDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
     val weightsPerLabelAndFeature = weightsPerLabelAndFeatureDrm.collect
     weightsPerLabelAndFeatureDrm.uncache()
 

--- a/math-scala/src/main/scala/org/apache/mahout/classifier/naivebayes/NaiveBayes.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/classifier/naivebayes/NaiveBayes.scala
@@ -217,7 +217,7 @@ trait NaiveBayes extends java.io.Serializable{
                         testSet: DrmLike[K],
                         testComplementary: Boolean = false,
                         cParser: CategoryParser = seq2SparseCategoryParser)
-                        (implicit ctx: DistributedContext): ResultAnalyzer = {
+                       (implicit ctx: DistributedContext): ResultAnalyzer = {
 
     val labelMap = model.labelIndex
 
@@ -246,7 +246,7 @@ trait NaiveBayes extends java.io.Serializable{
     val inCoreTestSet = testSet.collect
 
     // get the labels of the test set and extract the keys
-    val testSetLabelMap = testSet.getRowLabelBindings //.map(x => cParser(x._1) -> x._2)
+    val testSetLabelMap = testSet.getRowLabelBindings
 
     // empty Matrix in which we'll set the classification scores
     val inCoreScoredTestSet = testSet.like(numTestInstances, numLabels)
@@ -266,10 +266,9 @@ trait NaiveBayes extends java.io.Serializable{
 
     val analyzer = new ResultAnalyzer(labelMap.keys.toList.sorted, "DEFAULT")
 
-    // need to do this with out collecting
-    // val inCoreScoredTestSet = scoredTestSet.collect
+    // assign labels- winner takes all
     for (i <- 0 until numTestInstances) {
-      val (bestIdx, bestScore) = argmax(inCoreScoredTestSet(i,::))
+      val (bestIdx, bestScore) = argmax(inCoreScoredTestSet(i, ::))
       val classifierResult = new ClassifierResult(reverseLabelMap(bestIdx), bestScore)
       analyzer.addInstance(reverseTestSetLabelMap(i), classifierResult)
     }

--- a/spark/src/main/scala/org/apache/mahout/classifier/naivebayes/SparkNaiveBayes.scala
+++ b/spark/src/main/scala/org/apache/mahout/classifier/naivebayes/SparkNaiveBayes.scala
@@ -107,7 +107,7 @@ object SparkNaiveBayes extends NaiveBayes{
    * @return a result analyzer with confusion matrix and accuracy statistics
    */
 override def test[K: ClassTag](model: NBModel,
-                        testSet: DrmLike[K],
+                        testSet: DrmLike[String],
                         testComplementary: Boolean = false,
                         cParser: CategoryParser = seq2SparseCategoryParser)
                        (implicit ctx: DistributedContext): ResultAnalyzer = {

--- a/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
@@ -17,7 +17,7 @@
 
 package org.apache.mahout.drivers
 
-import org.apache.mahout.classifier.naivebayes.{NBModel, NaiveBayes}
+import org.apache.mahout.classifier.naivebayes.{SparkNaiveBayes, NBModel}
 import org.apache.mahout.math.drm
 import org.apache.mahout.math.drm.DrmLike
 import scala.collection.immutable.HashMap
@@ -96,7 +96,7 @@ object TestNBDriver extends MahoutSparkDriver {
 
     val testSet = readTestSet
     val model = readModel
-    val analyzer = NaiveBayes.test(model, testSet, testComplementary)
+    val analyzer = SparkNaiveBayes.test(model, testSet, testComplementary)
 
     println(analyzer)
 

--- a/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
@@ -78,7 +78,7 @@ object TrainNBDriver extends MahoutSparkDriver {
     val trainingSet = readTrainingSet
     // Use Spark-Optimized Naive Bayes here to extract labels and aggregate options
     val (labelIndex, aggregatedObservations) = SparkNaiveBayes.extractLabelsAndAggregateObservations(trainingSet)
-    val model = NaiveBayes.train(aggregatedObservations, labelIndex, complementary)
+    val model = SparkNaiveBayes.train(aggregatedObservations, labelIndex, complementary)
 
     model.dfsWrite(outputPath)
 

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/io/MahoutKryoRegistrator.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/io/MahoutKryoRegistrator.scala
@@ -20,6 +20,7 @@ package org.apache.mahout.sparkbindings.io
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.serializers.JavaSerializer
 import com.google.common.collect.HashBiMap
+import org.apache.mahout.classifier.naivebayes.{NBModel, ComplementaryNBClassifier, StandardNBClassifier, AbstractNBClassifier}
 import org.apache.mahout.math._
 import org.apache.spark.serializer.KryoRegistrator
 import org.apache.mahout.sparkbindings._
@@ -36,5 +37,12 @@ class MahoutKryoRegistrator extends KryoRegistrator {
     kryo.addDefaultSerializer(classOf[DenseVector], new WritableKryoSerializer[Vector, VectorWritable])
     kryo.addDefaultSerializer(classOf[Matrix], new WritableKryoSerializer[Matrix, MatrixWritable])
     kryo.register(classOf[com.google.common.collect.HashBiMap[String, Int]], new JavaSerializer())
+
+    kryo.register(classOf[AbstractNBClassifier], new JavaSerializer())
+    kryo.register(classOf[StandardNBClassifier], new JavaSerializer())
+    kryo.register(classOf[ComplementaryNBClassifier], new JavaSerializer())
+    kryo.register(classOf[NBModel], new JavaSerializer())
+
+
   }
 }

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/io/MahoutKryoRegistrator.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/io/MahoutKryoRegistrator.scala
@@ -38,10 +38,10 @@ class MahoutKryoRegistrator extends KryoRegistrator {
     kryo.addDefaultSerializer(classOf[Matrix], new WritableKryoSerializer[Matrix, MatrixWritable])
     kryo.register(classOf[com.google.common.collect.HashBiMap[String, Int]], new JavaSerializer())
 
-    kryo.register(classOf[AbstractNBClassifier], new JavaSerializer())
-    kryo.register(classOf[StandardNBClassifier], new JavaSerializer())
-    kryo.register(classOf[ComplementaryNBClassifier], new JavaSerializer())
-    kryo.register(classOf[NBModel], new JavaSerializer())
+  //  kryo.register(classOf[AbstractNBClassifier], new JavaSerializer())
+  //  kryo.register(classOf[StandardNBClassifier], new JavaSerializer())
+  //  kryo.register(classOf[ComplementaryNBClassifier], new JavaSerializer())
+  //  kryo.register(classOf[NBModel], new JavaSerializer())
 
 
   }

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/io/MahoutKryoRegistrator.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/io/MahoutKryoRegistrator.scala
@@ -20,7 +20,6 @@ package org.apache.mahout.sparkbindings.io
 import com.esotericsoftware.kryo.Kryo
 import com.esotericsoftware.kryo.serializers.JavaSerializer
 import com.google.common.collect.HashBiMap
-import org.apache.mahout.classifier.naivebayes.{NBModel, ComplementaryNBClassifier, StandardNBClassifier, AbstractNBClassifier}
 import org.apache.mahout.math._
 import org.apache.spark.serializer.KryoRegistrator
 import org.apache.mahout.sparkbindings._
@@ -37,12 +36,6 @@ class MahoutKryoRegistrator extends KryoRegistrator {
     kryo.addDefaultSerializer(classOf[DenseVector], new WritableKryoSerializer[Vector, VectorWritable])
     kryo.addDefaultSerializer(classOf[Matrix], new WritableKryoSerializer[Matrix, MatrixWritable])
     kryo.register(classOf[com.google.common.collect.HashBiMap[String, Int]], new JavaSerializer())
-
-  //  kryo.register(classOf[AbstractNBClassifier], new JavaSerializer())
-  //  kryo.register(classOf[StandardNBClassifier], new JavaSerializer())
-  //  kryo.register(classOf[ComplementaryNBClassifier], new JavaSerializer())
-  //  kryo.register(classOf[NBModel], new JavaSerializer())
-
 
   }
 }

--- a/spark/src/test/scala/org/apache/mahout/classifier/naivebayes/NBSparkTestSuite.scala
+++ b/spark/src/test/scala/org/apache/mahout/classifier/naivebayes/NBSparkTestSuite.scala
@@ -22,6 +22,8 @@ import org.apache.mahout.math.scalabindings._
 import org.apache.mahout.sparkbindings.test.DistributedSparkSuite
 import org.apache.mahout.test.MahoutSuite
 import org.scalatest.FunSuite
+import scala.collection.JavaConversions
+import JavaConversions._
 
 class NBSparkTestSuite extends FunSuite with MahoutSuite with DistributedSparkSuite with NBTestBase {
 
@@ -81,6 +83,77 @@ class NBSparkTestSuite extends FunSuite with MahoutSuite with DistributedSparkSu
     dslAggInCore(dslCat2, 1) - sparkAggInCore(dslCat2, 1) should be < epsilon //0.2
     dslAggInCore(dslCat2, 2) - sparkAggInCore(dslCat2, 2) should be < epsilon //0.0
     dslAggInCore(dslCat2, 3) - sparkAggInCore(dslCat2, 3) should be < epsilon //0.2
+
+  }
+
+
+  test("Spark train and test a model with the confusion matrix") {
+
+    val rowBindings = new java.util.HashMap[String,Integer]()
+    rowBindings.put("/Cat1/doc_a/", 0)
+    rowBindings.put("/Cat2/doc_b/", 1)
+    rowBindings.put("/Cat1/doc_c/", 2)
+    rowBindings.put("/Cat2/doc_d/", 3)
+    rowBindings.put("/Cat1/doc_e/", 4)
+    rowBindings.put("/Cat2/doc_f/", 5)
+    rowBindings.put("/Cat1/doc_g/", 6)
+    rowBindings.put("/Cat2/doc_h/", 7)
+    rowBindings.put("/Cat1/doc_i/", 8)
+    rowBindings.put("/Cat2/doc_j/", 9)
+
+    val seed = 1
+
+    val matrixSetup = Matrices.uniformView(10, 50 , seed)
+
+    println("TFIDF matrix")
+    println(matrixSetup)
+
+    matrixSetup.setRowLabelBindings(rowBindings)
+
+    val TFIDFDrm = drm.drmParallelizeWithRowLabels(matrixSetup)
+
+    //  println("Parallelized and Collected")
+    //  println(TFIDFDrm.collect)
+
+    val (labelIndex, aggregatedTFIDFDrm) = SparkNaiveBayes.extractLabelsAndAggregateObservations(TFIDFDrm)
+
+    println("Aggregated by key")
+    println(aggregatedTFIDFDrm.collect)
+    println(labelIndex)
+
+
+    // train a Standard NB Model- no label index here
+    val model = NaiveBayes.train(aggregatedTFIDFDrm, labelIndex, false)
+
+    // validate the model- will throw an exception if model is invalid
+    model.validate()
+
+    // save the model
+    model.dfsWrite(TmpDir)
+
+    // reload a new model which should be equal to the original
+    // this will automatically trigger a validate() call
+    val materializedModel= NBModel.dfsRead(TmpDir)
+
+    // check to se if the new model is complementary
+    materializedModel.isComplementary should be (model.isComplementary)
+
+    // check the label indexMaps
+    for(elem <- model.labelIndex){
+      model.labelIndex(elem._1) == materializedModel.labelIndex(elem._1) should be (true)
+    }
+
+    //   val testTFIDFDrm = drm.drmParallelizeWithRowLabels(m = matrixSetup, numPartitions = 2)
+
+    // self test on this model
+    val result = NaiveBayes.test(materializedModel, TFIDFDrm , false)
+
+    println(result)
+
+    result.getConfusionMatrix.getMatrix.getQuick(0, 0) should be(5)
+    result.getConfusionMatrix.getMatrix.getQuick(0, 1) should be(0)
+    result.getConfusionMatrix.getMatrix.getQuick(1, 0) should be(0)
+    result.getConfusionMatrix.getMatrix.getQuick(1, 1) should be(5)
 
   }
 }

--- a/spark/src/test/scala/org/apache/mahout/classifier/naivebayes/NBSparkTestSuite.scala
+++ b/spark/src/test/scala/org/apache/mahout/classifier/naivebayes/NBSparkTestSuite.scala
@@ -146,7 +146,7 @@ class NBSparkTestSuite extends FunSuite with MahoutSuite with DistributedSparkSu
     //   val testTFIDFDrm = drm.drmParallelizeWithRowLabels(m = matrixSetup, numPartitions = 2)
 
     // self test on this model
-    val result = NaiveBayes.test(materializedModel, TFIDFDrm , false)
+    val result = SparkNaiveBayes.test(materializedModel, TFIDFDrm , false)
 
     println(result)
 


### PR DESCRIPTION
Explicitly define math-scala NaiveBayes.test(...) as sequential and in memory.  Extend test(..) into SparkNaiveBayes and distribute the classification process. Also some general cleanup.
