### PR TITLE
MAHOUT-1786: Make classes implements Serializable for Spark 1.5+

### DIFF
--- a/math/src/main/java/org/apache/mahout/math/AbstractMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/AbstractMatrix.java
@@ -24,13 +24,14 @@ import org.apache.mahout.math.flavor.MatrixFlavor;
 import org.apache.mahout.math.flavor.TraversingStructureEnum;
 import org.apache.mahout.math.function.*;
 
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Map;
 
 /**
  * A few universal implementations of convenience functions for a JVM-backed matrix.
  */
-public abstract class AbstractMatrix implements Matrix {
+public abstract class AbstractMatrix implements Matrix, Serializable {
 
   protected Map<String, Integer> columnLabelBindings;
   protected Map<String, Integer> rowLabelBindings;

--- a/math/src/main/java/org/apache/mahout/math/AbstractVector.java
+++ b/math/src/main/java/org/apache/mahout/math/AbstractVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.mahout.math;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 import com.google.common.base.Preconditions;
@@ -26,7 +27,7 @@ import org.apache.mahout.math.function.DoubleFunction;
 import org.apache.mahout.math.function.Functions;
 
 /** Implementations of generic capabilities like sum of elements and dot products */
-public abstract class AbstractVector implements Vector, LengthCachingVector {
+public abstract class AbstractVector implements Vector, LengthCachingVector, Serializable {
 
   private int size;
   protected double lengthSquared = -1.0;

--- a/math/src/main/java/org/apache/mahout/math/ConstantVector.java
+++ b/math/src/main/java/org/apache/mahout/math/ConstantVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.mahout.math;
 
+import java.io.Serializable;
 import java.util.Iterator;
 
 import com.google.common.collect.AbstractIterator;
@@ -24,7 +25,7 @@ import com.google.common.collect.AbstractIterator;
 /**
  * Implements a vector with all the same values.
  */
-public class ConstantVector extends AbstractVector {
+public class ConstantVector extends AbstractVector implements Serializable {
   private final double value;
 
   public ConstantVector(double value, int size) {

--- a/math/src/main/java/org/apache/mahout/math/DelegatingVector.java
+++ b/math/src/main/java/org/apache/mahout/math/DelegatingVector.java
@@ -20,6 +20,8 @@ package org.apache.mahout.math;
 import org.apache.mahout.math.function.DoubleDoubleFunction;
 import org.apache.mahout.math.function.DoubleFunction;
 
+import java.io.Serializable;
+
 /**
  * A delegating vector provides an easy way to decorate vectors with weights or id's and such while
  * keeping all of the Vector functionality.
@@ -27,7 +29,7 @@ import org.apache.mahout.math.function.DoubleFunction;
  * This vector implements LengthCachingVector because almost all delegates cache the length and
  * the cost of false positives is very low.
  */
-public class DelegatingVector implements Vector, LengthCachingVector {
+public class DelegatingVector implements Vector, LengthCachingVector, Serializable {
   protected Vector delegate;
 
   public DelegatingVector(Vector v) {

--- a/math/src/main/java/org/apache/mahout/math/DenseMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/DenseMatrix.java
@@ -20,10 +20,11 @@ package org.apache.mahout.math;
 import org.apache.mahout.math.flavor.MatrixFlavor;
 import org.apache.mahout.math.flavor.TraversingStructureEnum;
 
+import java.io.Serializable;
 import java.util.Arrays;
 
 /** Matrix of doubles implemented using a 2-d array */
-public class DenseMatrix extends AbstractMatrix {
+public class DenseMatrix extends AbstractMatrix implements Serializable {
 
   private double[][] values;
 

--- a/math/src/main/java/org/apache/mahout/math/DenseSymmetricMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/DenseSymmetricMatrix.java
@@ -19,10 +19,12 @@ package org.apache.mahout.math;
 
 import org.apache.mahout.math.flavor.TraversingStructureEnum;
 
+import java.io.Serializable;
+
 /**
  * Economy packaging for a dense symmetric in-core matrix.
  */
-public class DenseSymmetricMatrix extends UpperTriangular {
+public class DenseSymmetricMatrix extends UpperTriangular implements Serializable {
   public DenseSymmetricMatrix(int n) {
     super(n);
   }

--- a/math/src/main/java/org/apache/mahout/math/DenseVector.java
+++ b/math/src/main/java/org/apache/mahout/math/DenseVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.mahout.math;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -24,7 +25,7 @@ import java.util.NoSuchElementException;
 import com.google.common.base.Preconditions;
 
 /** Implements vector as an array of doubles */
-public class DenseVector extends AbstractVector {
+public class DenseVector extends AbstractVector implements Serializable {
 
   private double[] values;
 

--- a/math/src/main/java/org/apache/mahout/math/DiagonalMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/DiagonalMatrix.java
@@ -20,10 +20,11 @@ package org.apache.mahout.math;
 import org.apache.mahout.math.flavor.MatrixFlavor;
 import org.apache.mahout.math.flavor.TraversingStructureEnum;
 
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-public class DiagonalMatrix extends AbstractMatrix implements MatrixTimesOps {
+public class DiagonalMatrix extends AbstractMatrix implements MatrixTimesOps, Serializable {
   private final Vector diagonal;
 
   public DiagonalMatrix(Vector values) {

--- a/math/src/main/java/org/apache/mahout/math/NamedVector.java
+++ b/math/src/main/java/org/apache/mahout/math/NamedVector.java
@@ -20,7 +20,9 @@ package org.apache.mahout.math;
 import org.apache.mahout.math.function.DoubleDoubleFunction;
 import org.apache.mahout.math.function.DoubleFunction;
 
-public class NamedVector implements Vector {
+import java.io.Serializable;
+
+public class NamedVector implements Vector, Serializable {
 
   private Vector delegate;
   private String name;

--- a/math/src/main/java/org/apache/mahout/math/PivotedMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/PivotedMatrix.java
@@ -19,10 +19,12 @@ package org.apache.mahout.math;
 
 import com.google.common.base.Preconditions;
 
+import java.io.Serializable;
+
 /**
  * Matrix that allows transparent row and column permutation.
  */
-public class PivotedMatrix extends AbstractMatrix {
+public class PivotedMatrix extends AbstractMatrix implements Serializable {
 
   private Matrix base;
   private int[] rowPivot;

--- a/math/src/main/java/org/apache/mahout/math/RandomAccessSparseVector.java
+++ b/math/src/main/java/org/apache/mahout/math/RandomAccessSparseVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.mahout.math;
 
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -27,7 +28,7 @@ import org.apache.mahout.math.set.AbstractSet;
 
 
 /** Implements vector that only stores non-zero doubles */
-public class RandomAccessSparseVector extends AbstractVector {
+public class RandomAccessSparseVector extends AbstractVector implements Serializable {
 
   private static final int INITIAL_CAPACITY = 11;
 

--- a/math/src/main/java/org/apache/mahout/math/RandomTrinaryMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/RandomTrinaryMatrix.java
@@ -17,6 +17,7 @@
 
 package org.apache.mahout.math;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -29,7 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  * If the simple hash method is not satisfactory, an optional high quality mode is available
  * which uses a murmur hash of the coordinates.
  */
-public class RandomTrinaryMatrix extends AbstractMatrix {
+public class RandomTrinaryMatrix extends AbstractMatrix implements Serializable {
   private static final AtomicInteger ID = new AtomicInteger();
   private static final int PRIME1 = 104047;
   private static final int PRIME2 = 101377;

--- a/math/src/main/java/org/apache/mahout/math/SequentialAccessSparseVector.java
+++ b/math/src/main/java/org/apache/mahout/math/SequentialAccessSparseVector.java
@@ -17,6 +17,7 @@
 
 package org.apache.mahout.math;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -40,7 +41,7 @@ import org.apache.mahout.math.function.Functions;
  *
  * See {@link OrderedIntDoubleMapping}
  */
-public class SequentialAccessSparseVector extends AbstractVector {
+public class SequentialAccessSparseVector extends AbstractVector implements Serializable {
 
   private OrderedIntDoubleMapping values;
 

--- a/math/src/main/java/org/apache/mahout/math/SparseColumnMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/SparseColumnMatrix.java
@@ -19,13 +19,15 @@ package org.apache.mahout.math;
 
 import org.apache.mahout.math.flavor.TraversingStructureEnum;
 
+import java.io.Serializable;
+
 /**
  * sparse matrix with general element values whose columns are accessible quickly. Implemented as a column array of
  * SparseVectors.
  *
  * @deprecated tons of inconsistences. Use transpose view of SparseRowMatrix for fast column-wise iteration.
  */
-public class SparseColumnMatrix extends AbstractMatrix {
+public class SparseColumnMatrix extends AbstractMatrix implements Serializable {
 
   private Vector[] columnVectors;
 

--- a/math/src/main/java/org/apache/mahout/math/SparseMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/SparseMatrix.java
@@ -26,11 +26,12 @@ import org.apache.mahout.math.function.IntObjectProcedure;
 import org.apache.mahout.math.list.IntArrayList;
 import org.apache.mahout.math.map.OpenIntObjectHashMap;
 
+import java.io.Serializable;
 import java.util.Iterator;
 import java.util.Map;
 
 /** Doubly sparse matrix. Implemented as a Map of RandomAccessSparseVector rows */
-public class SparseMatrix extends AbstractMatrix {
+public class SparseMatrix extends AbstractMatrix implements Serializable {
 
   private OpenIntObjectHashMap<Vector> rowVectors;
   

--- a/math/src/main/java/org/apache/mahout/math/SparseRowMatrix.java
+++ b/math/src/main/java/org/apache/mahout/math/SparseRowMatrix.java
@@ -21,11 +21,13 @@ import org.apache.mahout.math.flavor.MatrixFlavor;
 import org.apache.mahout.math.flavor.TraversingStructureEnum;
 import org.apache.mahout.math.function.Functions;
 
+import java.io.Serializable;
+
 /**
  * sparse matrix with general element values whose rows are accessible quickly. Implemented as a row
  * array of either SequentialAccessSparseVectors or RandomAccessSparseVectors.
  */
-public class SparseRowMatrix extends AbstractMatrix {
+public class SparseRowMatrix extends AbstractMatrix implements Serializable {
   private Vector[] rowVectors;
 
   private final boolean randomAccessRows;

--- a/math/src/main/java/org/apache/mahout/math/WeightedVector.java
+++ b/math/src/main/java/org/apache/mahout/math/WeightedVector.java
@@ -17,10 +17,12 @@
 
 package org.apache.mahout.math;
 
+import java.io.Serializable;
+
 /**
  * Decorates a vector with a floating point weight and an index.
  */
-public class WeightedVector extends DelegatingVector {
+public class WeightedVector extends DelegatingVector implements Serializable {
   private static final int INVALID_INDEX = -1;
   private double weight;
   private int index;


### PR DESCRIPTION
Add some "implements Serializable" for Apache Spark 1.5+
There might be other classes that would benefit from the same modification.
