### PR TITLE
MAHOUT-1864: Twenty Newsgroups Classification Example fails in case running with MAHOUT_LOCAL=true

### DIFF
--- a/examples/bin/set-dfs-commands.sh
+++ b/examples/bin/set-dfs-commands.sh
@@ -24,31 +24,32 @@
 # Run by each example script.
 
 # Find a hadoop shell
-if [ "$HADOOP_HOME" != "" ] && [ "$MAHOUT_LOCAL" == "" ] ; then
+if [ "${HADOOP_HOME}" != "" ] && [ "${MAHOUT_LOCAL}" == "" ] ; then
   HADOOP="${HADOOP_HOME}/bin/hadoop"
   if [ ! -e $HADOOP ]; then
     echo "Can't find hadoop in $HADOOP, exiting"
     exit 1
   fi
+
+  # Check Hadoop version
+  v=`${HADOOP_HOME}/bin/hadoop version | egrep "Hadoop [0-9]+.[0-9]+.[0-9]+" | cut -f 2 -d ' ' | cut -f 1 -d '.'`
+
+  if [ $v -eq "1" -o $v -eq "0" ]
+  then
+    echo "Discovered Hadoop v0 or v1."
+    export DFS="${HADOOP_HOME}/bin/hadoop dfs"
+    export DFSRM="$DFS -rmr -skipTrash"
+  elif [ $v -eq "2" ]
+  then
+    echo "Discovered Hadoop v2."
+    export DFS="${HADOOP_HOME}/bin/hdfs dfs"
+    export DFSRM="$DFS -rm -r -skipTrash"
+  else
+    echo "Can't determine Hadoop version."
+    exit 1
+  fi
+  echo "Setting dfs command to $DFS, dfs rm to $DFSRM."
+
+  export HVERSION=$v
 fi
 
-# Check Hadoop version
-v=`${HADOOP_HOME}/bin/hadoop version | egrep "Hadoop [0-9]+.[0-9]+.[0-9]+" | cut -f 2 -d ' ' | cut -f 1 -d '.'`
-
-if [ $v -eq "1" -o $v -eq "0" ]
-then
-  echo "Discovered Hadoop v0 or v1."
-  export DFS="${HADOOP_HOME}/bin/hadoop dfs"
-  export DFSRM="$DFS -rmr -skipTrash"
-elif [ $v -eq "2" ]
-then
-  echo "Discovered Hadoop v2."
-  export DFS="${HADOOP_HOME}/bin/hdfs dfs"
-  export DFSRM="$DFS -rm -r -skipTrash"
-else
-  echo "Can't determine Hadoop version."
-  exit 1
-fi
-echo "Setting dfs command to $DFS, dfs rm to $DFSRM."
-
-export HVERSION=$v 


### PR DESCRIPTION
Twenty Newsgroups Classification Example fails in case running with `MAHOUT_LOCAL=true` or else when `HADOOP_HOME` env variable is not set.

[Newsgroups](https://mahout.apache.org/users/classification/twenty-newsgroups.html) lists instructions in order to run this classifier. When running in standalone mode(`MAHOUT_LOCAL=true`), i.e., running `$ ./examples/bin/classify-20newsgroups.sh`, the script runs `./examples/bin/set-dfs-commands.sh` internally to export hadoop related env variables.

`set-dfs-commands.sh` attempts to check for hadoop version despite running with `MAHOUT_LOCAL` set as true. IMHO, the script works fine considering the prerequisites, but, it will as well make sense if we can update the script `./examples/bin/set-dfs-commands.sh` to export hadoop env varibales only in case `MAHOUT_LOCAL` is not set to true.
