### PR TITLE
MAHOUT-1967

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -843,11 +843,17 @@
     <module>distribution</module>
     <module>math-scala</module>
     <module>spark</module>
-    <!--module>flink</module-->
     <module>h2o</module>
   </modules>
 
   <profiles>
+
+    <profile>
+      <id>flink</id>
+    <modules>
+      <module>flink</module>
+    </modules>
+    </profile>
 
     <profile>
       <id>viennacl</id>


### PR DESCRIPTION
Building flink conditionally based on the "-Pflink" flag

Note:
1. Just doing a mvn install -Pflink gives a hadoop.version related error. mvn install -Pflink -Phadoop2 works
2. 1 Test out of 112 tests fails due to an out of memory problem. Link: http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException