### PR TITLE
MAHOUT:1810 Use a method taken from FlinkMLTools for cache persistance

### DIFF
--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
@@ -357,12 +357,12 @@ object FlinkEngine extends DistributedEngine {
     res.collect().head
   }
 
-  private def generateTypeInformation[K: ClassTag]: TypeInformation[K] = {
+  def generateTypeInformation[K: ClassTag]: TypeInformation[K] = {
     val tag = implicitly[ClassTag[K]]
 
     generateTypeInformationFromTag(tag)
   }
-  
+
   private def generateTypeInformationFromTag[K](tag: ClassTag[K]): TypeInformation[K] = {
     if (tag.runtimeClass.equals(classOf[Int])) {
       createTypeInformation[Int].asInstanceOf[TypeInformation[K]]
@@ -375,5 +375,8 @@ object FlinkEngine extends DistributedEngine {
     } else {
       throw new IllegalArgumentException(s"index type $tag is not supported")
     }
+  }
+  object FlinkEngine {
+
   }
 }

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/package.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/package.scala
@@ -99,6 +99,7 @@ package object flinkbindings {
   }
 
   def datasetWrap[K: ClassTag](dataset: DataSet[(K, Vector)]): CheckpointedDrm[K] = {
+    implicit val typeInformation = FlinkEngine.generateTypeInformation[K]
     new CheckpointedFlinkDrm[K](dataset)
   }
 


### PR DESCRIPTION
As a temporary measure, use this method to persist the dataset to the filesystem when caching rather that drmDfsRead()/Write.

Todo: 

1. Break up into  `persist` and  `readPersistedDataset` methods and only read a persisted dataset if it is already cached.
2. Use a property setting for the base dir.
3. Check to make sure that this method maintains parallelism deg for the dataset, if not set the new parallelism degree to the original