### PR TITLE
NOJIRA: dynamically determine evalZeros in OpAewUnaryFunc

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/DistributedEngine.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/DistributedEngine.scala
@@ -196,13 +196,13 @@ object DistributedEngine {
       // Fusion of unary funcs into single, like 1 + x * x.
       // Since we repeating the pass over self after rewrite, we dont' need to descend into arguments
       // recursively here.
-      case op1@OpAewUnaryFunc(op2@OpAewUnaryFunc(a, _, _), _, _) ⇒
+      case op1@OpAewUnaryFunc(op2@OpAewUnaryFunc(a, _), _) ⇒
         pass2(OpAewUnaryFuncFusion(a, op1 :: op2 :: Nil))
 
       // Fusion one step further, like 1 + 2 * x * x. All should be rewritten as one UnaryFuncFusion.
       // Since we repeating the pass over self after rewrite, we dont' need to descend into arguments
       // recursively here.
-      case op@OpAewUnaryFuncFusion(op2@OpAewUnaryFunc(a, _, _), _) ⇒
+      case op@OpAewUnaryFuncFusion(op2@OpAewUnaryFunc(a, _), _) ⇒
         pass2(OpAewUnaryFuncFusion(a, op.ff :+ op2))
 
       // A.t.t => A

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/RLikeDrmOps.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/RLikeDrmOps.scala
@@ -38,13 +38,13 @@ class RLikeDrmOps[K: ClassTag](drm: DrmLike[K]) extends DrmLikeOps[K](drm) {
 
   def /(that: DrmLike[K]): DrmLike[K] = OpAewB[K](A = this, B = that, op = "/")
 
-  def +(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = _ + that, evalZeros = true)
+  def +(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = _ + that)
 
-  def +:(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = that + _, evalZeros = true)
+  def +:(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = that + _)
 
-  def -(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = _ - that, evalZeros = true)
+  def -(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = _ - that)
 
-  def -:(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = that - _, evalZeros = true)
+  def -:(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = that - _)
 
   def *(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = _ * that)
 
@@ -52,9 +52,9 @@ class RLikeDrmOps[K: ClassTag](drm: DrmLike[K]) extends DrmLikeOps[K](drm) {
 
   def ^(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = math.pow(_, that))
 
-  def /(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = _ / that, evalZeros = that == 0.0)
+  def /(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = _ / that)
 
-  def /:(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = that / _, evalZeros = true)
+  def /:(that: Double): DrmLike[K] = OpAewUnaryFunc[K](A = this, f = that / _)
 
   def :%*%(that: DrmLike[Int]): DrmLike[K] = OpAB[K](A = this.drm, B = that)
 

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/logical/OpAewUnaryFunc.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/logical/OpAewUnaryFunc.scala
@@ -26,9 +26,10 @@ import scala.util.Random
  */
 case class OpAewUnaryFunc[K: ClassTag](
     override var A: DrmLike[K],
-    val f: (Double) => Double,
-    val evalZeros:Boolean = false
+    val f: (Double) => Double
     ) extends AbstractUnaryOp[K,K] with TEwFunc {
+
+  val evalZeros = if (f(0.0) == 0.0) false else true
 
   override protected[mahout] lazy val partitioningTag: Long =
     if (A.canHaveMissingRows)

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/package.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/package.scala
@@ -151,9 +151,9 @@ package object drm {
 
   ///////////////////////////////////////////////////////////
   // Elementwise unary functions on distributed operands.
-  def dexp[K: ClassTag](drmA: DrmLike[K]): DrmLike[K] = new OpAewUnaryFunc[K](drmA, math.exp, true)
+  def dexp[K: ClassTag](drmA: DrmLike[K]): DrmLike[K] = new OpAewUnaryFunc[K](drmA, math.exp)
 
-  def dlog[K: ClassTag](drmA: DrmLike[K]): DrmLike[K] = new OpAewUnaryFunc[K](drmA, math.log, true)
+  def dlog[K: ClassTag](drmA: DrmLike[K]): DrmLike[K] = new OpAewUnaryFunc[K](drmA, math.log)
 
   def dabs[K: ClassTag](drmA: DrmLike[K]): DrmLike[K] = new OpAewUnaryFunc[K](drmA, math.abs)
 

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/SparkEngine.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/SparkEngine.scala
@@ -325,7 +325,7 @@ object SparkEngine extends DistributedEngine {
       case op@OpAtA(a) ⇒ AtA.at_a(op, tr2phys(a)(op.classTagA))
       case op@OpAx(a, x) ⇒ Ax.ax_with_broadcast(op, tr2phys(a)(op.classTagA))
       case op@OpAtx(a, x) ⇒ Ax.atx_with_broadcast(op, tr2phys(a)(op.classTagA))
-      case op@OpAewUnaryFunc(a, _, _) ⇒ AewB.a_ew_func(op, tr2phys(a)(op.classTagA))
+      case op@OpAewUnaryFunc(a, _) ⇒ AewB.a_ew_func(op, tr2phys(a)(op.classTagA))
       case op@OpAewUnaryFuncFusion(a, _) ⇒ AewB.a_ew_func(op, tr2phys(a)(op.classTagA))
       case op@OpAewB(a, b, opId) ⇒ AewB.a_ew_b(op, tr2phys(a)(op.classTagA), tr2phys(b)(op.classTagB))
       case op@OpCbind(a, b) ⇒ CbindAB.cbindAB_nograph(op, tr2phys(a)(op.classTagA), tr2phys(b)(op.classTagB))


### PR DESCRIPTION
- saves sparse computation in operators like "+ 0.0", "- 0.0" etc.
  (when the scalar comes as a variable that happens to be 0.0)

- makes code less vulnerable to errors like a missed setting of
  "evalZeroes = true" parameter while adding a new operator in
  the future.

Signed-off-by: Anand Avati <avati@redhat.com>