### PR TITLE
MAHOUT-1975 Add PR Template for Github PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,28 @@
+### Purpose of PR:
+Please give a short description of what this PR is for.
+
+
+First, make sure you are opening this PR against the `develop` branch (not master).
+Right beneath "Open PR" you will see `base fork: apache/mahout` dropdown, then `master` as a dropdown. Click that and select `develop` (or in some cases the name of the feature-branch you're working on).
+
+### Important ToDos
+Please mark each with an "x"
+- [ ] Opening PR against `develop` NOT `master` (OR `feature-name` if this is part of an ongoing feature development).
+- [ ] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/ZEPPELIN/]
+- [ ] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX
+is the JIRA number.
+- [ ] Created unit tests where appropriate
+- [ ] Added licenses correct on newly added files
+- [ ] Assigned JIRA to self
+- [ ] Added documentation in scala docs/java docs, (and website once that
+is merged to dev)
+- [ ] Successfully built and ran all unit tests, verified that all tests
+pass locally.
+
+If all of these things aren't complete, but you still feel it is
+appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
+descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"
+
+Oh by the way, does this change break earlier versions?
+
+Is this the beginning of a larger project for which a feature branch should be made?


### PR DESCRIPTION
### Purpose of PR:

This PR adds this slick template to the message box when people open PRs!

### Important ToDos
Please mark each with an "x"
- [x] Opening PR against `develop` NOT `master` (OR `feature-name` if this is part of an ongoing feature development).
- [x] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/ZEPPELIN/]
- [x] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX
is the JIRA number.
- [x] Assigned JIRA to self (almost forgot- thanks template!)
- [ ] Created unit tests where appropriate **N/A**
- [ ] Added documentation in scala docs/java docs, (and website once that
is merged to dev) **N/A**
- [ ] Added licenses correct on newly added files **N/A** (adding license will mess up the template)
- [ ] Successfully built and ran all unit tests, verified that all tests
pass locally. **N/A** Won't know this is working for sure until it is added to master.

If all of these things aren't complete, but you still feel it is
appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"

Oh by the way, does this change break earlier versions?
No

Is this the beginning of a larger project for which a feature branch should be made?
No- straight to dev