### PR TITLE
MAHOUT-1802: Capture attached checkpoints (if cached)

### DIFF
--- a/h2o/src/main/scala/org/apache/mahout/h2obindings/H2OEngine.scala
+++ b/h2o/src/main/scala/org/apache/mahout/h2obindings/H2OEngine.scala
@@ -67,26 +67,27 @@ object H2OEngine extends DistributedEngine {
   def drmDfsRead(path: String, parMin: Int = 0)(implicit dc: DistributedContext): CheckpointedDrm[_] = {
     val drmMetadata = hdfsUtils.readDrmHeader(path)
 
-    new CheckpointedDrmH2O(H2OHdfs.drmFromFile(path, parMin), dc)(drmMetadata.keyClassTag.asInstanceOf[ClassTag[Any]])
+    new CheckpointedDrmH2O(H2OHdfs.drmFromFile(path, parMin), dc, CacheHint.NONE)(drmMetadata.keyClassTag.
+      asInstanceOf[ClassTag[Any]])
   }
 
   /** This creates an empty DRM with specified number of partitions and cardinality. */
   def drmParallelizeEmpty(nrow: Int, ncol: Int, numPartitions: Int)(implicit dc: DistributedContext): CheckpointedDrm[Int] =
-    new CheckpointedDrmH2O[Int](H2OHelper.emptyDrm(nrow, ncol, numPartitions, -1), dc)
+    new CheckpointedDrmH2O[Int](H2OHelper.emptyDrm(nrow, ncol, numPartitions, -1), dc, CacheHint.NONE)
 
   def drmParallelizeEmptyLong(nrow: Long, ncol: Int, numPartitions: Int)(implicit dc: DistributedContext): CheckpointedDrm[Long] =
-    new CheckpointedDrmH2O[Long](H2OHelper.emptyDrm(nrow, ncol, numPartitions, -1), dc)
+    new CheckpointedDrmH2O[Long](H2OHelper.emptyDrm(nrow, ncol, numPartitions, -1), dc, CacheHint.NONE)
 
   /** Parallelize in-core matrix as H2O distributed matrix, using row ordinal indices as data set keys. */
   def drmParallelizeWithRowIndices(m: Matrix, numPartitions: Int)(implicit dc: DistributedContext): CheckpointedDrm[Int] =
-    new CheckpointedDrmH2O[Int](H2OHelper.drmFromMatrix(m, numPartitions, -1), dc)
+    new CheckpointedDrmH2O[Int](H2OHelper.drmFromMatrix(m, numPartitions, -1), dc, CacheHint.NONE)
 
   /** Parallelize in-core matrix as H2O distributed matrix, using row labels as a data set keys. */
   def drmParallelizeWithRowLabels(m: Matrix, numPartitions: Int)(implicit dc: DistributedContext): CheckpointedDrm[String] =
-    new CheckpointedDrmH2O[String](H2OHelper.drmFromMatrix(m, numPartitions, -1), dc)
+    new CheckpointedDrmH2O[String](H2OHelper.drmFromMatrix(m, numPartitions, -1), dc, CacheHint.NONE)
 
   def toPhysical[K:ClassTag](plan: DrmLike[K], ch: CacheHint.CacheHint): CheckpointedDrm[K] =
-    new CheckpointedDrmH2O[K](tr2phys(plan), plan.context)
+    new CheckpointedDrmH2O[K](tr2phys(plan), plan.context, ch)
 
   /** Eagerly evaluate operator graph into an H2O DRM */
   private def tr2phys[K: ClassTag](oper: DrmLike[K]): H2ODrm = {

--- a/h2o/src/main/scala/org/apache/mahout/h2obindings/drm/CheckpointedDrmH2O.scala
+++ b/h2o/src/main/scala/org/apache/mahout/h2obindings/drm/CheckpointedDrmH2O.scala
@@ -2,6 +2,7 @@ package org.apache.mahout.h2obindings.drm
 
 import org.apache.mahout.h2obindings._
 import org.apache.mahout.math.Matrix
+import org.apache.mahout.math.drm.CacheHint.CacheHint
 import org.apache.mahout.math.drm._
 
 import scala.reflect._
@@ -15,7 +16,8 @@ import scala.reflect._
   */
 class CheckpointedDrmH2O[K: ClassTag](
   val h2odrm: H2ODrm,
-  val context: DistributedContext
+  val context: DistributedContext,
+  override val cacheHint: CacheHint
 ) extends CheckpointedDrm[K] {
 
   /**

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/CheckpointedDrm.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/CheckpointedDrm.scala
@@ -18,11 +18,13 @@
 package org.apache.mahout.math.drm
 
 import org.apache.mahout.math.Matrix
+import org.apache.mahout.math.drm.CacheHint.CacheHint
 import scala.reflect.ClassTag
 
 /**
  * Checkpointed DRM API. This is a matrix that has optimized RDD lineage behind it and can be
  * therefore collected or saved.
+ *
  * @tparam K matrix key type (e.g. the keys of sequence files once persisted)
  */
 trait CheckpointedDrm[K] extends DrmLike[K] {
@@ -30,6 +32,8 @@ trait CheckpointedDrm[K] extends DrmLike[K] {
   def collect: Matrix
 
   def dfsWrite(path: String)
+
+  val cacheHint: CacheHint
 
   /** If this checkpoint is already declared cached, uncache. */
   def uncache(): this.type

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/DistributedEngine.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/DistributedEngine.scala
@@ -141,6 +141,9 @@ object DistributedEngine {
 
     action match {
 
+      // Logical but previously had checkpoint attached to it already that has some caching policy to it
+      case cpa: CheckpointAction[K] if cpa.cp.exists(_.cacheHint != CacheHint.NONE) ⇒ cpa.cp.get
+
       // self element-wise rewrite
       case OpAewB(a, b, op) if a == b => {
         op match {

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/SparkEngine.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/SparkEngine.scala
@@ -126,7 +126,7 @@ object SparkEngine extends DistributedEngine {
       rddInput = rddInput,
       _nrow = plan.nrow,
       _ncol = plan.ncol,
-      _cacheStorageLevel = cacheHint2Spark(ch),
+      cacheHint = ch,
       partitioningTag = plan.partitioningTag
     )
     newcp.cache()
@@ -172,7 +172,8 @@ object SparkEngine extends DistributedEngine {
   def drmParallelizeWithRowIndices(m: Matrix, numPartitions: Int = 1)
                                   (implicit sc: DistributedContext)
   : CheckpointedDrm[Int] = {
-    new CheckpointedDrmSpark(rddInput = parallelizeInCore(m, numPartitions), _nrow = m.nrow, _ncol = m.ncol)
+    new CheckpointedDrmSpark(rddInput = parallelizeInCore(m, numPartitions), _nrow = m.nrow, _ncol = m.ncol,
+      cacheHint = CacheHint.NONE)
   }
 
   private[sparkbindings] def parallelizeInCore(m: Matrix, numPartitions: Int = 1)
@@ -191,7 +192,8 @@ object SparkEngine extends DistributedEngine {
     val rb = m.getRowLabelBindings
     val p = for (i: String ← rb.keySet().toIndexedSeq) yield i → m(rb(i), ::)
 
-    new CheckpointedDrmSpark(rddInput = sc.parallelize(p, numPartitions), _nrow = m.nrow, _ncol = m.ncol)
+    new CheckpointedDrmSpark(rddInput = sc.parallelize(p, numPartitions), _nrow = m.nrow, _ncol = m.ncol,
+      cacheHint = CacheHint.NONE)
   }
 
   /** This creates an empty DRM with specified number of partitions and cardinality. */
@@ -204,7 +206,7 @@ object SparkEngine extends DistributedEngine {
 
       for (i ← partStart until partEnd) yield (i, new RandomAccessSparseVector(ncol): Vector)
     })
-    new CheckpointedDrmSpark[Int](rdd, nrow, ncol)
+    new CheckpointedDrmSpark[Int](rdd, nrow, ncol, cacheHint = CacheHint.NONE)
   }
 
   def drmParallelizeEmptyLong(nrow: Long, ncol: Int, numPartitions: Int = 10)
@@ -216,7 +218,7 @@ object SparkEngine extends DistributedEngine {
 
       for (i ← partStart until partEnd) yield (i, new RandomAccessSparseVector(ncol): Vector)
     })
-    new CheckpointedDrmSpark[Long](rdd, nrow, ncol)
+    new CheckpointedDrmSpark[Long](rdd, nrow, ncol, cacheHint = CacheHint.NONE)
   }
 
   /**

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/package.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/package.scala
@@ -140,8 +140,8 @@ package object sparkbindings {
   def drmWrap[K: ClassTag](rdd: DrmRdd[K], nrow: Long = -1, ncol: Int = -1, cacheHint: CacheHint.CacheHint =
   CacheHint.NONE, canHaveMissingRows: Boolean = false): CheckpointedDrm[K] =
 
-    new CheckpointedDrmSpark[K](rddInput = rdd, _nrow = nrow, _ncol = ncol, _cacheStorageLevel = SparkEngine
-      .cacheHint2Spark(cacheHint), _canHaveMissingRows = canHaveMissingRows)
+    new CheckpointedDrmSpark[K](rddInput = rdd, _nrow = nrow, _ncol = ncol, cacheHint = cacheHint,
+      _canHaveMissingRows = canHaveMissingRows)
 
 
   /** Another drmWrap version that takes in vertical block-partitioned input to form the matrix. */


### PR DESCRIPTION
Currently, the optimizer generates checkpoints and attaches them to actual logical elements of the DAG via CheckpointAction$cp. 

ie:


```
drmC = drmA+ drmB

val cp1 = drmC.checkpoint() // checkpoint
val cp2 = drmC.checkpoint() // cp2 == cp1

drmD = cp1 + drmE // cp1 + drmE
```

but, in:
`
drmD = drmC + drmE // computes drmA + drmB + drmC all over`

`drmC` already has` cp1` attached to it so we should assume the common computational path is the intent here regardless and should be used, instead of building plans that recompute it. That is,

`drmD = drmC + drmE` should imply `cp1 + drmE `as well even if checkpoint is not used explicitly.


This PR allows us to avoid excessive declarations like 

```
drmAcp = drmA.checkpoint

drmB = drmAcp %*%... 
```

and instead just use 

```
drmA.checkpoint()

drmB = drmA %*% ....
```