### PR TITLE
MAHOUT-1691: iterable of vectors to matrix

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
@@ -106,6 +106,25 @@ package object scalabindings {
   def prod2Vec(s: Product) = new DenseVector(s.productIterator.
       map(_.asInstanceOf[Number].doubleValue()).toArray)
 
+  implicit def iterable2Matrix(that: Iterable[Vector]): Matrix = {
+    val first = that.head
+    val nrow = that.size
+    val ncol = first.size
+
+    val m = if (first.isDense) {
+      new DenseMatrix(nrow, ncol)
+    } else {
+      new SparseRowMatrix(nrow, ncol)
+    }
+
+    that.zipWithIndex.foreach { case (row, idx) => 
+      m.assignRow(idx.toInt, row)
+    }
+
+    m
+  }
+
+
   def diagv(v: Vector): DiagonalMatrix = new DiagonalMatrix(v)
 
   def diag(v: Double, size: Int): DiagonalMatrix =


### PR DESCRIPTION
Some syntactic sugar for writing 

```
val res = drmX.mapBlock(drmX.ncol) {
  case (keys, block) => {
    keys -> block.map(row => (row - mean) / std)
  }
}
```

Instead of writing 

```
val res = drmX.mapBlock(drmX.ncol) {
  case (keys, block) => {
    val copy = block.like
    copy := block.map(row => (row - mean) / std)
    (keys, copy)
  }
}
```

When having side effects is not desirable 