### PR TITLE
MAHOUT-1971 Aggregate Transpose Bug

### DIFF
--- a/flink/src/main/scala/org/apache/mahout/flinkbindings/blas/FlinkOpAt.scala
+++ b/flink/src/main/scala/org/apache/mahout/flinkbindings/blas/FlinkOpAt.scala
@@ -49,7 +49,7 @@ object FlinkOpAt {
             val columnVector: Vector = new SequentialAccessSparseVector(ncol)
 
             keys.zipWithIndex.foreach {
-              case (key, idx) => columnVector(key) = block(idx, columnIndex)
+              case (key, idx) => columnVector(key) += block(idx, columnIndex)
             }
 
             (columnIndex, columnVector)

--- a/spark/src/main/scala/org/apache/mahout/sparkbindings/blas/At.scala
+++ b/spark/src/main/scala/org/apache/mahout/sparkbindings/blas/At.scala
@@ -62,7 +62,7 @@ object At {
           // Compute sparse vector. This should be quick if we assign values siquentially.
           val colV: Vector = new SequentialAccessSparseVector(ncol)
           keys.view.zipWithIndex.foreach({
-            case (row, blockRow) => colV(row) = blockA(blockRow, blockCol)
+            case (row, blockRow) => colV(row) += blockA(blockRow, blockCol)
           })
 
           blockCol -> colV

--- a/spark/src/test/scala/org/apache/mahout/sparkbindings/drm/DrmLikeSuite.scala
+++ b/spark/src/test/scala/org/apache/mahout/sparkbindings/drm/DrmLikeSuite.scala
@@ -23,6 +23,7 @@ import scalabindings._
 import drm._
 import RLikeOps._
 import RLikeDrmOps._
+import org.apache.mahout.logging.info
 import org.apache.mahout.sparkbindings._
 import org.apache.mahout.sparkbindings.test.DistributedSparkSuite
 
@@ -138,5 +139,24 @@ class DrmLikeSuite extends FunSuite with DistributedSparkSuite with DrmLikeSuite
     val testM = dense((2,0,4), (3,0,5), (4,0,6))
 
     assert(dfM === testM)
+  }
+
+  test("Aggregating transpose") {
+
+    val mxA = new DenseMatrix(20, 10) := 1
+
+    val drmA = drmParallelize(mxA, numPartitions = 3)
+
+    val reassignedA = drmA.mapBlock() { case (keys, block) ⇒
+      keys.map(_ % 3) → block
+    }
+
+    val mxAggrA = reassignedA.t(::, 0 until 3).collect
+
+    info(mxAggrA.toString)
+
+    mxAggrA(0,0) shouldBe 7
+    mxAggrA(0,1) shouldBe 7
+    mxAggrA(0,2) shouldBe 6
   }
 }


### PR DESCRIPTION
Fixes in Spark and Flink bindings- adds test coverage to both.
