### PR TITLE
MAHOUT-2096 - next() Called On Possible Empty iterator()

### DIFF
--- a/community/mahout-mr/mr/src/main/java/org/apache/mahout/cf/taste/hadoop/als/ParallelALSFactorizationJob.java
+++ b/community/mahout-mr/mr/src/main/java/org/apache/mahout/cf/taste/hadoop/als/ParallelALSFactorizationJob.java
@@ -392,7 +392,11 @@ public class ParallelALSFactorizationJob extends AbstractJob {
     @Override
     protected void reduce(VarIntWritable index, Iterable<VarLongWritable> ids, Context ctx)
       throws IOException, InterruptedException {
-      ctx.write(index, ids.iterator().next());
+      if (ids.iterator().hasNext()) {
+        ctx.write(index, ids.iterator().next());
+      } else {
+        log.debug("Iterator is empty");
+      }
     }
   }
 


### PR DESCRIPTION
### Purpose of PR:
Initially there was no check for the empty iterator when calling the next() function, which could result in an exception.

### Important ToDos
Please mark each with an "x"
- [ x ] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/mahout/]
- [ x ] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX is the JIRA number.
- [ ] Created unit tests where appropriate
- [ ] Added licenses correct on newly added files
- [ ] Assigned JIRA to self
- [ ] Added documentation in scala docs/java docs, and to website
- [ x ] Successfully built and ran all unit tests, verified that all tests pass locally.

If all of these things aren't complete, but you still feel it is
appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"

Does this change break earlier versions? - No 

Is this the beginning of a larger project for which a feature branch should be made? - Not sure
