### PR TITLE
MAHOUT-1815: dsqDist(X,Y) and dsqDist(X) failing in flink tests.

### DIFF
--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
@@ -152,10 +152,10 @@ object FlinkEngine extends DistributedEngine {
         // express ABt via AtB: let C=At and D=Bt, and calculate CtD
         // TODO: create specific implementation of ABt, see MAHOUT-1750
         val opAt = OpAt(a.asInstanceOf[DrmLike[Int]]) // TODO: casts!
-      val at = FlinkOpAt.sparseTrick(opAt, flinkTranslate(a.asInstanceOf[DrmLike[Int]]))
+        val at = FlinkOpAt.sparseTrick(opAt, flinkTranslate(a.asInstanceOf[DrmLike[Int]]))
         val c = new CheckpointedFlinkDrm(at.asRowWise.ds, _nrow = opAt.nrow, _ncol = opAt.ncol)
         val opBt = OpAt(b.asInstanceOf[DrmLike[Int]]) // TODO: casts!
-      val bt = FlinkOpAt.sparseTrick(opBt, flinkTranslate(b.asInstanceOf[DrmLike[Int]]))
+        val bt = FlinkOpAt.sparseTrick(opBt, flinkTranslate(b.asInstanceOf[DrmLike[Int]]))
         val d = new CheckpointedFlinkDrm(bt.asRowWise.ds, _nrow = opBt.nrow, _ncol = opBt.ncol)
         FlinkOpAtB.notZippable(OpAtB(c, d), flinkTranslate(c), flinkTranslate(d)).asInstanceOf[FlinkDrm[K]]
       case op@OpAtA(a) if op.keyClassTag == ClassTag.Int ⇒ FlinkOpAtA.at_a(op, flinkTranslate(a)).asInstanceOf[FlinkDrm[K]]

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/blas/FlinkOpAtB.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/blas/FlinkOpAtB.scala
@@ -81,9 +81,7 @@ object FlinkOpAtB {
         val (idx, _) = it.head
 
         val block = it.map { t => t._2 }.reduce { (m1, m2) => m1 + m2 }
-
-//        val keys = idx.until(block.nrow).toArray[Int]
-
+        
         val blockStart = idx * blockHeight
         val keys = Array.tabulate(block.nrow)(blockStart + _)
 

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/blas/FlinkOpAtB.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/blas/FlinkOpAtB.scala
@@ -82,10 +82,15 @@ object FlinkOpAtB {
 
         val block = it.map { t => t._2 }.reduce { (m1, m2) => m1 + m2 }
 
-        val keys = idx.until(block.nrow).toArray[Int]
+//        val keys = idx.until(block.nrow).toArray[Int]
+
+        val blockStart = idx * blockHeight
+        val keys = Array.tabulate(block.nrow)(blockStart + _)
+
         out.collect(keys -> block)
       }
     })
+
 
     new BlockifiedFlinkDrm[Int](res, ncol)
   }


### PR DESCRIPTION
After taking the Very long way around trying to repartition, etc., it turns out that the row just needed to be properly re-keyed.

Tests pass now.

Though we may want to re-examine the implementation of FlinkOpAtB, as it seems pretty inefficient.