### PR TITLE
MAHOUT-1622: MultithreadedBatchItemSimilarities output fix

### DIFF
--- a/mr/src/main/java/org/apache/mahout/cf/taste/impl/similarity/precompute/MultithreadedBatchItemSimilarities.java
+++ b/mr/src/main/java/org/apache/mahout/cf/taste/impl/similarity/precompute/MultithreadedBatchItemSimilarities.java
@@ -26,8 +26,7 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.google.common.collect.Lists;
-import com.google.common.io.Closeables;
+import java.util.ArrayList;
 import org.apache.mahout.cf.taste.common.TasteException;
 import org.apache.mahout.cf.taste.impl.common.LongPrimitiveIterator;
 import org.apache.mahout.cf.taste.model.DataModel;
@@ -106,7 +105,7 @@ public class MultithreadedBatchItemSimilarities extends BatchItemSimilarities {
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       }
-      Closeables.close(writer, false);
+      writer.close();
     }
 
     return output.getNumSimilaritiesProcessed();
@@ -167,7 +166,7 @@ public class MultithreadedBatchItemSimilarities extends BatchItemSimilarities {
 
     @Override
     public void run() {
-      while (numActiveWorkers.get() != 0) {
+      while (numActiveWorkers.get() != 0 || !results.isEmpty()) {
         try {
           List<SimilarItems> similarItemsOfABatch = results.poll(10, TimeUnit.MILLISECONDS);
           if (similarItemsOfABatch != null) {
@@ -206,7 +205,7 @@ public class MultithreadedBatchItemSimilarities extends BatchItemSimilarities {
         try {
           long[] itemIDBatch = itemIDBatches.take();
 
-          List<SimilarItems> similarItemsOfBatch = Lists.newArrayListWithCapacity(itemIDBatch.length);
+          List<SimilarItems> similarItemsOfBatch = new ArrayList<>(itemIDBatch.length);
           for (long itemID : itemIDBatch) {
             List<RecommendedItem> similarItems = getRecommender().mostSimilarItems(itemID, getSimilarItemsPerItem());
 

--- a/mr/src/test/java/org/apache/mahout/cf/taste/impl/similarity/precompute/MultithreadedBatchItemSimilaritiesTest.java
+++ b/mr/src/test/java/org/apache/mahout/cf/taste/impl/similarity/precompute/MultithreadedBatchItemSimilaritiesTest.java
@@ -33,6 +33,7 @@ import org.junit.Test;
 import java.io.IOException;
 import java.util.Arrays;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 
@@ -76,5 +77,25 @@ public class MultithreadedBatchItemSimilaritiesTest {
       batchSimilarities.computeItemSimilarities(2, 1, mock(SimilarItemsWriter.class));
       fail();
     } catch (IOException e) {}
+  }
+  
+  @Test
+  public void testCorrectNumberOfOutputSimilarities() {
+     FastByIDMap<PreferenceArray> userData = new FastByIDMap<PreferenceArray>();
+     userData.put(1, new GenericUserPreferenceArray(Arrays.asList(new GenericPreference(1, 1, 1),
+         new GenericPreference(1, 2, 1), new GenericPreference(1, 3, 1))));
+     userData.put(2, new GenericUserPreferenceArray(Arrays.asList(new GenericPreference(2, 1, 1),
+         new GenericPreference(2, 2, 1), new GenericPreference(2, 4, 1))));
+
+     DataModel dataModel = new GenericDataModel(userData);
+     ItemBasedRecommender recommender =
+         new GenericItemBasedRecommender(dataModel, new TanimotoCoefficientSimilarity(dataModel));
+
+     BatchItemSimilarities batchSimilarities = new MultithreadedBatchItemSimilarities(recommender, 10, 2);
+
+     try {
+       int numOutputSimilarities = batchSimilarities.computeItemSimilarities(2, 1, mock(SimilarItemsWriter.class));
+       assertEquals(numOutputSimilarities, 10);
+     } catch (IOException e) {}
   }
 }


### PR DESCRIPTION
In some cases the Output class in MultithreadedBatchItemSimilarities does
not output all of the similarity pairs that it should. It is very possible
for the number of active workers to go to zero while in the while loop,
in which case the remaining similarities for the finished workers will not
be flushed to the output. This is because the while loop is only
conditioned on whether there are active workers or not. An easy fix is to
also check to make sure the results structure is not empty. This way both
the number of active workers must be 0 and the result set must be empty to
exit the while loop.

On-behalf-of: Jesse Daniels <jessedaniels1@gmail.com>
Signed-off-by: Anand Avati <avati@redhat.com>