### PR TITLE
MAHOUT-2065 [WIP] fix high risk crash bug

### DIFF
--- a/community/mahout-mr/mr/src/main/java/org/apache/mahout/clustering/streaming/mapreduce/StreamingKMeansDriver.java
+++ b/community/mahout-mr/mr/src/main/java/org/apache/mahout/clustering/streaming/mapreduce/StreamingKMeansDriver.java
@@ -424,7 +424,7 @@ public final class StreamingKMeansDriver extends AbstractJob {
     throws IOException, ExecutionException, InterruptedException {
     long start = System.currentTimeMillis();
     // Run StreamingKMeans step in parallel by spawning 1 thread per input path to process.
-    ExecutorService pool = Executors.newCachedThreadPool();
+    ExecutorService pool = Executors.newFixedThreadPool(10);
     List<Future<Iterable<Centroid>>> intermediateCentroidFutures = new ArrayList<>();
     for (FileStatus status : HadoopUtil.listStatus(FileSystem.get(conf), input, PathFilters.logsCRCFilter())) {
       intermediateCentroidFutures.add(pool.submit(new StreamingKMeansThread(status.getPath(), conf)));


### PR DESCRIPTION
### Purpose of PR:
Fix: [#MAHOUT-2065](https://issues.apache.org/jira/browse/MAHOUT-2065)newCachedThreadPool() has higher risk in causing OutOfMemoryError, newFixedThreadPool() should be used.

### Important ToDos
Please mark each with an "x"
- [x ] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/ZEPPELIN/]
- [x ] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX is the JIRA number.
- [x ] Successfully built and ran all unit tests, verified that all tests pass locally.