### PR TITLE
MAHOUT-1806: Do not request caching upon implicit checkpointing

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/CheckpointedOps.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/CheckpointedOps.scala
@@ -43,7 +43,7 @@ class CheckpointedOps[K](val drm: CheckpointedDrm[K]) {
 
     drm.context.allreduceBlock(drm, bmf, rf)
 
-
+  /** Second norm */
   def norm():Double = drm.context.norm(drm)
 }
 

--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/RLikeDrmOps.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/RLikeDrmOps.scala
@@ -168,13 +168,5 @@ object RLikeDrmOps {
 
   implicit def ops2Drm[K](ops: DrmLikeOps[K]): DrmLike[K] = ops.drm
 
-  // Removed in move to 1.2.1 PR #74 https://github.com/apache/mahout/pull/74/files
-  // Not sure why.
-  // implicit def cp2cpops[K: ClassTag](cp: CheckpointedDrm[K]): CheckpointedOps[K] = new CheckpointedOps(cp)
-
-  /**
-   * This is probably dangerous since it triggers implicit checkpointing with default storage level
-   * setting.
-   */
-  implicit def drm2cpops[K](drm: DrmLike[K]): CheckpointedOps[K] = new CheckpointedOps(drm.checkpoint())
+  implicit def drm2cpops[K](drm: DrmLike[K]): CheckpointedOps[K] = new CheckpointedOps(drm)
 }


### PR DESCRIPTION
When a DRM is checkpointed implicitly, it should not request any caching. E.g.: `drmA.norm`.