### PR TITLE
MAHOUT-1953 Delete jars from MAHOUT_HOME

### DIFF
--- a/flink/pom.xml
+++ b/flink/pom.xml
@@ -125,6 +125,22 @@
           <argLine>-Xmx4g</argLine>
         </configuration>
       </plugin>
+      <!-- remove jars from top directory on clean -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>../</directory>
+              <includes>
+                <include>mahout-flink*.jar</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/h2o/pom.xml
+++ b/h2o/pom.xml
@@ -137,7 +137,22 @@
           </execution>
         </executions>
       </plugin>
-
+      <!-- remove jars from top directory on clean -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>../</directory>
+              <includes>
+                <include>mahout-h2o*.jar</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/hdfs/pom.xml
+++ b/hdfs/pom.xml
@@ -100,7 +100,22 @@
           </supplementalModels>
         </configuration>
       </plugin>
-
+      <!-- remove jars from top directory on clean -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>../</directory>
+              <includes>
+                <include>mahout-hdfs*.jar</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/math-scala/pom.xml
+++ b/math-scala/pom.xml
@@ -133,7 +133,22 @@
           </execution>
         </executions>
       </plugin>
-
+      <!-- remove jars from top directory on clean -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>../</directory>
+              <includes>
+                <include>mahout-math-scala*.jar</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/math/pom.xml
+++ b/math/pom.xml
@@ -175,6 +175,22 @@
           <!--</execution>-->
         <!--</executions>-->
       <!--</plugin>-->
+      <!-- remove jars from top directory on clean -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>../</directory>
+              <includes>
+                <include>mahout-math*.jar</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/mr/pom.xml
+++ b/mr/pom.xml
@@ -120,7 +120,22 @@
           </supplementalModels>
         </configuration>
       </plugin>
-
+      <!-- remove jars from top directory on clean -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>../</directory>
+              <includes>
+                <include>mahout-mr*.jar</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -156,7 +156,22 @@
           </execution>
         </executions>
       </plugin>
-
+      <!-- remove jars from top directory on clean -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.0.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>../</directory>
+              <includes>
+                <include>mahout-spark*.jar</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Jars are coppied on `mvn package` to MAHOUT_HOME however, `mvn clean` does not delete this packages. 

This corrects that oversite. 
