### PR TITLE
MAHOUT-2029 Fix broken links in Developer section in navbar

### DIFF
--- a/website/_includes/navbar.html
+++ b/website/_includes/navbar.html
@@ -28,8 +28,8 @@
                     <a class="nav-link dropdown-toggle" href="" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Developers</a>
                     <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                         <a class="dropdown-item" href="/developers/developer-resources.html">Developer Resources</a>
-                        <a class="dropdown-item" href="/developers/buildingmahout/">Building Mahout from Source</a>
-                        <a class="dropdown-item" href="/developers/issue-tracker/">Issues Tracking (JIRA)</a>
+                        <a class="dropdown-item" href="/developers/buildingmahout">Building Mahout from Source</a>
+                        <a class="dropdown-item" href="/developers/issue-tracker">Issues Tracking (JIRA)</a>
                         <!-- <a class="dropdown-item" href="/developers/patch-check-list/">Patch Check List</a> going to github template -->
                         <!-- <a class="dropdown-item" href="/developers/reference/">References</a> a lot of overlap with books, talks, etc. page -->
                         <a class="dropdown-item" href="/developers/release-notes/">Release Notes</a>


### PR DESCRIPTION
### Purpose of PR:
Fixes links in Developers section of navbar of the website. Removes trailing slashes.
- Building Mahout from Source
- Issues Tracking (JIRA)

Release notes link is still broken.

### Important ToDos
Please mark each with an "x"
- [X] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/MAHOUT-2029]
- [X] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX is the JIRA number.
- [ ] Created unit tests where appropriate
- [ ] Added licenses correct on newly added files
- [ ] Assigned JIRA to self
- [ ] Added documentation in scala docs/java docs, and to website
- [ ] Successfully built and ran all unit tests, verified that all tests pass locally.

If all of these things aren't complete, but you still feel it is
appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"

Does this change break earlier versions?
No

Is this the beginning of a larger project for which a feature branch should be made?
No