### PR TITLE
MAHOUT-1833 - Enhance svec function to accept cardinality as parameter

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
@@ -211,7 +211,6 @@ package object scalabindings {
     } else {
       tmp = cardinality
     }
-    println(tmp)
     val initialCapacity = sdata.size
     val sv = new RandomAccessSparseVector(tmp, initialCapacity)
     sdata.foreach(t ⇒ sv.setQuick(t._1, t._2.asInstanceOf[Number].doubleValue()))

--- a/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
@@ -198,13 +198,22 @@ package object scalabindings {
 
   /**
    * create a sparse vector out of list of tuple2's
-   * @param sdata
+   * @param sdata cardinality
    * @return
    */
-  def svec(sdata: TraversableOnce[(Int, AnyVal)]) = {
-    val cardinality = if (sdata.nonEmpty) sdata.map(_._1).max + 1 else 0
+  def svec(sdata: TraversableOnce[(Int, AnyVal)], cardinality: Int = -1) = {
+    val required = if (sdata.nonEmpty) sdata.map(_._1).max + 1 else 0
+    var tmp = -1
+    if (cardinality < 0) {
+      tmp = required
+    } else if (cardinality < required) {
+      throw new IllegalArgumentException(s"Required cardinality %required but got %cardinality")
+    } else {
+      tmp = cardinality
+    }
+    println(tmp)
     val initialCapacity = sdata.size
-    val sv = new RandomAccessSparseVector(cardinality, initialCapacity)
+    val sv = new RandomAccessSparseVector(tmp, initialCapacity)
     sdata.foreach(t ⇒ sv.setQuick(t._1, t._2.asInstanceOf[Number].doubleValue()))
     sv
   }

--- a/math-scala/src/test/scala/org/apache/mahout/math/scalabindings/VectorOpsSuite.scala
+++ b/math-scala/src/test/scala/org/apache/mahout/math/scalabindings/VectorOpsSuite.scala
@@ -32,11 +32,22 @@ class VectorOpsSuite extends FunSuite with MahoutSuite {
     val sparseVec = svec((5 -> 1) :: (10 -> 2.0) :: Nil)
     println(sparseVec)
 
+    assert(sparseVec.size() == 11)
+
     val sparseVec2: Vector = (5 -> 1.0) :: (10 -> 2.0) :: Nil
     println(sparseVec2)
 
     val sparseVec3: Vector = new RandomAccessSparseVector(100) := (5 -> 1.0) :: Nil
     println(sparseVec3)
+
+    val sparseVec4 = svec((5 -> 1) :: (10 -> 2.0) :: Nil, 100)
+    println(sparseVec4)
+
+    assert(sparseVec4.size() == 100)
+
+    intercept[IllegalArgumentException] {
+      val sparseVec5 = svec((5 -> 1) :: (10 -> 2.0) :: Nil, 10)  
+    }
 
     val denseVec1: Vector = (1.0, 1.1, 1.2)
     println(denseVec1)


### PR DESCRIPTION
### What is this PR for?
Enhance the existing svec function to accept cardinality as parameter(with default value defined), so user can specify the created vector size they want.

### What type of PR is it?
[Improvement]

### Todos
* [x] - Add the cardinality parameter to svec with default value defined
* [x] - Add test case to MathSuite
* [ ] - Update any doc if needed(pending to check)

### What is the Jira issue?
* [MAHOUT-1833](https://issues.apache.org/jira/browse/MAHOUT-1833)

### How should this be tested?
1. Clone the code into local
2. Maven build and test, all tests should be green

### Questions:
* Does the licenses files need update? No
* Is there breaking changes for older versions? No
* Does this needs documentation? Pending to check