### PR TITLE
MAHOUT-2018: missing dash delimiter in mahout-spark module pom.xml

### DIFF
--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -130,7 +130,7 @@
             <phase>package</phase>
             <configuration>
               <tasks>
-                <copy file="target/mahout-spark_${scala.compat.version}-${version}-spark_${spark.compat.version}.jar" tofile="../mahout-spark_${scala.compat.version}-${version}spark_${spark.compat.version}.jar" />
+                <copy file="target/mahout-spark_${scala.compat.version}-${version}-spark_${spark.compat.version}.jar" tofile="../mahout-spark_${scala.compat.version}-${version}-spark_${spark.compat.version}.jar" />
                 <copy file="target/mahout-spark_${scala.compat.version}-${version}-dependency-reduced.jar" tofile="../mahout-spark_${scala.compat.version}-${version}-dependency-reduced.jar" />
               </tasks>
             </configuration>


### PR DESCRIPTION
### Purpose of PR:
Please give a short description of what this PR is for.


### Important ToDos
Please mark each with an "x"
- [x ] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/ZEPPELIN/]
- [ x] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX is the JIRA number.
- [ ] Created unit tests where appropriate
- [ ] Added licenses correct on newly added files
- [ x] Assigned JIRA to self
- [ ] Added documentation in scala docs/java docs, and to website
- [x] Successfully built and ran all unit tests, verified that all tests pass locally.

If all of these things aren't complete, but you still feel it is
appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"

Does this change break earlier versions?

Is this the beginning of a larger project for which a feature branch should be made?
