### PR TITLE
MAHOUT-1493:  Add CLI options for --overwrite and --alphaI  to NB Drivers 

### DIFF
--- a/examples/bin/classify-20newsgroups.sh
+++ b/examples/bin/classify-20newsgroups.sh
@@ -65,9 +65,6 @@ if [ "x$alg" == "xnaivebayes-Spark" -o "x$alg" == "xcnaivebayes-Spark" ]; then
     echo "Plese set your MASTER env variable to point to your Spark Master URL. exiting..."
     exit 1
   fi
-  set +e
-     $HADOOP dfs -rmr ${WORK_DIR}/spark-model
-  set -e
 fi
 
 if [ "x$alg" != "xclean" ]; then
@@ -161,7 +158,7 @@ if  ( [ "x$alg" == "xnaivebayes-MapReduce" ] ||  [ "x$alg" == "xcnaivebayes-MapR
       echo "Training Naive Bayes model"
       ./bin/mahout spark-trainnb \
         -i ${WORK_DIR}/20news-train-vectors \
-        -o ${WORK_DIR}/spark-model $c -ma $MASTER
+        -o ${WORK_DIR}/spark-model $c -ow -a 0.5 -ma $MASTER
 
       echo "Self testing on training set"
       ./bin/mahout spark-testnb \

--- a/examples/bin/classify-20newsgroups.sh
+++ b/examples/bin/classify-20newsgroups.sh
@@ -158,7 +158,7 @@ if  ( [ "x$alg" == "xnaivebayes-MapReduce" ] ||  [ "x$alg" == "xcnaivebayes-MapR
       echo "Training Naive Bayes model"
       ./bin/mahout spark-trainnb \
         -i ${WORK_DIR}/20news-train-vectors \
-        -o ${WORK_DIR}/spark-model $c -ow -a 0.5 -ma $MASTER
+        -o ${WORK_DIR}/spark-model $c -ow -ma $MASTER
 
       echo "Self testing on training set"
       ./bin/mahout spark-testnb \

--- a/math-scala/src/main/scala/org/apache/mahout/classifier/naivebayes/NBModel.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/classifier/naivebayes/NBModel.scala
@@ -100,7 +100,7 @@ class NBModel(val weightsPerLabelAndFeature: Matrix = null,
     //todo:  write something other than a DRM for label Index, is Complementary, alphaI.
 
     // add a directory to put all of the DRMs in
-    val fullPathToModel = pathToModel + "/naiveBayesModel"
+    val fullPathToModel = pathToModel + NBModel.modelBaseDirectory
 
     drmParallelize(weightsPerLabelAndFeature).dfsWrite(fullPathToModel + "/weightsPerLabelAndFeatureDrm.drm")
     drmParallelize(sparse(weightsPerFeature)).dfsWrite(fullPathToModel + "/weightsPerFeatureDrm.drm")
@@ -150,6 +150,9 @@ class NBModel(val weightsPerLabelAndFeature: Matrix = null,
 }
 
 object NBModel extends java.io.Serializable {
+
+  val modelBaseDirectory = "/naiveBayesModel"
+
   /**
    * Read a trained model in from from the filesystem.
    * @param pathToModel directory from which to read individual model components
@@ -159,7 +162,7 @@ object NBModel extends java.io.Serializable {
     //todo:  Takes forever to read we need a more practical method of writing models. Readers/Writers?
 
     // read from a base directory for all drms
-    val fullPathToModel = pathToModel + "/naiveBayesModel"
+    val fullPathToModel = pathToModel + modelBaseDirectory
 
     val weightsPerFeatureDrm = drmDfsRead(fullPathToModel + "/weightsPerFeatureDrm.drm").checkpoint(CacheHint.MEMORY_ONLY)
     val weightsPerFeature = weightsPerFeatureDrm.collect(0, ::)

--- a/spark/src/main/scala/org/apache/mahout/common/Hadoop1HDFSUtil.scala
+++ b/spark/src/main/scala/org/apache/mahout/common/Hadoop1HDFSUtil.scala
@@ -17,6 +17,7 @@
 
 package org.apache.mahout.common
 
+
 import org.apache.hadoop.io.{Writable, SequenceFile}
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.hadoop.conf.Configuration
@@ -29,7 +30,11 @@ import JavaConversions._
  */
 object Hadoop1HDFSUtil extends HDFSUtil {
 
-  
+  /**
+   * Read the header of a sequence file and determine the Key and Value type
+   * @param path
+   * @return
+   */
   def readDrmHeader(path: String): DrmMetadata = {
     val dfsPath = new Path(path)
     val fs = dfsPath.getFileSystem(new Configuration())
@@ -60,6 +65,19 @@ object Hadoop1HDFSUtil extends HDFSUtil {
       reader.close()
     }
 
+  }
+
+  /**
+   * Delete a path from the filesystem
+   * @param path
+   */
+  def delete(path: String) {
+    val dfsPath = new Path(path)
+    val fs = dfsPath.getFileSystem(new Configuration())
+
+    if (fs.exists(dfsPath)) {
+      fs.delete(dfsPath, true)
+    }
   }
 
 }

--- a/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
@@ -77,7 +77,7 @@ object TestNBDriver extends MahoutSparkDriver {
   /** Read the test set from inputPath/part-x-00000 sequence file of form <Text,VectorWritable> */
   private def readTestSet: DrmLike[_] = {
     val inputPath = parser.opts("input").asInstanceOf[String]
-    val trainingSet = drm.drmDfsRead(inputPath).par(auto = true)
+    val trainingSet = drm.drmDfsRead(inputPath)
     trainingSet
   }
 

--- a/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TestNBDriver.scala
@@ -20,6 +20,7 @@ package org.apache.mahout.drivers
 import org.apache.mahout.classifier.naivebayes.{SparkNaiveBayes, NBModel}
 import org.apache.mahout.math.drm
 import org.apache.mahout.math.drm.DrmLike
+import org.apache.mahout.math.drm.RLikeDrmOps.drm2RLikeOps
 import scala.collection.immutable.HashMap
 
 
@@ -76,7 +77,7 @@ object TestNBDriver extends MahoutSparkDriver {
   /** Read the test set from inputPath/part-x-00000 sequence file of form <Text,VectorWritable> */
   private def readTestSet: DrmLike[_] = {
     val inputPath = parser.opts("input").asInstanceOf[String]
-    val trainingSet = drm.drmDfsRead(inputPath)
+    val trainingSet = drm.drmDfsRead(inputPath).par(auto = true)
     trainingSet
   }
 

--- a/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
@@ -81,7 +81,7 @@ object TrainNBDriver extends MahoutSparkDriver {
   /** Read the training set from inputPath/part-x-00000 sequence file of form <Text,VectorWritable> */
   private def readTrainingSet: DrmLike[_]= {
     val inputPath = parser.opts("input").asInstanceOf[String]
-    val trainingSet= drm.drmDfsRead(inputPath).par(auto = true)
+    val trainingSet= drm.drmDfsRead(inputPath)
     trainingSet
   }
 

--- a/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
@@ -53,7 +53,7 @@ object TrainNBDriver extends MahoutSparkDriver {
       } text ("Train a complementary model, Default: false.")
 
       // Laplace smoothing paramater default is 1.0
-      opts = opts + ("alphaI" -> 1.0f)
+      opts = opts + ("alphaI" -> 1.0)
       opt[Double]("alphaI") abbr ("a") action { (x, options) =>
         options + ("alphaI" -> x)
       } text ("Laplace soothing factor default is 1.0") validate { x =>

--- a/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
@@ -90,7 +90,7 @@ object TrainNBDriver extends MahoutSparkDriver {
 
     val complementary = parser.opts("trainComplementary").asInstanceOf[Boolean]
     val outputPath = parser.opts("output").asInstanceOf[String]
-    val alpha = parser.opts("alphaI").asInstanceOf[Float]
+    val alpha = parser.opts("alphaI").asInstanceOf[Double]
     val overwrite = parser.opts("overwrite").asInstanceOf[Boolean]
 
     val fullPathToModel = outputPath + NBModel.modelBaseDirectory
@@ -102,7 +102,7 @@ object TrainNBDriver extends MahoutSparkDriver {
     val trainingSet = readTrainingSet
     // Use Spark-Optimized Naive Bayes here to extract labels and aggregate options
     val (labelIndex, aggregatedObservations) = SparkNaiveBayes.extractLabelsAndAggregateObservations(trainingSet)
-    val model = SparkNaiveBayes.train(aggregatedObservations, labelIndex, complementary, alpha)
+    val model = SparkNaiveBayes.train(aggregatedObservations, labelIndex, complementary, alpha.toFloat)
 
     model.dfsWrite(outputPath)
 

--- a/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/TrainNBDriver.scala
@@ -21,6 +21,7 @@ import org.apache.mahout.classifier.naivebayes._
 import org.apache.mahout.classifier.naivebayes.SparkNaiveBayes
 import org.apache.mahout.math.drm
 import org.apache.mahout.math.drm.DrmLike
+import org.apache.mahout.math.drm.RLikeDrmOps.drm2RLikeOps
 import scala.collection.immutable.HashMap
 
 
@@ -65,7 +66,7 @@ object TrainNBDriver extends MahoutSparkDriver {
   /** Read the training set from inputPath/part-x-00000 sequence file of form <Text,VectorWritable> */
   private def readTrainingSet: DrmLike[_]= {
     val inputPath = parser.opts("input").asInstanceOf[String]
-    val trainingSet= drm.drmDfsRead(inputPath)
+    val trainingSet= drm.drmDfsRead(inputPath).par(auto = true)
     trainingSet
   }
 


### PR DESCRIPTION
Presently `mahout spark-trainnb` will not complete if a model already exists in the output directory.  These last options add in an `--overwrite` option to overwrite a model in the given output directory.  

as well:
  - adds `.par(auto = true)` to the input Drm
  - adds a `delete(...)` method to `Hadppo1HDFSUtils` which does not handle any IO exceptions
  - adds an almost trivial  `--alphaI` option to set the Laplace smoothing factor from the CLI

This patch will complete the full port of the old MapReduce Naive Bayes to the `math-scala` and `spark` modules.    