### PR TITLE
MAHOUT-1771 Cluster dumper omits indices and 0 elements for dense vector or sparse containing 0s

### DIFF
--- a/mr/src/main/java/org/apache/mahout/clustering/AbstractCluster.java
+++ b/mr/src/main/java/org/apache/mahout/clustering/AbstractCluster.java
@@ -353,7 +353,7 @@ public abstract class AbstractCluster implements Cluster {
   public static List<Object> formatVectorAsJson(Vector v, String[] bindings) throws IOException {
 
     boolean hasBindings = bindings != null;
-    boolean isSparse = !v.isDense() && v.getNumNondefaultElements() != v.size();
+    boolean isSparse = v.getNumNonZeroElements() != v.size();
 
     // we assume sequential access in the output
     Vector provider = v.isSequentialAccess() ? v : new SequentialAccessSparseVector(v);


### PR DESCRIPTION
Output indices in cluster representation whenever *any* vector has *some* zero elements that won't be output.