### PR TITLE
MAHOUT-1808: remove unused operations from sparkbindings

### DIFF
--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/DrmRddInput.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/DrmRddInput.scala
@@ -38,7 +38,4 @@ class DrmRddInput[K: ClassTag](private val input: Either[DrmRdd[K], BlockifiedDr
 
   def sparkContext: SparkContext = backingRdd.sparkContext
 
-  def persist(sl: StorageLevel) = backingRdd.persist(newLevel = sl)
-
-  def unpersist(blocking: Boolean = true) = backingRdd.unpersist(blocking)
 }


### PR DESCRIPTION
clean up sparkbindings of a few unused operations in DrmRddInput. 