### PR TITLE
MAHOUT-1794: Support MAHOUT_WORK_DIR environment variable

### DIFF
--- a/examples/bin/classify-20newsgroups.sh
+++ b/examples/bin/classify-20newsgroups.sh
@@ -36,7 +36,11 @@ START_PATH=`pwd`
 # Set commands for dfs
 source ${START_PATH}/set-dfs-commands.sh
 
-WORK_DIR=/tmp/mahout-work-${USER}
+if [[ -z "$MAHOUT_WORK_DIR" ]]; then
+  WORK_DIR=/tmp/mahout-work-${USER}
+else
+  WORK_DIR=$MAHOUT_WORK_DIR
+fi
 algorithm=( cnaivebayes-MapReduce naivebayes-MapReduce cnaivebayes-Spark naivebayes-Spark sgd clean)
 if [ -n "$1" ]; then
   choice=$1

--- a/examples/bin/classify-20newsgroups.sh
+++ b/examples/bin/classify-20newsgroups.sh
@@ -109,7 +109,7 @@ if  ( [ "x$alg" == "xnaivebayes-MapReduce" ] ||  [ "x$alg" == "xcnaivebayes-MapR
     echo "Copying 20newsgroups data to HDFS"
     set +e
     $DFSRM ${WORK_DIR}/20news-all
-    $DFS -mkdir ${WORK_DIR}
+    $DFS -mkdir -p ${WORK_DIR}
     $DFS -mkdir ${WORK_DIR}/20news-all
     set -e
     if [ $HVERSION -eq "1" ] ; then

--- a/examples/bin/classify-wikipedia.sh
+++ b/examples/bin/classify-wikipedia.sh
@@ -114,7 +114,7 @@ if [ "x$alg" == "xCBayes" ] || [ "x$alg" == "xBinaryCBayes" ] ; then
     echo "Copying wikipedia data to HDFS"
     set +e
     $DFSRM ${WORK_DIR}/wikixml
-    $DFS -mkdir ${WORK_DIR}
+    $DFS -mkdir -p ${WORK_DIR}
     set -e
     $DFS -put ${WORK_DIR}/wikixml ${WORK_DIR}/wikixml
   fi

--- a/examples/bin/classify-wikipedia.sh
+++ b/examples/bin/classify-wikipedia.sh
@@ -42,7 +42,11 @@ START_PATH=`pwd`
 # Set commands for dfs
 source ${START_PATH}/set-dfs-commands.sh
 
-WORK_DIR=/tmp/mahout-work-wiki
+if [[ -z "$MAHOUT_WORK_DIR" ]]; then
+  WORK_DIR=/tmp/mahout-work-wiki
+else
+  WORK_DIR=$MAHOUT_WORK_DIR
+fi
 algorithm=( CBayes BinaryCBayes clean)
 if [ -n "$1" ]; then
   choice=$1

--- a/examples/bin/cluster-reuters.sh
+++ b/examples/bin/cluster-reuters.sh
@@ -102,7 +102,7 @@ if [ ! -e ${WORK_DIR}/reuters-out-seqdir ]; then
         set +e
         $DFSRM ${WORK_DIR}/reuters-sgm
         $DFSRM ${WORK_DIR}/reuters-out
-        $DFS -mkdir ${WORK_DIR}/
+        $DFS -mkdir -p ${WORK_DIR}/
         $DFS -mkdir ${WORK_DIR}/reuters-sgm
         $DFS -mkdir ${WORK_DIR}/reuters-out
         $DFS -put ${WORK_DIR}/reuters-sgm ${WORK_DIR}/reuters-sgm

--- a/examples/bin/cluster-reuters.sh
+++ b/examples/bin/cluster-reuters.sh
@@ -43,7 +43,11 @@ if [ ! -e $MAHOUT ]; then
   exit 1
 fi
 
-WORK_DIR=/tmp/mahout-work-${USER}
+if [[ -z "$MAHOUT_WORK_DIR" ]]; then
+  WORK_DIR=/tmp/mahout-work-${USER}
+else
+  WORK_DIR=$MAHOUT_WORK_DIR
+fi
 
 algorithm=( kmeans fuzzykmeans lda streamingkmeans clean)
 if [ -n "$1" ]; then

--- a/examples/bin/cluster-syntheticcontrol.sh
+++ b/examples/bin/cluster-syntheticcontrol.sh
@@ -48,7 +48,11 @@ START_PATH=`pwd`
 # Set commands for dfs
 source ${START_PATH}/set-dfs-commands.sh
 
-WORK_DIR=/tmp/mahout-work-${USER}
+if [[ -z "$MAHOUT_WORK_DIR" ]]; then
+  WORK_DIR=/tmp/mahout-work-${USER}
+else
+  WORK_DIR=$MAHOUT_WORK_DIR
+fi
 
 echo "creating work directory at ${WORK_DIR}"
 mkdir -p ${WORK_DIR}

--- a/examples/bin/factorize-movielens-1M.sh
+++ b/examples/bin/factorize-movielens-1M.sh
@@ -43,7 +43,12 @@ fi
 export MAHOUT_LOCAL=true
 MAHOUT="$MAHOUT_HOME/bin/mahout"
 
-WORK_DIR=/tmp/mahout-work-${USER}
+if [[ -z "$MAHOUT_WORK_DIR" ]]; then
+  WORK_DIR=/tmp/mahout-work-${USER}
+else
+  WORK_DIR=$MAHOUT_WORK_DIR
+fi
+
 echo "creating work directory at ${WORK_DIR}"
 mkdir -p ${WORK_DIR}/movielens
 

--- a/examples/bin/factorize-netflix.sh
+++ b/examples/bin/factorize-netflix.sh
@@ -45,7 +45,11 @@ fi
 
 MAHOUT="../../bin/mahout"
 
-WORK_DIR=/tmp/mahout-work-${USER}
+if [[ -z "$MAHOUT_WORK_DIR" ]]; then
+  WORK_DIR=/tmp/mahout-work-${USER}
+else
+  WORK_DIR=$MAHOUT_WORK_DIR
+fi
 
 START_PATH=`pwd`
 


### PR DESCRIPTION
Support MAHOUT_WORK_DIR environment variable in examples to allow user to specify an alternate scratch/temp space instead of the defined one.  This will allow users in some environments without local drives or with small /tmp mounts to still run the examples.