### PR TITLE
[MAHOUT-1955]: ViennaCL jars are not being picked up by the shell startup script

### DIFF
--- a/viennacl-omp/pom.xml
+++ b/viennacl-omp/pom.xml
@@ -183,7 +183,30 @@
         <version>1.2.1</version>
       </plugin>
 
+      <!-- copy jars to top directory, which is MAHOUT_HOME -->
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <configuration>
+              <tasks>
+                <copy file="target/mahout-native-viennacl-omp_${scala.compat.version}-${version}.jar" tofile="../mahout-native-viennacl-omp_${scala.compat.version}-${version}.jar" />
+              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+
     </plugins>
+
+
 
   </build>
 

--- a/viennacl/pom.xml
+++ b/viennacl/pom.xml
@@ -184,6 +184,26 @@
         <version>1.2.1</version>
       </plugin>
 
+      <!-- copy jars to top directory, which is MAHOUT_HOME -->
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.4</version>
+        <executions>
+          <execution>
+            <id>copy</id>
+            <phase>package</phase>
+            <configuration>
+              <tasks>
+                <copy file="target/mahout-native-viennacl_${scala.compat.version}-${version}.jar" tofile="../mahout-native-viennacl_${scala.compat.version}-${version}.jar" />
+              </tasks>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
     </plugins>
 
   </build>


### PR DESCRIPTION
As reported by Nikolai Sakharnykh, ViennaCL jars were not being picked up by the shell:

After building with `mvn clean install -Pviennacl -Phadoop2`

launching the shell with:

`MASTER=local[4] mahout spark-shell`
 
and loading launching: `scala> timeSparseDRMMMul(1000,1000,1000,1,.02,1234L)`

```17/03/15 09:36:17 INFO RootSolverFactory$: Creating org.apache.mahout.viennacl.opencl.GPUMMul solver

17/03/15 09:36:17 INFO RootSolverFactory$: Unable to create class GPUMMul: attempting OpenMP version

17/03/15 09:36:17 INFO RootSolverFactory$: Creating org.apache.mahout.viennacl.openmp.OMPMMul solver

17/03/15 09:36:17 INFO RootSolverFactory$: org.apache.mahout.viennacl.openmp.OMPMMul$

17/03/15 09:36:17 INFO RootSolverFactory$: Unable to create class OMPMMul: falling back to java version``` 

Issue is that `mahout-native-viennacl_2.10` and `mahout-native-viennacl-omp_2.10` were not being copied to the `$MAHOUT_HOME` base dir, and thus not being picked up by `load-shell.sh`.
```
By modifying the poms to copy jars to the base dir.  This problem is fixed:
```
MASTER=local[4] mahout spark-shell
{...} 
17/03/16 00:01:27 INFO backend.RootSolverFactory$: Creating org.apache.mahout.viennacl.opencl.GPUMMul solver
17/03/16 00:01:27 INFO backend.RootSolverFactory$: Successfully created org.apache.mahout.viennacl.opencl.GPUMMul solver
17/03/16 00:01:27 INFO opencl.GPUMMul$: Using gpuRWCW method
{...}```