### PR TITLE
[MAHOUT-1896] Add convenience methods for interacting with Spark ML

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -149,6 +149,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-mllib_${scala.compat.version}</artifactId>
+      <version>${spark.version}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.mahout</groupId>
       <artifactId>mahout-math-scala_${scala.compat.version}</artifactId>
     </dependency>


### PR DESCRIPTION
Currently the method for ingesting RDDs to DRM is `drmWrap`. This is a flexible method, however there are many cases when the RDD to be wrapped is either RDD[org.apache.spark.mllib.lingalg.Vector], RDD[org.apache.spark.mllib.regression.LabeledPoint], or DataFrame[Row] (as is the case when working with SparkML. It makes sense to create convenience methods for converting these types to DRM.

* [x] Add `drmWrapMLLibLabeledPoint`
* [x] Add `drmWrapDataFrame`
* [x] Add `drmWrapMLLibVector`
* [x] Tests


Minor improvement

[Relevent JIRA MAHOUT-1896](https://issues.apache.org/jira/browse/MAHOUT-1896)

Requires no license updates