### PR TITLE
h2o-test: use unique session id strings

### DIFF
--- a/h2o/src/test/scala/org/apache/mahout/h2obindings/test/DistributedH2OSuite.scala
+++ b/h2o/src/test/scala/org/apache/mahout/h2obindings/test/DistributedH2OSuite.scala
@@ -30,7 +30,7 @@ trait DistributedH2OSuite extends DistributedMahoutSuite with LoggerConfiguratio
   override protected def beforeEach() {
     super.beforeEach()
 
-    mahoutCtx = mahoutH2OContext("mah2out")
+    mahoutCtx = mahoutH2OContext("mah2out" + System.currentTimeMillis())
   }
 
   override protected def afterEach() {


### PR DESCRIPTION
When tests are run in parallel, session IDs can collide and cause
unexpected failures. Give a unique session ID string for each test
to allow safe testing in parallel.

Signed-off-by: Anand Avati <avati@redhat.com>