### PR TITLE
MAHOUT-1939: Shade fastutil jar conflicictng with CDH Spark

### DIFF
--- a/math/pom.xml
+++ b/math/pom.xml
@@ -129,6 +129,33 @@
           </supplementalModels>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.0.0</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>it.unimi.dsi:fastutil</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>it.unimi.dsi.fastutil</pattern>
+                  <shadedPattern>shaded.it.unimi.dsi.fastutil</shadedPattern>
+                </relocation>
+              </relocations>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Reports of fastutils versions conflicting on CDH.  Shade our fastutils in `mahout-math`.