### PR TITLE
MAHOUT-1795: Build math & spark bindings under scala 2.11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -868,9 +868,6 @@
       <id>hadoop2</id>
       <activation>
         <activeByDefault>true</activeByDefault>
-        <property>
-          <name>env.JENKINS_URL</name>
-        </property>
       </activation>
       <properties>
         <hadoop.classifier>hadoop2</hadoop.classifier>
@@ -914,6 +911,26 @@
       <properties>
         <pmd.skip>true</pmd.skip>
         <checkstyle.skip>true</checkstyle.skip>
+      </properties>
+    </profile>
+    <profile>
+      <id>scala-2.10</id>
+      <activation>
+        <property><name>!scala-2.11</name></property>
+      </activation>
+      <properties>
+        <scala.compat.version>2.10</scala.compat.version>
+        <scala.version>2.10.4</scala.version>
+      </properties>
+    </profile>
+    <profile>
+      <id>scala-2.11</id>
+      <activation>
+        <property><name>scala-2.11</name></property>
+      </activation>
+      <properties>
+        <scala.compat.version>2.11</scala.compat.version>
+        <scala.version>2.11.8</scala.version>
       </properties>
     </profile>
     <profile>
@@ -1031,7 +1048,6 @@
     <profile>
       <id>ci</id>
       <activation>
-        <activeByDefault>false</activeByDefault>
         <property>
           <name>env.JENKINS_URL</name>
         </property>

--- a/spark/src/main/assembly/dependency-reduced.xml
+++ b/spark/src/main/assembly/dependency-reduced.xml
@@ -38,12 +38,12 @@
       <includes>
         <!-- guava only included to get Preconditions in mahout-math and mahout-hdfs -->
         <include>com.google.guava:guava</include>
-        <include>com.github.scopt</include>
+        <include>com.github.scopt_${scala.compat.version}</include>
         <include>com.tdunning:t-digest</include>
         <include>org.apache.commons:commons-math3</include>
         <include>it.unimi.dsi:fastutil</include>
-        <include>org.apache.mahout:mahout-native-viennacl_2.10</include>
-        <include>org.apache.mahout:mahout-native-viennacl-omp_2.10</include>
+        <include>org.apache.mahout:mahout-native-viennacl_${scala.compat.version}</include>
+        <include>org.apache.mahout:mahout-native-viennacl-omp_${scala.compat.version}</include>
         <include>org.bytedeco:javacpp</include>
       </includes>
     </dependencySet>


### PR DESCRIPTION
The shell isn't building, so only enable it for 2.10.

Unfortunately this means that there's a 2x2 build matrix with hadoop/scala versions. The only way to resolve this
was to switch to activating profiles through properties, so if you were previously using -Phadoop1, you'll want
to use -Dhadoop1. The default config without any options is effectively -Phadoop2,scala-2.10.
