### PR TITLE
MAHOUT-1704: Pare down dependency jar for h2o

### DIFF
--- a/bin/mahout
+++ b/bin/mahout
@@ -186,9 +186,10 @@ then
        CLASSPATH=${CLASSPATH}:$f;
     done
 
-    for f in $MAHOUT_HOME/h2o/target/mahout-h2o-*.jar; do
+    for f in $MAHOUT_HOME/h2o/target/mahout-h2o*.jar; do
        CLASSPATH=${CLASSPATH}:$f;
     done
+
   fi
 
   # add jars for running from the command line if we requested shell or spark CLI driver

--- a/h2o/README.md
+++ b/h2o/README.md
@@ -28,7 +28,7 @@ H2O is fundamentally a peer-to-peer system. H2O nodes join together to form a cl
 
 The Mahout H2O integration is fit into this model by having N-1 "worker" nodes and one driver node, all belonging to the same cloud name. The default cloud name used for the integration is "mah2out". Clouds have to be spun up per task/job.
 
-**WARNING**: Some Linux systems have default firewall rules which might block traffic required for the following tests. In order to successfully run the tests you might need to temporarily turn off firewall rules with `sh# iptables -F`
+**WARNING**: Some Linux systems have default firewall rules which might block traffic required for the following tests. In order to successfully run the tests you might need to temporarily turn off firewall rules with `sh# cdc
 
 First bring up worker nodes:
 

--- a/h2o/README.md
+++ b/h2o/README.md
@@ -28,7 +28,7 @@ H2O is fundamentally a peer-to-peer system. H2O nodes join together to form a cl
 
 The Mahout H2O integration is fit into this model by having N-1 "worker" nodes and one driver node, all belonging to the same cloud name. The default cloud name used for the integration is "mah2out". Clouds have to be spun up per task/job.
 
-**WARNING**: Some Linux systems have default firewall rules which might block traffic required for the following tests. In order to successfully run the tests you might need to temporarily turn off firewall rules with `sh# cdc
+**WARNING**: Some Linux systems have default firewall rules which might block traffic required for the following tests. In order to successfully run the tests you might need to temporarily turn off firewall rules with `sh# iptables -F`
 
 First bring up worker nodes:
 

--- a/h2o/pom.xml
+++ b/h2o/pom.xml
@@ -123,6 +123,16 @@
   </build>
 
   <dependencies>
