### PR TITLE
Remove the redundant null check statements of a non-null value.

### DIFF
--- a/math/src/main/java/org/apache/mahout/math/list/ObjectArrayList.java
+++ b/math/src/main/java/org/apache/mahout/math/list/ObjectArrayList.java
@@ -188,9 +188,9 @@ public class ObjectArrayList<T> extends AbstractObjectList<T> {
     if (this == otherObj) {
       return true;
     }
-    if (otherObj == null) {
-      return false;
-    }
+    //if (otherObj == null) {
+    //  return false;
+    //}
     ObjectArrayList<?> other = (ObjectArrayList<?>) otherObj;
     if (size() != other.size()) {
       return false;


### PR DESCRIPTION
This IfStatement is a redundant check of a known non-null otherObj because the null check of otherObj is contained in the previous instanceof check.
http://findbugs.sourceforge.net/bugDescriptions.html#RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE

