### PR TITLE
MAHOUT-1706: remove dependency jars from /lib in the binary distribution

### DIFF
--- a/bin/mahout
+++ b/bin/mahout
@@ -230,10 +230,6 @@ then
     fi
   fi
 
-  # add release dependencies to CLASSPATH
-  for f in $MAHOUT_HOME/lib/*.jar; do
-    CLASSPATH=${CLASSPATH}:$f;
-  done
 else
   CLASSPATH=${CLASSPATH}:$MAHOUT_HOME/math/target/classes
   CLASSPATH=${CLASSPATH}:$MAHOUT_HOME/hdfs/target/classes

--- a/bin/mahout
+++ b/bin/mahout
@@ -242,7 +242,12 @@ else
   CLASSPATH=${CLASSPATH}:$MAHOUT_HOME/h2o/target/classes
 fi
 
-
+# add development dependencies to CLASSPATH
+ if [ "$SPARK" != "1" ]; then
+  for f in $MAHOUT_HOME/examples/target/dependency/hadoop*.jar; do
+  CLASSPATH=${CLASSPATH}:$f;
+ done
+fi
 # cygwin path translation
 if $cygwin; then
   CLASSPATH=`cygpath -p -w "$CLASSPATH"`

--- a/bin/mahout
+++ b/bin/mahout
@@ -242,13 +242,6 @@ else
   CLASSPATH=${CLASSPATH}:$MAHOUT_HOME/h2o/target/classes
 fi
 
-# add development dependencies to CLASSPATH
-if [ "$SPARK" != "1" ]; then
-  for f in $MAHOUT_HOME/examples/target/dependency/*.jar; do
-    CLASSPATH=${CLASSPATH}:$f;
-  done
-fi
-
 
 # cygwin path translation
 if $cygwin; then

--- a/distribution/src/main/assembly/bin.xml
+++ b/distribution/src/main/assembly/bin.xml
@@ -29,18 +29,6 @@
     <fileSet>
       <directory>${project.basedir}/../examples/target/dependency</directory>
       <includes>
-        <include>*.jar</include>
-      </includes>
-      <excludes>
-        <exclude>mahout-*</exclude>
-        <exclude>hadoop-*</exclude>
-		<exclude>junit-*</exclude>
-      </excludes>
-      <outputDirectory>lib</outputDirectory>
-    </fileSet>
-    <fileSet>
-      <directory>${project.basedir}/../examples/target/dependency</directory>
-      <includes>
         <include>mahout-collections*.jar</include>
       </includes>
       <outputDirectory>lib</outputDirectory>

--- a/runtests.sh
+++ b/runtests.sh
@@ -31,6 +31,9 @@ PING_LOOP_PID=$!
 mvn clean -DskipTests=true -Dmaven.javadoc.skip=true -B -V install >> $BUILD_OUTPUT 2>&1 
 cd hdfs && mvn test >> $BUILD_OUTPUT 2>&1
 cd ../math && mvn test >> $BUILD_OUTPUT 2>&1
+cd ../mr && mvn test >> $BUILD_OUTPUT 2>&1
+cd ../integration && mvn test >> $BUILD_OUTPUT 2>&1
+cd ../examples && mvn test >> $BUILD_OUTPUT 2>&1
 cd ../math-scala && mvn test >> $BUILD_OUTPUT 2>&1
 cd ../spark && mvn test >> $BUILD_OUTPUT 2>&1
 #cd ../flink && mvn test >> $BUILD_OUTPUT 2>&1

--- a/runtests.sh
+++ b/runtests.sh
@@ -31,9 +31,9 @@ PING_LOOP_PID=$!
 mvn clean -DskipTests=true -Dmaven.javadoc.skip=true -B -V install >> $BUILD_OUTPUT 2>&1 
 cd hdfs && mvn test >> $BUILD_OUTPUT 2>&1
 cd ../math && mvn test >> $BUILD_OUTPUT 2>&1
-cd ../mr && mvn test >> $BUILD_OUTPUT 2>&1
-cd ../integration && mvn test >> $BUILD_OUTPUT 2>&1
-cd ../examples && mvn test >> $BUILD_OUTPUT 2>&1
+#//cd ../mr && mvn test >> $BUILD_OUTPUT 2>&1
+#//cd ../integration && mvn test >> $BUILD_OUTPUT 2>&1
+#cd ../examples && mvn test >> $BUILD_OUTPUT 2>&1
 cd ../math-scala && mvn test >> $BUILD_OUTPUT 2>&1
 cd ../spark && mvn test >> $BUILD_OUTPUT 2>&1
 #cd ../flink && mvn test >> $BUILD_OUTPUT 2>&1


### PR DESCRIPTION
The mahout distribution currently is shipping ~56 MB of dependecy jars in the /lib directory of the distribution.   These are only added to the classpath by /bin/mahout in the binary distribution. It seems that we can remove them from the distribution. (we need to get the size of the distribution down)

Any input is appreciated. 