+    <dependency>
+    <groupId>org.scala-lang</groupId>
+    <artifactId>scala-reflect</artifactId>
+    <version>${scala.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.scala-lang</groupId>
+    <artifactId>scala-library</artifactId>
+    <version>${scala.version}</version>
+  </dependency>
 
     <dependency>
       <groupId>org.apache.mahout</groupId>

--- a/h2o/pom.xml
+++ b/h2o/pom.xml
@@ -45,14 +45,14 @@
         <artifactId>maven-assembly-plugin</artifactId>
         <executions>
           <execution>
-            <id>h2o-dependency-reduced</id>
+            <id>dependency-reduced</id>
             <phase>package</phase>
             <goals>
               <goal>single</goal>
             </goals>
             <configuration>
               <descriptors>
-                <descriptor>src/main/assembly/h2o-dependency-reduced.xml</descriptor>
+                <descriptor>src/main/assembly/dependency-reduced.xml</descriptor>
               </descriptors>
             </configuration>
           </execution>

--- a/h2o/pom.xml
+++ b/h2o/pom.xml
@@ -123,11 +123,6 @@
   </build>
 
   <dependencies>
-    <dependency>
-    <groupId>org.scala-lang</groupId>
-    <artifactId>scala-reflect</artifactId>
-    <version>${scala.version}</version>
-  </dependency>
   <dependency>
     <groupId>org.scala-lang</groupId>
     <artifactId>scala-library</artifactId>

--- a/h2o/pom.xml
+++ b/h2o/pom.xml
@@ -35,27 +35,26 @@
 
   <packaging>jar</packaging>
 
-  <build>
-    <plugins>
 
+
+  <build>
+
+    <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-assembly-plugin</artifactId>
-        <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-          <archive>
-            <manifest>
-              <mainClass>water.H2O</mainClass>
-            </manifest>
-          </archive>
-        </configuration>
         <executions>
           <execution>
+            <id>h2o-dependency-reduced</id>
             <phase>package</phase>
             <goals>
               <goal>single</goal>
             </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/main/assembly/h2o-dependency-reduced.xml</descriptor>
+              </descriptors>
+            </configuration>
           </execution>
         </executions>
       </plugin>

--- a/h2o/src/main/assembly/h2o-dependency-reduced.xml
+++ b/h2o/src/main/assembly/h2o-dependency-reduced.xml
@@ -37,6 +37,8 @@
       <useTransitiveFiltering>true</useTransitiveFiltering>
       <includes>
         <include>ai.h2o:h2o-core</include>
+        <include>org.scala-lang:scala-library</include>
+        <include>org.scala-lang:scala-reflect</include>
       </includes>
     </dependencySet>
   </dependencySets>

--- a/h2o/src/main/assembly/h2o-dependency-reduced.xml
+++ b/h2o/src/main/assembly/h2o-dependency-reduced.xml
@@ -18,7 +18,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0
   http://maven.apache.org/xsd/assembly-1.1.0.xsd">
-  <id>h2o-dependency-reduced</id>
+  <id>dependency-reduced</id>
   <formats>
     <format>jar</format>
   </formats>

--- a/h2o/src/main/assembly/h2o-dependency-reduced.xml
+++ b/h2o/src/main/assembly/h2o-dependency-reduced.xml
@@ -38,7 +38,6 @@
       <includes>
         <include>ai.h2o:h2o-core</include>
         <include>org.scala-lang:scala-library</include>
-        <include>org.scala-lang:scala-reflect</include>
       </includes>
     </dependencySet>
   </dependencySets>

--- a/h2o/src/main/assembly/h2o-dependency-reduced.xml
+++ b/h2o/src/main/assembly/h2o-dependency-reduced.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one or more
+ contributor license agreements.  See the NOTICE file distributed with
+ this work for additional information regarding copyright ownership.
+ The ASF licenses this file to You under the Apache License, Version 2.0
+ (the "License"); you may not use this file except in compliance with
+ the License.  You may obtain a copy of the License at
+     http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<assembly
+  xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0
+  http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>h2o-dependency-reduced</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <dependencySets>
+    <dependencySet>
+      <unpack>true</unpack>
+      <unpackOptions>
+      <!-- MAHOUT-1126 -->
+      <excludes>
+         <exclude>META-INF/LICENSE</exclude>
+      </excludes>
+      </unpackOptions>
+      <scope>runtime</scope>
+      <outputDirectory>/</outputDirectory>
+      <useTransitiveFiltering>true</useTransitiveFiltering>
+      <includes>
+        <include>ai.h2o:h2o-core</include>
+      </includes>
+    </dependencySet>
+  </dependencySets>
+</assembly>

--- a/h2o/src/test/scala/org/apache/mahout/h2obindings/test/DistributedH2OSuite.scala
+++ b/h2o/src/test/scala/org/apache/mahout/h2obindings/test/DistributedH2OSuite.scala
@@ -29,8 +29,8 @@ trait DistributedH2OSuite extends DistributedMahoutSuite with LoggerConfiguratio
 
   override protected def beforeEach() {
     super.beforeEach()
-
-//    mahoutCtx = mahoutH2OContext("mah2out" + System.currentTimeMillis())
+// replace after MAHOUT-1704
+// mahoutCtx = mahoutH2OContext("mah2out" + System.currentTimeMillis())
     mahoutCtx = mahoutH2OContext("mah2out" )
   }
 

--- a/h2o/src/test/scala/org/apache/mahout/h2obindings/test/DistributedH2OSuite.scala
+++ b/h2o/src/test/scala/org/apache/mahout/h2obindings/test/DistributedH2OSuite.scala
@@ -29,9 +29,7 @@ trait DistributedH2OSuite extends DistributedMahoutSuite with LoggerConfiguratio
 
   override protected def beforeEach() {
     super.beforeEach()
-// replace after MAHOUT-1704
-// mahoutCtx = mahoutH2OContext("mah2out" + System.currentTimeMillis())
-    mahoutCtx = mahoutH2OContext("mah2out" )
+ mahoutCtx = mahoutH2OContext("mah2out" + System.currentTimeMillis())
   }
 
   override protected def afterEach() {

--- a/h2o/src/test/scala/org/apache/mahout/h2obindings/test/DistributedH2OSuite.scala
+++ b/h2o/src/test/scala/org/apache/mahout/h2obindings/test/DistributedH2OSuite.scala
@@ -30,7 +30,8 @@ trait DistributedH2OSuite extends DistributedMahoutSuite with LoggerConfiguratio
   override protected def beforeEach() {
     super.beforeEach()
 
-    mahoutCtx = mahoutH2OContext("mah2out" + System.currentTimeMillis())
+//    mahoutCtx = mahoutH2OContext("mah2out" + System.currentTimeMillis())
+    mahoutCtx = mahoutH2OContext("mah2out" )
   }
 
   override protected def afterEach() {


### PR DESCRIPTION
This takes the dependency jar for h2o down to ~17M from~68M. Need to verify if this contains all needed deps. I have successfully tested launching {{$mahout h2o-node}} and run $mvn test in parallel on 2 nodes. 