### PR TITLE
MAHOUT-1570, sub-pr: a siggestion: let's unify all key class tag extractors. 

### DIFF
--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
@@ -20,7 +20,7 @@ package org.apache.mahout.flinkbindings.drm
 
 import scala.collection.JavaConverters._
 import scala.util.Random
-import scala.reflect.ClassTag
+import scala.reflect.{ClassTag, classTag}
 import org.apache.flink.api.common.functions.MapFunction
 import org.apache.flink.api.common.functions.ReduceFunction
 import org.apache.flink.api.java.hadoop.mapred.HadoopOutputFormat
@@ -75,7 +75,8 @@ class CheckpointedFlinkDrm[K: ClassTag](val ds: DrmDataSet[K],
     list.head
   }
 
-  def keyClassTag: ClassTag[K] = implicitly[ClassTag[K]]
+
+  override val keyClassTag: ClassTag[K] = classTag[K]
 
   def cache() = {
     // TODO

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/package.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/package.scala
@@ -108,11 +108,6 @@ package object flinkbindings {
     new CheckpointedFlinkDrm[K](dataset)
   }
 
-  private[flinkbindings] def extractRealClassTag[K: ClassTag](drm: DrmLike[K]): ClassTag[_] = drm match {
-    case d: CheckpointAction[K] => d.classTag
-    case d: CheckpointedFlinkDrm[K] => d.keyClassTag
-    // will not always return correct result, often result in Any
-    case _ => implicitly[ClassTag[K]]
-  }
+  private[flinkbindings] def extractRealClassTag[K: ClassTag](drm: DrmLike[K]): ClassTag[_] = drm.keyClassTag
 
 }

