### PR TITLE
MAHOUT-1693: Override .toString() in AbstractMatrix using VectorView

### DIFF
--- a/math/src/main/java/org/apache/mahout/math/AbstractMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/AbstractMatrix.java
@@ -780,15 +780,53 @@ public abstract class AbstractMatrix implements Matrix {
     }
   }
 
+//  @Override
+//  public String toString() {
+//    int row = 0;
+//    int col = 0;
+//    int maxRowToDisplay = 10;
+//    int maxColToDisplay = 50;
+//    StringBuilder s = new StringBuilder("{\n");
+//    Iterator<MatrixSlice> it = iterator();
+//    while ((it.hasNext()) && (row < maxRowToDisplay)) {
+//      MatrixSlice next = it.next();
+//      s.append("  ").append(next.index()).append("  =>\t");
+//        Iterator<Vector.Element> vIt = next.vector().nonZeroes().iterator();
+//        while ((col < maxColToDisplay) && (vIt.hasNext())) {
+//          s.append(vIt.next());
+//          col++;
+//        }
+//      s.append('\n');
+//      row++;
+//    }
+//    s.append("}");
+//    return s.toString();
+//  }
+
   @Override
   public String toString() {
+    int row = 0;
+    int maxRowToDisplay = 10;
+    int maxColToDisplay = 50;
+
     StringBuilder s = new StringBuilder("{\n");
     Iterator<MatrixSlice> it = iterator();
-    while (it.hasNext()) {
+    while ((it.hasNext()) && (row < maxRowToDisplay)) {
       MatrixSlice next = it.next();
-      s.append("  ").append(next.index()).append("  =>\t").append(next.vector()).append('\n');
+      s.append(" ").append(next.index())
+        .append(" =>\t")
+        .append(new VectorView(next.vector(),0, maxColToDisplay))
+        .append('\n');
+      row ++;
     }
-    s.append("}");
-    return s.toString();
+    String returnString = s.toString();
+    if(maxColToDisplay > maxRowToDisplay) {
+      returnString = returnString.replaceAll("}", "...");
+    }
+    if(maxRowToDisplay > numRows())
+      return returnString +("...");
+    else{
+      return returnString +("}");
+    }
   }
 }

--- a/math/src/main/java/org/apache/mahout/math/AbstractMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/AbstractMatrix.java
@@ -798,16 +798,16 @@ public abstract class AbstractMatrix implements Matrix {
       MatrixSlice next = it.next();
       s.append(" ").append(next.index())
         .append(" =>\t")
-        .append(new VectorView(next.vector(),0 , colsToDisplay))
+        .append(new VectorView(next.vector(), 0, colsToDisplay))
         .append('\n');
       row ++;
     }
     String returnString = s.toString();
     if (maxColsToDisplay <= columnSize()) {
-      returnString = returnString.replace("}", " ... ");
+      returnString = returnString.replace("}", " ... } ");
     }
     if(maxRowsToDisplay <= rowSize())
-      return returnString + ("...");
+      return returnString + ("... }");
     else{
       return returnString + ("}");
     }

--- a/math/src/main/java/org/apache/mahout/math/AbstractMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/AbstractMatrix.java
@@ -780,53 +780,36 @@ public abstract class AbstractMatrix implements Matrix {
     }
   }
 
