### PR TITLE
MAHOUT-2052 [WIP] Broken codeblock in a samsara tutorial html file.

### DIFF
--- a/website/docs/latest/tutorials/samsara/play-with-shell.md
+++ b/website/docs/latest/tutorials/samsara/play-with-shell.md
@@ -41,10 +41,12 @@ We describe how to do a quick toy setup of Spark & Mahout on your local machine,
 
  1. Goto the directory where you unpacked Spark and type ```sbin/start-all.sh``` to locally start Spark
  1. Open a browser, point it to [http://localhost:8080/](http://localhost:8080/) to check whether Spark successfully started. Copy the url of the spark master at the top of the page (it starts with **spark://**)
- 1. Define the following environment variables: <div class="codehilite"><pre>export MAHOUT_HOME=[directory into which you checked out Mahout]
-export SPARK_HOME=[directory where you unpacked Spark]
-export MASTER=[url of the Spark master]
-</pre></div>
+ 1. Define the following environment variables: 
+    <pre class="codehilite">
+    export MAHOUT_HOME=[directory into which you checked out Mahout]
+    export SPARK_HOME=[directory where you unpacked Spark]
+    export MASTER=[url of the Spark master]
+    </pre>
  1. Finally, change to the directory where you unpacked Mahout and type ```bin/mahout spark-shell```, 
 you should see the shell starting and get the prompt ```mahout> ```. Check 
 [FAQ](http://mahout.apache.org/users/sparkbindings/faq.html) for further troubleshooting.

--- a/website/docs/latest/tutorials/samsara/play-with-shell.md
+++ b/website/docs/latest/tutorials/samsara/play-with-shell.md
@@ -41,10 +41,10 @@ We describe how to do a quick toy setup of Spark & Mahout on your local machine,
 
  1. Goto the directory where you unpacked Spark and type ```sbin/start-all.sh``` to locally start Spark
  1. Open a browser, point it to [http://localhost:8080/](http://localhost:8080/) to check whether Spark successfully started. Copy the url of the spark master at the top of the page (it starts with **spark://**)
- 1. Define the following environment variables: <pre class="codehilite">export MAHOUT_HOME=[directory into which you checked out Mahout]
+ 1. Define the following environment variables: <div class="codehilite"><pre>export MAHOUT_HOME=[directory into which you checked out Mahout]
 export SPARK_HOME=[directory where you unpacked Spark]
 export MASTER=[url of the Spark master]
-</pre>
+</pre></div>
  1. Finally, change to the directory where you unpacked Mahout and type ```bin/mahout spark-shell```, 
 you should see the shell starting and get the prompt ```mahout> ```. Check 
 [FAQ](http://mahout.apache.org/users/sparkbindings/faq.html) for further troubleshooting.


### PR DESCRIPTION
### Purpose of PR:
As you can see below,
there is a broken codeblock and the tag ``<pre>`` is shown in a samsara tutorial html file.

![image](https://user-images.githubusercontent.com/24687378/42917644-675a96f6-8b45-11e8-8064-eb2c26b38a2c.png)

This is because of ``<pre class="codehilite"></pre>`` and it should be changed to ``<div class="codehilite"><pre> ... </pre></div>``

### Important ToDos
Please mark each with an "x"
- [x] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/ZEPPELIN/]
- [x] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX is the JIRA number.
- [ ] Created unit tests where appropriate
- [ ] Added licenses correct on newly added files
- [ ] Assigned JIRA to self
- [ ] Added documentation in scala docs/java docs, and to website
- [ ] Successfully built and ran all unit tests, verified that all tests pass locally.

If all of these things aren't complete, but you still feel it is
appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"

Does this change break earlier versions?
No

Is this the beginning of a larger project for which a feature branch should be made?
No