### PR TITLE
MAHOUT-1875: Use faster shallowCopy for dense matices in blockify drm…

### DIFF
--- a/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
+++ b/math-scala/src/main/scala/org/apache/mahout/math/scalabindings/package.scala
@@ -420,7 +420,7 @@ package object scalabindings {
 
   /**
     * Check the density of an in-core matrix based on supplied criteria.
-    * Returns true if we think mx is densier than threshold with at least 80% confidence.
+    * Returns true if we think mx is denser than threshold with at least 80% confidence.
     *
     * @param mx  The matrix to check density of.
     * @param threshold the threshold of non-zero elements above which we consider a Matrix Dense
@@ -465,7 +465,7 @@ package object scalabindings {
       else if (mean > threshold + iv) return true // dense
     }
 
-    return mean > threshold // if (mean > threshold) dense
+    mean > threshold // if (mean > threshold) dense
 
   }
 

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/package.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/drm/package.scala
@@ -66,7 +66,7 @@ package object drm {
         // Test the density of the data. If the matrix does meets the
         // requirements for density, convert the Vectors to a DenseMatrix.
         val resBlock = if (densityAnalysis(block)) {
-          val dBlock = new DenseMatrix(vectors.length, blockncol)
+          val dBlock = new DenseMatrix(Array.ofDim[Double](vectors.length, blockncol), true)
           var row = 0
           while (row < vectors.length) {
             dBlock(row, ::) := vectors(row)


### PR DESCRIPTION
…/package.blockify(..)