### PR TITLE
MAHOUT-1653 Spark-1.3 for 0.10.0

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -109,10 +109,10 @@
       <groupId>org.apache.mahout</groupId>
       <artifactId>mahout-spark_${scala.compat.version}</artifactId>
     </dependency>
-    <dependency>
+  <!--  <dependency>
       <groupId>org.apache.mahout</groupId>
       <artifactId>mahout-spark-shell_${scala.compat.version}</artifactId>
-    </dependency>
+    </dependency> -->
     <dependency>
       <groupId>org.apache.mahout</groupId>
       <artifactId>mahout-math-scala_${scala.compat.version}</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -774,7 +774,7 @@
     <module>distribution</module>
     <module>math-scala</module>
     <module>spark</module>
-    <module>spark-shell</module>
+  <!--  <module>spark-shell</module> -->
     <module>h2o</module>
   </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -120,7 +120,7 @@
     <slf4j.version>1.7.10</slf4j.version>
     <scala.compat.version>2.10</scala.compat.version>
     <scala.version>2.10.4</scala.version>
-    <spark.version>1.1.1</spark.version>
+    <spark.version>1.3.0</spark.version>
     <h2o.version>0.1.25</h2o.version>
   </properties>
   <issueManagement>

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/CheckpointedDrmSpark.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/CheckpointedDrmSpark.scala
@@ -30,6 +30,8 @@ import org.apache.hadoop.io.{LongWritable, Text, IntWritable, Writable}
 import org.apache.mahout.math.drm._
 import org.apache.mahout.sparkbindings._
 import org.apache.spark.SparkContext._
+import org.apache.spark.SparkContext
+import org.apache.spark.rdd.RDD
 
 /** ==Spark-specific optimizer-checkpointed DRM.==
   *
@@ -165,7 +167,8 @@ class CheckpointedDrmSpark[K: ClassTag](
       else if (classOf[Writable].isAssignableFrom(ktag.runtimeClass)) (x: K) => x.asInstanceOf[Writable]
       else throw new IllegalArgumentException("Do not know how to convert class tag %s to Writable.".format(ktag))
 
-    rdd.saveAsSequenceFile(path)
+    // this is a (working) deprecated method used as a stop-gap while we investigate the shell issues
+    SparkContext.rddToSequenceFileRDDFunctions(rdd.asInstanceOf[RDD[(K, Vector)]]).saveAsSequenceFile(path)
   }
 
   protected def computeNRow = {

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/package.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/package.scala
@@ -23,7 +23,6 @@ import scala.collection.JavaConversions._
 import org.apache.hadoop.io.{LongWritable, Text, IntWritable, Writable}
 import org.apache.log4j.Logger
 import java.lang.Math
-import org.apache.spark.rdd.{FilteredRDD, RDD}
 import scala.reflect.ClassTag
 import org.apache.mahout.math.scalabindings._
 import RLikeOps._


### PR DESCRIPTION
Uses a  deprecated method in `CheckpointedDrmSpark.scala` and has the shell build disabled. 