### PR TITLE
MAHOUT-1773: Fix cluster-syntheticcontrol.sh for HDFS synthax

### DIFF
--- a/examples/bin/cluster-syntheticcontrol.sh
+++ b/examples/bin/cluster-syntheticcontrol.sh
@@ -66,13 +66,13 @@ if [ ! -f ${WORK_DIR}/synthetic_control.data ]; then
 fi
 if [ "$HADOOP_HOME" != "" ] && [ "$MAHOUT_LOCAL" == "" ]; then
   echo "Checking the health of DFS..."
-  $DFS -ls
+  $DFS -ls /
   if [ $? -eq 0 ];then 
     echo "DFS is healthy... "
     echo "Uploading Synthetic control data to HDFS"
     $DFSRM testdata
-    $DFS -mkdir testdata
-    $DFS -put ${WORK_DIR}/synthetic_control.data testdata
+    $DFS -mkdir /testdata
+    $DFS -put ${WORK_DIR}/synthetic_control.data /testdata
     echo "Successfully Uploaded Synthetic control data to HDFS "
 
     ../../bin/mahout org.apache.mahout.clustering.syntheticcontrol."${clustertype}".Job


### PR DESCRIPTION
Added  '/' to some lines, so it can check the root of the HDFS, where it's possible to use -mkdir, -put and others. Otherwise the example keeps failing (Hadoop 2.4.1).