### PR TITLE
[MAHOUT-1939] Revert for CLI Driver Fix

### DIFF
--- a/math/pom.xml
+++ b/math/pom.xml
@@ -149,32 +149,32 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.0.0</version>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <artifactSet>
-                <includes>
-                  <include>it.unimi.dsi:fastutil</include>
-                </includes>
-              </artifactSet>
-              <relocations>
-                <relocation>
-                  <pattern>it.unimi.dsi.fastutil</pattern>
-                  <shadedPattern>shaded.it.unimi.dsi.fastutil</shadedPattern>
-                </relocation>
-              </relocations>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
+      <!--<plugin>-->
+        <!--<groupId>org.apache.maven.plugins</groupId>-->
+        <!--<artifactId>maven-shade-plugin</artifactId>-->
+        <!--<version>3.0.0</version>-->
+        <!--<executions>-->
+          <!--<execution>-->
+            <!--<phase>package</phase>-->
+            <!--<goals>-->
+              <!--<goal>shade</goal>-->
+            <!--</goals>-->
+            <!--<configuration>-->
+              <!--<artifactSet>-->
+                <!--<includes>-->
+                  <!--<include>it.unimi.dsi:fastutil</include>-->
+                <!--</includes>-->
+              <!--</artifactSet>-->
+              <!--<relocations>-->
+                <!--<relocation>-->
+                  <!--<pattern>it.unimi.dsi.fastutil</pattern>-->
+                  <!--<shadedPattern>shaded.it.unimi.dsi.fastutil</shadedPattern>-->
+                <!--</relocation>-->
+              <!--</relocations>-->
+            <!--</configuration>-->
+          <!--</execution>-->
+        <!--</executions>-->
+      <!--</plugin>-->
     </plugins>
   </build>
 


### PR DESCRIPTION
fastutils shaded jar was creating an unwanted dependency-reduced-jar in mahout math. and not being passed to CLI or shell.