### PR TITLE
MAHOUT-1813: Functional "apply" DSL for distributed and in-memory matrices

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/math/drm/DrmLikeOps.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/drm/DrmLikeOps.scala
@@ -19,7 +19,7 @@ package org.apache.mahout.math.drm
 
 import scala.reflect.ClassTag
 import org.apache.mahout.math.scalabindings._
-import org.apache.mahout.math.drm.logical.{OpPar, OpMapBlock, OpRowRange}
+import org.apache.mahout.math.drm.logical.{OpAewUnaryFunc, OpPar, OpMapBlock, OpRowRange}
 
 /** Common Drm ops */
 class DrmLikeOps[K](protected[drm] val drm: DrmLike[K]) {
@@ -115,5 +115,26 @@ class DrmLikeOps[K](protected[drm] val drm: DrmLike[K]) {
       })
 
     } else rowSrc
+  }
+
+  /**
+    * Apply a function element-wise.
+    *
+    * @param f         element-wise function
+    * @param evalZeros Do we have to process zero elements? true, false, auto: if auto, we will test
+    *                  the supplied function for `f(0) != 0`, and depending on the result, will
+    *                  decide if we want evaluation for zero elements. WARNING: the AUTO setting
+    *                  may not always work correctly for functions that are meant to run in a specific
+    *                  backend context, or non-deterministic functions, such as {-1,0,1} random
+    *                  generators.
+    * @return new DRM with the element-wise function applied.
+    */
+  def apply(f: Double ⇒ Double, evalZeros: AutoBooleanEnum.T = AutoBooleanEnum.AUTO) = {
+    val ezeros = evalZeros match {
+      case AutoBooleanEnum.TRUE ⇒ true
+      case AutoBooleanEnum.FALSE ⇒ false
+      case AutoBooleanEnum.AUTO ⇒ f(0) != 0
+    }
+    new OpAewUnaryFunc[K](drm, f, ezeros)
   }
 }

--- a/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
@@ -29,6 +29,12 @@ package object scalabindings {
   // Reserved "ALL" range
   final val `::`: Range = null
 
+  // Some enums
+  object AutoBooleanEnum extends Enumeration {
+    type T = Value
+    val TRUE, FALSE, AUTO = Value
+  }
+
   implicit def seq2Vector(s: TraversableOnce[AnyVal]) =
     new DenseVector(s.map(_.asInstanceOf[Number].doubleValue()).toArray)
 

--- a/math-scala/src/test/scala/org/apache/mahout/math/drm/RLikeDrmOpsSuiteBase.scala
+++ b/math-scala/src/test/scala/org/apache/mahout/math/drm/RLikeDrmOpsSuiteBase.scala
@@ -644,7 +644,7 @@ trait RLikeDrmOpsSuiteBase extends DistributedMahoutSuite with Matchers {
     val drmA = drmParallelize(mxA)
 
     (drmA(x => x + 1).collect - (mxAControl + 1)).norm should be < 1e-7
-    (drmA(x => x * 2).collect - (2 * mxAControl )).norm should be < 1e-7
+    (drmA(x => x * 2).collect - (2 * mxAControl)).norm should be < 1e-7
 
   }
 

--- a/math-scala/src/test/scala/org/apache/mahout/math/drm/RLikeDrmOpsSuiteBase.scala
+++ b/math-scala/src/test/scala/org/apache/mahout/math/drm/RLikeDrmOpsSuiteBase.scala
@@ -634,5 +634,19 @@ trait RLikeDrmOpsSuiteBase extends DistributedMahoutSuite with Matchers {
 
   }
 
+  test("functional apply()") {
+    val mxA = sparse (
+      (1 -> 3) :: (7 -> 7) :: Nil,
+      (4 -> 5) :: (5 -> 8) :: Nil
+    )
+
+    val mxAControl = mxA cloned
+    val drmA = drmParallelize(mxA)
+
+    (drmA(x => x + 1).collect - (mxAControl + 1)).norm should be < 1e-7
+    (drmA(x => x * 2).collect - (2 * mxAControl )).norm should be < 1e-7
+
+  }
+
 
 }

--- a/math-scala/src/test/scala/org/apache/mahout/math/scalabindings/MatrixOpsSuite.scala
+++ b/math-scala/src/test/scala/org/apache/mahout/math/scalabindings/MatrixOpsSuite.scala
@@ -139,7 +139,7 @@ class MatrixOpsSuite extends FunSuite with MahoutSuite {
     val mxAControl = mxA cloned
 
     (mxA(x ⇒ x + 1) - (mxAControl + 1)).norm should be < 1e-7
-    (mxA(x ⇒ x * 2) - (2 * mxAControl )).norm should be < 1e-7
+    (mxA(x ⇒ x * 2) - (2 * mxAControl)).norm should be < 1e-7
 
   }
 

--- a/math-scala/src/test/scala/org/apache/mahout/math/scalabindings/MatrixOpsSuite.scala
+++ b/math-scala/src/test/scala/org/apache/mahout/math/scalabindings/MatrixOpsSuite.scala
@@ -131,6 +131,18 @@ class MatrixOpsSuite extends FunSuite with MahoutSuite {
     g.sum shouldBe 3
   }
 
+  test("functional apply()") {
+    val mxA = sparse (
+      (1 -> 3) :: (7 -> 7) :: Nil,
+      (4 -> 5) :: (5 -> 8) :: Nil
+    )
+    val mxAControl = mxA cloned
+
+    (mxA(x ⇒ x + 1) - (mxAControl + 1)).norm should be < 1e-7
+    (mxA(x ⇒ x * 2) - (2 * mxAControl )).norm should be < 1e-7
+
+  }
+
   test("sparse") {
 
     val a = sparse((1, 3) :: Nil,


### PR DESCRIPTION
We have functional "Assign" for in-memory matrices, e.g.:

```
    mxA := { x => x + 1 }
    mxA ::= { x=> x * 2 }
```

However, we lack similar unary elementwise function capability with distributed matrices, because distributed matrices are logically immutable.
The suggestion here is to use apply(func) to augment that capability for DRMs:

```
    drmA(x => x + 1)
    drmA(x => 2 * x)
```

Handling sparse/dense functional assignments: Second optional parameter, evalZeros, can be one of TRUE, FALSE, or AUTO (default AUTO).
It regulates treatement of 0 elements in matrices: whether we can skip assignments to 0 elements. AUTO (which is default) tests the
supplied function whether it changes 0 elements:

    evalZeroTest = f(0) != 0

Obviously, this will not work in all situations (e.g. non-deterministic functions), so we want to retain ability to explicitly override this
with `true` or `false`.

For completeness mostly, similar functional no-side-effect applies are implemented for in-memory types, e.g.:

```
    mxA(x => x + 1)
    mxA(x => 2 * x)
    mxA( (row, col, x) => x + 1)
```
etc.