### PR TITLE
Consider returning a zero length array rather than null.

### DIFF
--- a/mr/src/main/java/org/apache/mahout/clustering/lda/cvb/CVB0Driver.java
+++ b/mr/src/main/java/org/apache/mahout/clustering/lda/cvb/CVB0Driver.java
@@ -521,7 +521,7 @@ public class CVB0Driver extends AbstractJob {
   public static Path[] getModelPaths(Configuration conf) {
     String[] modelPathNames = conf.getStrings(MODEL_PATHS);
     if (modelPathNames == null || modelPathNames.length == 0) {
-      return null;
+      return new Path[0];
     }
     Path[] modelPaths = new Path[modelPathNames.length];
     for (int i = 0; i < modelPathNames.length; i++) {


### PR DESCRIPTION
It is often a better design to return a length zero array rather than a null reference to indicate that there are no results (i.e., an empty list of results).
This way, no explicit check for null is needed by clients of the method.
On the other hand, using null to indicate "there is no answer to this question" is probably appropriate.
http://findbugs.sourceforge.net/bugDescriptions.html#PZLA_PREFER_ZERO_LENGTH_ARRAYS


