### PR TITLE
MAHOUT-1934: OpenMP jars aren't being picked up 

### DIFF
--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/package.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/package.scala
@@ -262,8 +262,13 @@ package object sparkbindings {
       j.matches(".*mahout-spark_\\d.*\\.jar") ||
       // vcl jars: mahout-native-viennacl_2.10.jar,
       //           mahout-native-viennacl-omp_2.10.jar
-      j.matches(".*mahout-native-viennacl_\\d.*\\\\.jar") ||
-      j.matches(".*mahout-native-viennacl-omp_\\d.*\\.jar")
+//      j.matches(".*mahout-native-viennacl_\\d.*\\\\.jar") ||
+//      j.matches(".*mahout-native-viennacl-omp_\\d.*\\.jar")||
+        j.matches(".*mahout-native-viennacl*.jar")||
+        // while WIP on MAHOUT-1894, use single wildcard
+        // TODO: remove after 1894 is closed out
+        j.matches(".mahout-spark*-dependency-reduced.jar")
+
     )
         // Tune out "bad" classifiers
         .filter(n =>


### PR DESCRIPTION
add in dependency-reduced.jar to put javacpp jars on executor classpath. Hack for now. use simple wildcard as well.