### PR TITLE
MAHOUT-1938: Switch to Intel AVX 2 instruction set

### DIFF
--- a/viennacl-omp/linux-haswell.properties
+++ b/viennacl-omp/linux-haswell.properties
@@ -1,4 +1,4 @@
-platform=linux-haswell
+platform=linux-x86_64
 platform.path.separator=:
 platform.source.suffix=.cpp
 platform.includepath.prefix=-I

--- a/viennacl-omp/pom.xml
+++ b/viennacl-omp/pom.xml
@@ -141,7 +141,7 @@
                 <argument>-jar</argument>
                 <argument>${org.bytedeco:javacpp:jar}</argument>
                 <argument>-propertyfile</argument>
-                <argument>linux-haswell.properties</argument>
+                <argument>linux-x86_64-viennacl.properties</argument>
                 <argument>-classpath</argument>
                 <argument>${project.build.outputDirectory}:${org.scala-lang:scala-library:jar}</argument>
                 <argument>org.apache.mahout.viennacl.openmp.javacpp.CompressedMatrix</argument>

--- a/viennacl-omp/pom.xml
+++ b/viennacl-omp/pom.xml
@@ -133,7 +133,7 @@
             </goals>
             <configuration>
               <environmentVariables>
-                <LD_LIBRARY_PATH>{project.basedir}/target/classes/org/apache/mahout/javacpp/linalg/linux-x86_64_omp/
+                <LD_LIBRARY_PATH>{project.basedir}/target/classes/org/apache/mahout/javacpp/linalg/linux-x86_64/
                 </LD_LIBRARY_PATH>
               </environmentVariables>
               <executable>java</executable>

--- a/viennacl-omp/pom.xml
+++ b/viennacl-omp/pom.xml
@@ -141,7 +141,7 @@
                 <argument>-jar</argument>
                 <argument>${org.bytedeco:javacpp:jar}</argument>
                 <argument>-propertyfile</argument>
-                <argument>linux-x86_64-viennacl.properties</argument>
+                <argument>linux-haswell.properties</argument>
                 <argument>-classpath</argument>
                 <argument>${project.build.outputDirectory}:${org.scala-lang:scala-library:jar}</argument>
                 <argument>org.apache.mahout.viennacl.openmp.javacpp.CompressedMatrix</argument>

--- a/viennacl/linux-haswell.properties
+++ b/viennacl/linux-haswell.properties
@@ -1,4 +1,4 @@
-platform=linux-haswell
+platform=linux-x86_64
 platform.path.separator=:
 platform.source.suffix=.cpp
 platform.includepath.prefix=-I

--- a/viennacl/pom.xml
+++ b/viennacl/pom.xml
@@ -140,7 +140,7 @@
                 <argument>-jar</argument>
                 <argument>${org.bytedeco:javacpp:jar}</argument>
                 <argument>-propertyfile</argument>
-                <argument>linux-x86_64-viennacl.properties</argument>
+                <argument>linux-haswell.properties</argument>
                 <argument>-classpath</argument>
                 <argument>${project.build.outputDirectory}:${org.scala-lang:scala-library:jar}</argument>
                 <argument>org.apache.mahout.viennacl.opencl.javacpp.CompressedMatrix</argument>

--- a/viennacl/pom.xml
+++ b/viennacl/pom.xml
@@ -140,7 +140,7 @@
                 <argument>-jar</argument>
                 <argument>${org.bytedeco:javacpp:jar}</argument>
                 <argument>-propertyfile</argument>
-                <argument>linux-haswell.properties</argument>
+                <argument>linux-x86_64-viennacl.properties</argument>
                 <argument>-classpath</argument>
                 <argument>${project.build.outputDirectory}:${org.scala-lang:scala-library:jar}</argument>
                 <argument>org.apache.mahout.viennacl.opencl.javacpp.CompressedMatrix</argument>


### PR DESCRIPTION
A question that we may need to consider- do we want to release the binaries for AVX2?  There does not seem to be a fall-back to AMD arch.  