### PR TITLE
NOJIRA: minor row similarity cleanup

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -2,6 +2,8 @@ Mahout Change Log
 
 Release 0.11.0 - unreleased
 
+  NOJIRA: Clean up CLI help for spark-rowsimilarity and fixed test that intermitently failed (pferrel)
+
   MAHOUT-1685: Move Mahout shell to Spark 1.3+ (dlyubimov, apalumbo)
 
   MAHOUT-1653: Spark 1.3 (pferrel, apalumbo)

--- a/math-scala/src/main/scala/org/apache/mahout/drivers/MahoutOptionParser.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/drivers/MahoutOptionParser.scala
@@ -151,9 +151,9 @@ class MahoutOptionParser(programName: String) extends OptionParser[Map[String, A
 
   }
 
-  def parseIndexedDatasetFormatOptions() = {
+  def parseIndexedDatasetFormatOptions(notice: String = "\nOutput text file schema options:") = {
     opts = opts ++ MahoutOptionParser.TextDelimitedIndexedDatasetOptions
-    note("\nOutput text file schema options:")
+    note(notice)
     opt[String]("rowKeyDelim") abbr ("rd") action { (x, options) =>
       options + ("rowKeyDelim" -> x)
     } text ("Separates the rowID key from the vector values list (optional). Default: \"\\t\"")

--- a/math-scala/src/main/scala/org/apache/mahout/math/cf/SimilarityAnalysis.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/cf/SimilarityAnalysis.scala
@@ -59,6 +59,9 @@ object SimilarityAnalysis extends Serializable {
 
     implicit val distributedContext = drmARaw.context
 
+    // backend allowed to optimize partitioning
+    drmARaw.par(auto = true)
+
     // Apply selective downsampling, pin resulting matrix
     val drmA = sampleDownAndBinarize(drmARaw, randomSeed, maxNumInteractions)
 
@@ -79,6 +82,9 @@ object SimilarityAnalysis extends Serializable {
 
     // Now look at cross cooccurrences
     for (drmBRaw <- drmBs) {
+      // backend allowed to optimize partitioning
+      drmBRaw.par(auto = true)
+
       // Down-sample and pin other interaction matrix
       val drmB = sampleDownAndBinarize(drmBRaw, randomSeed, maxNumInteractions).checkpoint()
 

--- a/math-scala/src/main/scala/org/apache/mahout/math/cf/SimilarityAnalysis.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/cf/SimilarityAnalysis.scala
@@ -159,6 +159,9 @@ object SimilarityAnalysis extends Serializable {
 
     implicit val distributedContext = drmARaw.context
 
+    // backend allowed to optimize partitioning
+    drmARaw.par(auto = true)
+
     // Apply selective downsampling, pin resulting matrix
     val drmA = sampleDownAndBinarize(drmARaw, randomSeed, maxNumInteractions)
 

--- a/spark/src/main/scala/org/apache/mahout/drivers/ItemSimilarityDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/ItemSimilarityDriver.scala
@@ -59,7 +59,7 @@ object ItemSimilarityDriver extends MahoutSparkDriver {
   override def main(args: Array[String]): Unit = {
 
     parser = new MahoutSparkOptionParser(programName = "spark-itemsimilarity") {
-      head("spark-itemsimilarity", "Mahout 0.10.0")
+      head("spark-itemsimilarity", "Mahout")
 
       //Input output options, non-driver specific
       parseIOOptions(numInputs = 2)

--- a/spark/src/main/scala/org/apache/mahout/drivers/RowSimilarityDriver.scala
+++ b/spark/src/main/scala/org/apache/mahout/drivers/RowSimilarityDriver.scala
@@ -54,7 +54,7 @@ object RowSimilarityDriver extends MahoutSparkDriver {
   override def main(args: Array[String]): Unit = {
 
     parser = new MahoutSparkOptionParser(programName = "spark-rowsimilarity") {
-      head("spark-rowsimilarity", "Mahout 0.10.0")
+      head("spark-rowsimilarity", "Mahout")
 
       //Input output options, non-driver specific
       parseIOOptions()
@@ -67,14 +67,14 @@ object RowSimilarityDriver extends MahoutSparkDriver {
         options + ("maxObservations" -> x)
       } text ("Max number of observations to consider per row (optional). Default: " +
         RowSimilarityOptions("maxObservations")) validate { x =>
-          if (x > 0) success else failure("Option --maxObservations must be > 0")
+        if (x > 0) success else failure("Option --maxObservations must be > 0")
       }
 
       opt[Int]('m', "maxSimilaritiesPerRow") action { (x, options) =>
         options + ("maxSimilaritiesPerRow" -> x)
       } text ("Limit the number of similarities per item to this number (optional). Default: " +
         RowSimilarityOptions("maxSimilaritiesPerRow")) validate { x =>
-          if (x > 0) success else failure("Option --maxSimilaritiesPerRow must be > 0")
+        if (x > 0) success else failure("Option --maxSimilaritiesPerRow must be > 0")
       }
 
       // --threshold not implemented in SimilarityAnalysis.rowSimilarity
@@ -85,7 +85,7 @@ object RowSimilarityDriver extends MahoutSparkDriver {
       note("\nNote: Only the Log Likelihood Ratio (LLR) is supported as a similarity measure.")
 
       //Drm output schema--not driver specific, drm specific
-      parseIndexedDatasetFormatOptions()
+      parseIndexedDatasetFormatOptions("\nInput and Output text file schema options (same for both):")
 
       //How to search for input
       parseFileDiscoveryOptions()
@@ -126,7 +126,7 @@ object RowSimilarityDriver extends MahoutSparkDriver {
       null.asInstanceOf[IndexedDataset]
     } else {
 
-      val datasetA = indexedDatasetDFSRead(inFiles, readWriteSchema)
+      val datasetA = indexedDatasetDFSRead(src = inFiles, schema = readWriteSchema)
       datasetA
     }
   }
@@ -141,7 +141,7 @@ object RowSimilarityDriver extends MahoutSparkDriver {
       parser.opts("maxSimilaritiesPerRow").asInstanceOf[Int],
       parser.opts("maxObservations").asInstanceOf[Int])
 
-    rowSimilarityIDS.dfsWrite(parser.opts("output").asInstanceOf[String], readWriteSchema)
+    rowSimilarityIDS.dfsWrite(dest = parser.opts("output").asInstanceOf[String], schema = readWriteSchema)
 
     stop()
   }

--- a/spark/src/test/scala/org/apache/mahout/drivers/RowSimilarityDriverSuite.scala
+++ b/spark/src/test/scala/org/apache/mahout/drivers/RowSimilarityDriverSuite.scala
@@ -74,11 +74,12 @@ class RowSimilarityDriverSuite extends FunSuite with DistributedSparkSuite  {
       "--master", masterUrl))
 
     val simLines = mahoutCtx.textFile(outPath).collect
-    for (rowNum <- 0 to 4){
-      simLines(rowNum).split("[\t ]") should contain theSameElementsAs firstFiveSimDocsTokens
-    }
-    for (rowNum <- 5 to 9){
-      simLines(rowNum).split("[\t ]") should contain theSameElementsAs lastFiveSimDocsTokens
+    simLines.foreach { line =>
+      val lineTokens = line.split("[\t ]")
+      if (lineTokens.contains("doc1") ) // docs are two flavors so if only 4 similarities it will effectively classify
+        lineTokens should contain theSameElementsAs firstFiveSimDocsTokens
+      else
+        lineTokens should contain theSameElementsAs lastFiveSimDocsTokens
     }
 
   }


### PR DESCRIPTION
fixed an intermittent test failure, cleaned up row similarity help, fixed a minor bug reading into row similarity where the strength delimiter was in text but omitStrength was chosen