### PR TITLE
MAHOUT-1979 Remove delelop branch references

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -2,27 +2,20 @@
 Please give a short description of what this PR is for.
 
 
-First, make sure you are opening this PR against the `develop` branch (not master).
-Right beneath "Open PR" you will see `base fork: apache/mahout` dropdown, then `master` as a dropdown. Click that and select `develop` (or in some cases the name of the feature-branch you're working on).
-
 ### Important ToDos
 Please mark each with an "x"
-- [ ] Opening PR against `develop` NOT `master` (OR `feature-name` if this is part of an ongoing feature development).
 - [ ] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/ZEPPELIN/]
-- [ ] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX
-is the JIRA number.
+- [ ] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX is the JIRA number.
 - [ ] Created unit tests where appropriate
 - [ ] Added licenses correct on newly added files
 - [ ] Assigned JIRA to self
-- [ ] Added documentation in scala docs/java docs, (and website once that
-is merged to dev)
-- [ ] Successfully built and ran all unit tests, verified that all tests
-pass locally.
+- [ ] Added documentation in scala docs/java docs, and to website
+- [ ] Successfully built and ran all unit tests, verified that all tests pass locally.
 
 If all of these things aren't complete, but you still feel it is
 appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
 descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"
 
-Oh by the way, does this change break earlier versions?
+Does this change break earlier versions?
 
 Is this the beginning of a larger project for which a feature branch should be made?

--- a/website/front/developers/githubPRs.md
+++ b/website/front/developers/githubPRs.md
@@ -26,8 +26,8 @@ same time, it is recommended to use **squash commits**.
 
 Read [[2]] (merging locally). Merging pull requests are equivalent to merging contributor's branch:
 
-    git checkout develop      # switch to local master branch
-    git pull apache develop   # fast-forward to current remote HEAD
+    git checkout master      # switch to local master branch
+    git pull apache master   # fast-forward to current remote HEAD
     git pull --squash https://github.com/cuser/mahout cbranch  # merge to master 
 
 
@@ -50,11 +50,11 @@ Suppose everything is fine, you now can commit the squashed request
 edit message to contain "MAHOUT-YYYY description **closes #ZZ**", where ZZ is the pull request number. 
 Including "closes #ZZ" will close PR automatically. More information [[3]].
 
-   push apache develop
+   push apache master
 
 (this will require credentials).
 
-Note on `develop` branch: Minor patches, bug fixes, complete features, etc. may be merged to `develop`.  Features that 
+Note on `master` branch: Minor patches, bug fixes, complete features, etc. may be merged to `master`.  Features that 
 are still under development should be pushed to a feature branch with reasonable name or better yet `mahout-xxxx` where 
 `xxxx` is the JIRA number. 
 


### PR DESCRIPTION
### Purpose of PR:
Please give a short description of what this PR is for.
Removing references to "develop" branch

### Important ToDos
Please mark each with an "x"
- [x] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/ZEPPELIN/]
- [x] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX
is the JIRA number.
- [x] Created unit tests where appropriate
- [x] Added licenses correct on newly added files
- [x] Assigned JIRA to self
- [x] Added documentation in scala docs/java docs, (and website once that
is merged to dev)
- [x] Successfully built and ran all unit tests, verified that all tests
pass locally.

If all of these things aren't complete, but you still feel it is
appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"

Oh by the way, does this change break earlier versions?
No
Is this the beginning of a larger project for which a feature branch should be made?
No