### PR TITLE
MAHOUT-1906: Ensure customJars are added to the MahoutContext under c…

### DIFF
--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/package.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/package.scala
@@ -75,6 +75,7 @@ package object sparkbindings {
         }
 
         sparkConf.setJars(jars = mcjars.toSeq ++ customJars)
+        if (!(customJars.size > 0)) sparkConf.setJars(customJars.toSeq)
 
       } else {
         // In local mode we don't care about jars, do we?


### PR DESCRIPTION
…ertain conditions for spark 1.6+

When creating MahoutContext: if 1.6+ && backend is spark-standalone && addMahoutContextJars = false && customJars.isEmpty() Context creation fails with serialization error on task serialization.

Fix is to ensure that jars are added in this case.


