### PR TITLE
MAHOUT-1775 FileNotFoundException caused by aborting the process of downloading Wikipedia dataset

### DIFF
--- a/examples/bin/classify-wikipedia.sh
+++ b/examples/bin/classify-wikipedia.sh
@@ -78,9 +78,9 @@ if [ "x$alg" != "xclean" ]; then
         ########################################################
     fi
     if [ ! -e ${WORK_DIR}/wikixml/enwiki-latest-pages-articles.xml ]; then
-      echo "Extracting..."
+        echo "Extracting..."
        
-      cd ${WORK_DIR}/wikixml && bunzip2 enwiki-latest-pages-articles.xml.bz2 && cd .. && cd ..
+        cd ${WORK_DIR}/wikixml && bunzip2 enwiki-latest-pages-articles.xml.bz2 && cd .. && cd ..
     fi
 
 echo $START_PATH

--- a/examples/bin/classify-wikipedia.sh
+++ b/examples/bin/classify-wikipedia.sh
@@ -63,6 +63,8 @@ if [ "x$alg" != "xclean" ]; then
   mkdir -p ${WORK_DIR}
     if [ ! -e ${WORK_DIR}/wikixml ]; then
         mkdir -p ${WORK_DIR}/wikixml
+    fi
+    if [ ! -e ${WORK_DIR}/wikixml/enwiki-latest-pages-articles.xml.bz2 ]; then
         echo "Downloading wikipedia XML dump"
         ########################################################   
         #  Datasets: uncomment and run "clean" to change dataset   
@@ -74,7 +76,8 @@ if [ "x$alg" != "xclean" ]; then
         ######### full wikipedia dump: 10G zipped
         #curl http://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2 -o ${WORK_DIR}/wikixml/enwiki-latest-pages-articles.xml.bz2
         ########################################################
-      
+    fi
+    if [ ! -e ${WORK_DIR}/wikixml/enwiki-latest-pages-articles.xml ]; then
       echo "Extracting..."
        
       cd ${WORK_DIR}/wikixml && bunzip2 enwiki-latest-pages-articles.xml.bz2 && cd .. && cd ..


### PR DESCRIPTION
Instead of putting mkdir, downloading dataset, and extracting inside one single if block, put them into three separate ones.