### PR TITLE
Add an IfStatement to check the return value of resultFile.delete().

### DIFF
--- a/examples/src/main/java/org/apache/mahout/cf/taste/example/bookcrossing/BookCrossingDataModel.java
+++ b/examples/src/main/java/org/apache/mahout/cf/taste/example/bookcrossing/BookCrossingDataModel.java
@@ -58,7 +58,9 @@ public final class BookCrossingDataModel extends FileDataModel {
       throw new FileNotFoundException(originalFile.toString());
     }
     File resultFile = new File(new File(System.getProperty("java.io.tmpdir")), "taste.bookcrossing.txt");
-    resultFile.delete();
+    if (!resultFile.exists() && !resultFile.delete()) {
+	throw new IOException("Can not delete the result file.");
+    }
     Writer writer = null;
     try {
       writer = new OutputStreamWriter(new FileOutputStream(resultFile), Charsets.UTF_8);


### PR DESCRIPTION
This statement returns a value that is not checked.
The return value should be checked since it can indicate an unusual or unexpected function execution.
The statement returns false if the file could not be successfully deleted (rather than throwing an Exception).
If the result was not checked, developers would not notice if the statement signals an unexpected behavior by returning an atypical return value.
http://findbugs.sourceforge.net/bugDescriptions.html#RV_RETURN_VALUE_IGNORED_BAD_PRACTICE
