### PR TITLE
MAHOUT-2051 [WIP] Fix IllegalStateException in MixedGradient.java

### DIFF
--- a/mr/src/main/java/org/apache/mahout/classifier/sgd/MixedGradient.java
+++ b/mr/src/main/java/org/apache/mahout/classifier/sgd/MixedGradient.java
@@ -49,11 +49,8 @@ public class MixedGradient implements Gradient {
 
   @Override
   public Vector apply(String groupKey, int actual, Vector instance, AbstractVectorClassifier classifier) {
-    if (random.nextDouble() < alpha) {
+    if (hasZero && hasOne && random.nextDouble() < alpha) {
       // one option is to apply a ranking update relative to our recent history
-      if (!hasZero || !hasOne) {
-        throw new IllegalStateException();
-      }
       return rank.apply(groupKey, actual, instance, classifier);
     } else {
       hasZero |= actual == 0;


### PR DESCRIPTION
### Purpose of PR:
After initialization of a MixedGradient instance both variables "hasZero" and "hasOne" are false, which leads to an IllegalStateException in the function "apply" if random.nextDouble() < alpha.

The proposed change would avoid this by using only the base gradient until both cases (actual == 0 and actual == 1) occured at least once.


### Important ToDos
Please mark each with an "x"
- [x] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/ZEPPELIN/]
- [x] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX is the JIRA number.
- [ ] Created unit tests where appropriate
- [x] Added licenses correct on newly added files
- [ ] Assigned JIRA to self
- [ ] Added documentation in scala docs/java docs, and to website
- [x] Successfully built and ran all unit tests, verified that all tests pass locally.

If all of these things aren't complete, but you still feel it is
appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"

Does this change break earlier versions?
No

Is this the beginning of a larger project for which a feature branch should be made?
No
