### PR TITLE
Disable msurf and mGrid for Mahout 0.12.1

### DIFF
--- a/examples/bin/spark-shell-plot.mscala
+++ b/examples/bin/spark-shell-plot.mscala
@@ -55,8 +55,8 @@ val drmGauss = drmRand3d.mapBlock() {case (keys, block) =>
 mplot3d(drmGauss, samplePercent = 50)
 
 // 3d Surface needs to be ordered. --not working correctly as is
-//import org.apache.mahout.visualization.MSurf
-msurf(drmGauss, samplePercent = 10)
+//import org.apache.mahout.visualization.MSurf`
+// msurf(drmGauss, samplePercent = 10)
 
 // 3d "Matlab peaks"
 import org.apache.mahout.visualization._
@@ -81,7 +81,7 @@ mplot3d(drmPeaks, samplePercent = 10)
 
 // 3d Surface needs to be ordered. --not working correctly as is
 import org.apache.mahout.visualization._
-msurf(drmPeaks, samplePercent = 10)
+// msurf(drmPeaks, samplePercent = 10)
 
 
 
@@ -104,7 +104,7 @@ val drmGauss = drmRand3d.mapBlock() {case (keys, block) =>
   keys -> blockB
 }
 
-mgrid(drmGauss, samplePercent = 10)
+// mgrid(drmGauss, samplePercent = 10)
 
 
 // 2 and 3d histograms of gaussian data

--- a/math-scala/src/main/scala/org/apache/mahout/visualization/MGrid.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/visualization/MGrid.scala
@@ -33,6 +33,7 @@ import smile.plot._
   * @tparam K
   */
 class MGrid[K](drmXYZ: DrmLike[K], samplePercent: Double = 1, setVisible: Boolean = true) extends MahoutPlot{
+  throw new NotImplementedError("This Class is not yet fully implemented.")
 
   val drmSize = drmXYZ.checkpoint().numRows()
   val sampleDec: Double = samplePercent / 100.toDouble

--- a/math-scala/src/main/scala/org/apache/mahout/visualization/MSurf.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/visualization/MSurf.scala
@@ -35,6 +35,9 @@ import smile.plot._
   * @tparam K
   */
 class MSurf[K](drmXYZ: DrmLike[K], samplePercent: Double = 1, setVisible: Boolean = true) extends MahoutPlot {
+  throw new NotImplementedError("This Class is not yet fully implemented.")
+
+
   val drmSize = drmXYZ.checkpoint().numRows()
   val sampleDec: Double = samplePercent / 100.toDouble
 

--- a/math-scala/src/main/scala/org/apache/mahout/visualization/package.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/visualization/package.scala
@@ -51,6 +51,7 @@ package object visualization {
   }
 
   /**
+    * Not enabled in Mahout 0.12.1 Will be finished in Mahout 0.13.0
     * Syntatic sugar for MSurf class
     * @param drmXYZ
     * @param samplePercent
@@ -58,8 +59,9 @@ package object visualization {
     * @tparam K
     * @return
     */
-  def msurf[K](drmXYZ: DrmLike[K], samplePercent: Double = 1, setVisible: Boolean = true): MahoutPlot =
-    new MSurf[K](drmXYZ: DrmLike[K], samplePercent, setVisible)
+  // Disable for Mahout 0.12.1 finish in Mahout 0.13.0
+  //  def msurf[K](drmXYZ: DrmLike[K], samplePercent: Double = 1, setVisible: Boolean = true): MahoutPlot =
+  //    new MSurf[K](drmXYZ: DrmLike[K], samplePercent, setVisible)
 
   /**
     * Syntatic sugar for MPlot2d class
@@ -84,6 +86,7 @@ package object visualization {
     new MPlot3d[K](drmXYZ: DrmLike[K], samplePercent, setVisible)
 
   /**
+    * Not enabled in Mahout 0.12.1 Will be finished in Mahout 0.13.0
     * Syntatic sugar for MGrid class
     * @param drmXYZ
     * @param samplePercent
@@ -91,8 +94,9 @@ package object visualization {
     * @tparam K
     * @return
     */
-  def mgrid[K](drmXYZ: DrmLike[K], samplePercent: Double = 1, setVisible: Boolean = true): MahoutPlot =
-    new MGrid[K](drmXYZ: DrmLike[K], samplePercent, setVisible)
+  // Disable for Mahout 0.12.1 finish in Mahout 0.13.0
+  //  def mgrid[K](drmXYZ: DrmLike[K], samplePercent: Double = 1, setVisible: Boolean = true): MahoutPlot =
+  //    new MGrid[K](drmXYZ: DrmLike[K], samplePercent, setVisible)
 
   /**
     *


### PR DESCRIPTION
Temporarily disable Surface plotting and Grid plotting until Mahout 0.13.0.