### PR TITLE
MAHOUT-1817  Implement caching in Flink Bindings

### DIFF
--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
@@ -267,7 +267,7 @@ object FlinkEngine extends DistributedEngine {
 
   private[flinkbindings] def parallelize(m: Matrix, parallelismDegree: Int)
                                         (implicit dc: DistributedContext): DrmDataSet[Int] = {
-    val rows = (0 until m.nrow).map(i => (i, m(i, ::))) //.toSeq.sortWith((ii, jj) => ii._1 < jj._1)
+    val rows = (0 until m.nrow).map(i => (i, m(i, ::)))
     val dataSetType = TypeExtractor.getForObject(rows.head)
     //TODO: Make Sure that this is the correct partitioning scheme
     dc.env.fromCollection(rows)

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
@@ -359,9 +359,9 @@ object FlinkEngine extends DistributedEngine {
   }
 
   def generateTypeInformation[K: ClassTag]: TypeInformation[K] = {
-    implicit val tag = ClassTag[K]
+    implicit val ktag = classTag[K]
 
-    generateTypeInformationFromTag(tag)
+    generateTypeInformationFromTag(ktag)
   }
 
   private def generateTypeInformationFromTag[K](tag: ClassTag[K]): TypeInformation[K] = {

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/FlinkEngine.scala
@@ -127,6 +127,7 @@ object FlinkEngine extends DistributedEngine {
     newcp.cache()
   }
 
+
   private def flinkTranslate[K](oper: DrmLike[K]): FlinkDrm[K] = {
     implicit val kTag = oper.keyClassTag
     implicit val typeInformation = generateTypeInformation[K]
@@ -358,7 +359,7 @@ object FlinkEngine extends DistributedEngine {
   }
 
   def generateTypeInformation[K: ClassTag]: TypeInformation[K] = {
-    val tag = implicitly[ClassTag[K]]
+    implicit val tag = ClassTag[K]
 
     generateTypeInformationFromTag(tag)
   }
@@ -373,8 +374,5 @@ object FlinkEngine extends DistributedEngine {
     } else {
       throw new IllegalArgumentException(s"index type $tag is not supported")
     }
-  }
-  object FlinkEngine {
-
   }
 }

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
@@ -18,7 +18,7 @@
  */
 package org.apache.mahout.flinkbindings.drm
 
-import org.apache.flink.api.common.functions.{MapFunction, ReduceFunction}
+import org.apache.flink.api.common.functions.{MapFunction, ReduceFunction, RichFunction, RichMapFunction}
 import org.apache.flink.api.common.typeinfo.TypeInformation
 import org.apache.flink.api.java.io.{TypeSerializerInputFormat, TypeSerializerOutputFormat}
 import org.apache.flink.api.scala._
@@ -58,7 +58,7 @@ class CheckpointedFlinkDrm[K: ClassTag:TypeInformation](val ds: DrmDataSet[K],
   var persistanceRootDir: String = _
 
   // need to make sure that this is actually getting the correct propertirs for {{taskmanager.tmp.dirs}}
-  val mahoutHome = System.getProperty("MAHOUT_HOME")
+  val mahoutHome = getMahoutHome()
 
   GlobalConfiguration.loadConfiguration(mahoutHome + "/conf/flink-config.yaml")
 

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
@@ -27,6 +27,7 @@ import org.apache.flink.core.fs.Path
 import org.apache.flink.api.scala.hadoop.mapred.HadoopOutputFormat
 import org.apache.hadoop.io.{IntWritable, LongWritable, Text, Writable}
 import org.apache.hadoop.mapred.{FileOutputFormat, JobConf, SequenceFileOutputFormat}
+import org.apache.mahout.flinkbindings.io.Hadoop2HDFSUtil
 import org.apache.mahout.flinkbindings.{DrmDataSet, _}
 import org.apache.mahout.math._
 import org.apache.mahout.math.drm.CacheHint._
@@ -92,7 +93,10 @@ class CheckpointedFlinkDrm[K: ClassTag:TypeInformation](val ds: DrmDataSet[K],
   }
 
   def uncache() = {
-    // TODO
+    if (isCached) {
+      Hadoop2HDFSUtil.delete(cacheFileName)
+      isCached = false
+    }
     this
   }
 

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
@@ -105,16 +105,23 @@ class CheckpointedFlinkDrm[K: ClassTag:TypeInformation](val ds: DrmDataSet[K],
     }
     val _ds = readPersistedDataSet(cacheFileName, ds)
 
-    // We may want to look more closely at this:
-    // since we've cached a drm, triggering a computation
-    // it may not make sense to keep the same parallelism degree
-    if (!(parallelismDeg == _ds.getParallelism)) {
-      _ds.setParallelism(parallelismDeg).rebalance()
-    }
+    /** Leave the parallelism degree to be set the operators
+      * TODO: find out a way to set the parallelism degree based on the
+      * final drm after computation is actually triggered
+      *
+      *  // We may want to look more closely at this:
+      *  // since we've cached a drm, triggering a computation
+      *  // it may not make sense to keep the same parallelism degree
+      *  if (!(parallelismDeg == _ds.getParallelism)) {
+      *    _ds.setParallelism(parallelismDeg).rebalance()
+      *  }
+      *
+      */
+
     datasetWrap(_ds)
   }
 
-  def uncache():this.type = {
+  def uncache(): this.type = {
     if (isCached) {
       Hadoop2HDFSUtil.delete(cacheFileName)
       isCached = false

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/drm/CheckpointedFlinkDrm.scala
@@ -55,6 +55,7 @@ class CheckpointedFlinkDrm[K: ClassTag:TypeInformation](val ds: DrmDataSet[K],
   var cacheFileName: String = "undefinedCacheName"
   var isCached: Boolean = false
   var parallelismDeg: Int = -1
+  var persistanceRootDir: String = _
 
   // need to make sure that this is actually getting the correct propertirs for {{taskmanager.tmp.dirs}}
   val mahoutHome = System.getProperty("MAHOUT_HOME")
@@ -64,9 +65,9 @@ class CheckpointedFlinkDrm[K: ClassTag:TypeInformation](val ds: DrmDataSet[K],
   val conf = GlobalConfiguration.getConfiguration()
 
   if (!(conf == null )) {
-    val persistanceRootDir = conf.getString("taskmanager.tmp.dirs", "/tmp/")
+     persistanceRootDir = conf.getString("taskmanager.tmp.dirs", "/tmp/")
   } else {
-    val persistanceRootDir = "/tmp/"
+     persistanceRootDir = "/tmp/"
   }
 
 

--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/package.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/package.scala
@@ -105,4 +105,10 @@ package object flinkbindings {
 
   private[flinkbindings] def extractRealClassTag[K: ClassTag](drm: DrmLike[K]): ClassTag[_] = drm.keyClassTag
 
+  private[flinkbindings] def getMahoutHome() = {
+    var mhome = System.getenv("MAHOUT_HOME")
+    if (mhome == null) mhome = System.getProperty("mahout.home")
+    require(mhome != null, "MAHOUT_HOME is required to spawn mahout-based flink jobs")
+    mhome
+  }
 }


### PR DESCRIPTION
As a temporary measure, use this method to persist the `DataSet` to the filesystem when caching rather that drmDfsRead()/Write.

Todo:
 
1.  ~~Break up into `persist` and `readPersistedDataset` methods and only read a persisted dataset if it is already cached.~~
2.     ~~Use a property setting for the base dir~~.
3.     ~~Check to make sure that this method maintains parallelism deg for the dataset, if not set the new parallelism degree to the original~~


