### PR TITLE
Fix assignment of k12 and k21

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/math/cf/SimilarityAnalysis.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/cf/SimilarityAnalysis.scala
@@ -203,8 +203,8 @@ object SimilarityAnalysis extends Serializable {
     numInteractionsWithAandB: Long, numInteractions: Long) = {
 
     val k11 = numInteractionsWithAandB
-    val k12 = numInteractionsWithA - numInteractionsWithAandB
-    val k21 = numInteractionsWithB - numInteractionsWithAandB
+    val k12 = numInteractionsWithB - numInteractionsWithAandB
+    val k21 = numInteractionsWithA - numInteractionsWithAandB
     val k22 = numInteractions - numInteractionsWithA - numInteractionsWithB + numInteractionsWithAandB
 
     LogLikelihood.logLikelihoodRatio(k11, k12, k21, k22)


### PR DESCRIPTION
The values for these variables were incorrectly swapped according
to the description of the algorithm at:

http://tdunning.blogspot.de/2008/03/surprise-and-coincidence.html

According to the table, `k12` defines a variable that reflects the count of interactions with B but not A; the way it was defined in the source code was the interactions with A but not B, which should be the value of `k21`.
