### PR TITLE
MAHOUT-1706-0.10.x

### DIFF
--- a/bin/mahout
+++ b/bin/mahout
@@ -234,13 +234,6 @@ else
   CLASSPATH=${CLASSPATH}:$MAHOUT_HOME/h2o/target/classes
 fi
 
-# add development dependencies to CLASSPATH
-if [ "$SPARK" != "1" ]; then
-  for f in $MAHOUT_HOME/examples/target/dependency/*.jar; do
-    CLASSPATH=${CLASSPATH}:$f;
-  done
-fi
-
 
 # cygwin path translation
 if $cygwin; then

--- a/bin/mahout
+++ b/bin/mahout
@@ -234,7 +234,12 @@ else
   CLASSPATH=${CLASSPATH}:$MAHOUT_HOME/h2o/target/classes
 fi
 
-
+# add development dependencies to CLASSPATH
+ if [ "$SPARK" != "1" ]; then
+  for f in $MAHOUT_HOME/examples/target/dependency/hadoop*.jar; do
+  CLASSPATH=${CLASSPATH}:$f;
+ done
+fi
 # cygwin path translation
 if $cygwin; then
   CLASSPATH=`cygpath -p -w "$CLASSPATH"`

--- a/bin/mahout
+++ b/bin/mahout
@@ -222,10 +222,6 @@ then
 
   fi
 
-  # add release dependencies to CLASSPATH
-  for f in $MAHOUT_HOME/lib/*.jar; do
-    CLASSPATH=${CLASSPATH}:$f;
-  done
 else
   CLASSPATH=${CLASSPATH}:$MAHOUT_HOME/math/target/classes
   CLASSPATH=${CLASSPATH}:$MAHOUT_HOME/hdfs/target/classes

--- a/distribution/src/main/assembly/bin.xml
+++ b/distribution/src/main/assembly/bin.xml
@@ -29,18 +29,6 @@
     <fileSet>
       <directory>${project.basedir}/../examples/target/dependency</directory>
       <includes>
-        <include>*.jar</include>
-      </includes>
-      <excludes>
-        <exclude>mahout-*</exclude>
-        <exclude>hadoop-*</exclude>
-		<exclude>junit-*</exclude>
-      </excludes>
-      <outputDirectory>lib</outputDirectory>
-    </fileSet>
-    <fileSet>
-      <directory>${project.basedir}/../examples/target/dependency</directory>
-      <includes>
         <include>mahout-collections*.jar</include>
       </includes>
       <outputDirectory>lib</outputDirectory>


### PR DESCRIPTION
The mahout distribution currently is shipping ~56 MB of dependency jars in the /lib directory of the distribution. These are only added to the classpath by /bin/mahout in the binary distribution. It seems that we can remove them from the distribution. (we need to get the size of the distribution down).

This branch still needs testing on an cluster.