--- a/h2o/src/main/scala/org/apache/mahout/h2obindings/H2OEngine.scala
+++ b/h2o/src/main/scala/org/apache/mahout/h2obindings/H2OEngine.scala
@@ -112,7 +112,7 @@ object H2OEngine extends DistributedEngine {
       case op@OpRowRange(a, r) => RowRange.exec(tr2phys(a)(op.classTagA), r)
       // Custom operators
       case blockOp: OpMapBlock[K, _] => MapBlock.exec(tr2phys(blockOp.A)(blockOp.classTagA), blockOp.ncol, blockOp.bmf,
-        (blockOp.classTagK == implicitly[ClassTag[String]]), blockOp.classTagA, blockOp.classTagK)
+        (blockOp.keyClassTag == implicitly[ClassTag[String]]), blockOp.classTagA, blockOp.keyClassTag)
       case op@OpPar(a, m, e) => Par.exec(tr2phys(a)(op.classTagA), m, e)
       case cp: CheckpointedDrm[K] => cp.h2odrm
       case _ => throw new IllegalArgumentException("Internal:Optimizer has no exec policy for operator %s."

--- a/h2o/src/main/scala/org/apache/mahout/h2obindings/drm/CheckpointedDrmH2O.scala
+++ b/h2o/src/main/scala/org/apache/mahout/h2obindings/drm/CheckpointedDrmH2O.scala
@@ -18,6 +18,8 @@ class CheckpointedDrmH2O[K: ClassTag](
   val context: DistributedContext
 ) extends CheckpointedDrm[K] {
 
+  override val keyClassTag: ClassTag[K] = classTag[K]
+
   /**
     * Collecting DRM to in-core Matrix
     *
@@ -26,9 +28,6 @@ class CheckpointedDrmH2O[K: ClassTag](
     * as rowLabelBindings of the in-core matrix.
     */
   def collect: Matrix = H2OHelper.matrixFromDrm(h2odrm)
-
-  /** Explicit extraction of key class Tag   */
-  def keyClassTag: ClassTag[K] = implicitly[ClassTag[K]]
 
   /* XXX: call frame.remove */
   def uncache(): this.type = this

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/CheckpointedDrm.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/CheckpointedDrm.scala
@@ -18,7 +18,6 @@
 package org.apache.mahout.math.drm
 
 import org.apache.mahout.math.Matrix
-import scala.reflect.ClassTag
 
 /**
  * Checkpointed DRM API. This is a matrix that has optimized RDD lineage behind it and can be
@@ -33,13 +32,6 @@ trait CheckpointedDrm[K] extends DrmLike[K] {
 
   /** If this checkpoint is already declared cached, uncache. */
   def uncache(): this.type
-
-  /**
-   * Explicit extraction of key class Tag since traits don't support context bound access; but actual
-   * implementation knows it
-   */
-  def keyClassTag: ClassTag[K]
-
 
   /** changes the number of rows without touching the underlying data */
   def newRowCardinality(n: Int): CheckpointedDrm[K]

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/DrmLike.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/DrmLike.scala
@@ -25,6 +25,8 @@ import scala.reflect.ClassTag
  */
 trait DrmLike[K] {
 
+  val keyClassTag: ClassTag[K]
+
   protected[mahout] def partitioningTag: Long
 
   protected[mahout] def canHaveMissingRows: Boolean

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/logical/AbstractBinaryOp.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/logical/AbstractBinaryOp.scala
@@ -49,6 +49,4 @@ abstract class AbstractBinaryOp[A: ClassTag, B: ClassTag, K: ClassTag]
 
   def classTagB: ClassTag[B] = implicitly[ClassTag[B]]
 
-  def classTagK: ClassTag[K] = implicitly[ClassTag[K]]
-
 }

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/logical/AbstractUnaryOp.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/logical/AbstractUnaryOp.scala
@@ -30,8 +30,6 @@ abstract class AbstractUnaryOp[A: ClassTag, K: ClassTag]
 
   def classTagA: ClassTag[A] = implicitly[ClassTag[A]]
 
-  def classTagK: ClassTag[K] = implicitly[ClassTag[K]]
-
   override protected[mahout] lazy val canHaveMissingRows: Boolean = A.canHaveMissingRows
 
 }

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/logical/CheckpointAction.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/logical/CheckpointAction.scala
@@ -17,12 +17,15 @@
 
 package org.apache.mahout.math.drm.logical
 
-import scala.reflect.ClassTag
+import scala.reflect.{ClassTag, classTag}
 import scala.util.Random
 import org.apache.mahout.math.drm._
 
 /** Implementation of distributed expression checkpoint and optimizer. */
 abstract class CheckpointAction[K: ClassTag] extends DrmLike[K] {
+
+
+  override val keyClassTag: ClassTag[K] = classTag[K]
 
   protected[mahout] lazy val partitioningTag: Long = Random.nextLong()
 
@@ -44,6 +47,5 @@ abstract class CheckpointAction[K: ClassTag] extends DrmLike[K] {
     case Some(cp) => cp
   }
 
-  val classTag = implicitly[ClassTag[K]]
 }
 

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/CheckpointedDrmSpark.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/CheckpointedDrmSpark.scala
@@ -51,6 +51,9 @@ class CheckpointedDrmSpark[K: ClassTag](
     private var _canHaveMissingRows: Boolean = false
     ) extends CheckpointedDrm[K] {
 
+
+  override val keyClassTag: ClassTag[K] = classTag[K]
+
   lazy val nrow = if (_nrow >= 0) _nrow else computeNRow
   lazy val ncol = if (_ncol >= 0) _ncol else computeNCol
   lazy val canHaveMissingRows: Boolean = {
@@ -63,9 +66,6 @@ class CheckpointedDrmSpark[K: ClassTag](
 
   private var cached: Boolean = false
   override val context: DistributedContext = rddInput.backingRdd.context
-
-  /** Explicit extraction of key class Tag   */
-  def keyClassTag: ClassTag[K] = implicitly[ClassTag[K]]
 
   /**
    * Action operator -- does not necessary means Spark action; but does mean running BLAS optimizer


### PR DESCRIPTION
Unifying "keyClassTag" of checkpoitns and "classTagK" of logical operators and

elevating "keyClassTag" into DrmLike[] trait. No more logical forks any more .