-//  @Override
-//  public String toString() {
-//    int row = 0;
-//    int col = 0;
-//    int maxRowToDisplay = 10;
-//    int maxColToDisplay = 50;
-//    StringBuilder s = new StringBuilder("{\n");
-//    Iterator<MatrixSlice> it = iterator();
-//    while ((it.hasNext()) && (row < maxRowToDisplay)) {
-//      MatrixSlice next = it.next();
-//      s.append("  ").append(next.index()).append("  =>\t");
-//        Iterator<Vector.Element> vIt = next.vector().nonZeroes().iterator();
-//        while ((col < maxColToDisplay) && (vIt.hasNext())) {
-//          s.append(vIt.next());
-//          col++;
-//        }
-//      s.append('\n');
-//      row++;
-//    }
-//    s.append("}");
-//    return s.toString();
-//  }
-
   @Override
   public String toString() {
     int row = 0;
-    int maxRowToDisplay = 10;
-    int maxColToDisplay = 50;
+    int maxRowsToDisplay = 10;
+    int maxColsToDisplay = 20;
+    int colsToDisplay = maxColsToDisplay;
+
+    if(maxColsToDisplay > columnSize()){
+      colsToDisplay = columnSize();
+    }
+
 
     StringBuilder s = new StringBuilder("{\n");
     Iterator<MatrixSlice> it = iterator();
-    while ((it.hasNext()) && (row < maxRowToDisplay)) {
+    while ((it.hasNext()) && (row < maxRowsToDisplay)) {
       MatrixSlice next = it.next();
       s.append(" ").append(next.index())
         .append(" =>\t")
-        .append(new VectorView(next.vector(),0, maxColToDisplay))
+        .append(new VectorView(next.vector(),0 , colsToDisplay))
         .append('\n');
       row ++;
     }
     String returnString = s.toString();
-    if(maxColToDisplay > maxRowToDisplay) {
-      returnString = returnString.replaceAll("}", "...");
+    if (maxColsToDisplay <= columnSize()) {
+      returnString = returnString.replace("}", " ... ");
     }
-    if(maxRowToDisplay > numRows())
-      return returnString +("...");
+    if(maxRowsToDisplay <= rowSize())
+      return returnString + ("...");
     else{
-      return returnString +("}");
+      return returnString + ("}");
     }
   }
 }

--- a/math/src/main/java/org/apache/mahout/math/FunctionalMatrixView.java
+++ b/math/src/main/java/org/apache/mahout/math/FunctionalMatrixView.java
@@ -87,8 +87,8 @@ class FunctionalMatrixView extends AbstractMatrix {
     return new MatrixVectorView(this, 0, column, 1, 0, denseLike);
   }
 
-  @Override
-  public String toString(){
-    return "org.apache.mahout.math.FunctionalMatrixView";
-  }
+//  @Override
+//  public String toString(){
+//    return "org.apache.mahout.math.FunctionalMatrixView";
+//  }
 }

--- a/math/src/main/java/org/apache/mahout/math/FunctionalMatrixView.java
+++ b/math/src/main/java/org/apache/mahout/math/FunctionalMatrixView.java
@@ -87,8 +87,4 @@ class FunctionalMatrixView extends AbstractMatrix {
     return new MatrixVectorView(this, 0, column, 1, 0, denseLike);
   }
 
-//  @Override
-//  public String toString(){
-//    return "org.apache.mahout.math.FunctionalMatrixView";
-//  }
 }

--- a/math/src/main/java/org/apache/mahout/math/SparseColumnMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/SparseColumnMatrix.java
@@ -172,12 +172,37 @@ public class SparseColumnMatrix extends AbstractMatrix {
 
   @Override
   public String toString() {
+    int row = 0;
+    int maxRowsToDisplay = 10;
+    int maxColsToDisplay = 20;
+    int colsToDisplay = maxColsToDisplay;
+
+    if(maxColsToDisplay > columnSize()){
+      colsToDisplay = columnSize();
+    }
+
     StringBuilder s = new StringBuilder("{\n");
     for (MatrixSlice next : this.transpose()) {
-      s.append("  ").append(next.index()).append("  =>\t").append(next.vector()).append('\n');
+      if (row < maxRowsToDisplay) {
+        s.append("  ")
+          .append(next.index())
+          .append("  =>\t")
+          .append(new VectorView(next.vector(),0 , colsToDisplay))
+          .append('\n');
+        row++;
+      }
     }
-    s.append("}");
-    return s.toString();
+
+    String returnString = s.toString();
+    if (maxColsToDisplay <= columnSize()) {
+      returnString = returnString.replace("}", " ... ");
+    }
+
+    if (maxRowsToDisplay <= rowSize()) {
+      return returnString + "...";
+    } else {
+      return returnString + "}";
+    }
   }
 
 }

--- a/math/src/main/java/org/apache/mahout/math/SparseColumnMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/SparseColumnMatrix.java
@@ -187,7 +187,7 @@ public class SparseColumnMatrix extends AbstractMatrix {
         s.append("  ")
           .append(next.index())
           .append("  =>\t")
-          .append(new VectorView(next.vector(),0 , colsToDisplay))
+          .append(new VectorView(next.vector(), 0, colsToDisplay))
           .append('\n');
         row++;
       }
@@ -195,11 +195,11 @@ public class SparseColumnMatrix extends AbstractMatrix {
 
     String returnString = s.toString();
     if (maxColsToDisplay <= columnSize()) {
-      returnString = returnString.replace("}", " ... ");
+      returnString = returnString.replace("}", " ... }");
     }
 
     if (maxRowsToDisplay <= rowSize()) {
-      return returnString + "...";
+      return returnString + "... }";
     } else {
       return returnString + "}";
     }


### PR DESCRIPTION
I still have to test this out a bit, but this is a fix for the memory issues caused by the shell triggering .toString() after the instantiation of large  DenseMatrix, SparseMatrix and FunctionalMatrixViews (MAHOUT-1693).  This is set to display an (arbitrarily sized)10x20 upper left block of the matrix.  For sparse matrices this does affect the printout, so it may not be acceptable. 