### PR TITLE
[HOTFIX] Removing ASF Header from markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ bin/metastore_db
 *log
 website/_site
 website/Gemfile.lock
+website/.bundle
+website/.sass-cache

--- a/website/_posts/2020-10-10-version-14-1
+++ b/website/_posts/2020-10-10-version-14-1
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: post
 title: Version 14.1 Released

--- a/website/developers/buildingmahout.md
+++ b/website/developers/buildingmahout.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: Building Mahout

--- a/website/developers/developer-resources.md
+++ b/website/developers/developer-resources.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: Developer Resources

--- a/website/developers/github.md
+++ b/website/developers/github.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title:

--- a/website/developers/githubPRs.md
+++ b/website/developers/githubPRs.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title:

--- a/website/developers/gsoc.md
+++ b/website/developers/gsoc.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: GSOC

--- a/website/developers/how-to-become-a-committer.md
+++ b/website/developers/how-to-become-a-committer.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: How To Become A Committer

--- a/website/developers/how-to-contribute.md
+++ b/website/developers/how-to-contribute.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: How To Contribute

--- a/website/developers/how-to-release.md
+++ b/website/developers/how-to-release.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: How To Release

--- a/website/developers/how-to-update-the-website.md
+++ b/website/developers/how-to-update-the-website.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: How To Update The Website
@@ -63,7 +47,7 @@ open your favorite browser and make sure your changes look the way you expect th
 
 #### Commit code and open a PR
 
-Once you're sure everything is right, you commit your code, push to your github.com account (preferably on a branch other than `master`
+Once you're sure everything is right, you commit your code, push to your github.com account (preferably on a branch other than `trunk`
 then click "OpenPR"). This process closely follows [How To Contribute- Making Changes](/developers/how-to-contribute/#HowToContribute-MakingChanges) with an exception that for _WEBSITE ONLY_ changes we relax the requirement to open a JIRA ticket. That is to say, small
 website changes such as fixing a broken link or typo, do not require a specific JIRA issues, and where you would normally 
 commit with a message like `MAHOUT-XXXX The thing I did` (where `XXXX` is the assosciated JIRA number), you can instead 
@@ -84,5 +68,5 @@ Once everything is confirmed to be in order, the committer will merge your pull 
 #### Committers ONLY
 
 No further action is needed, this section is here to deliniate from the old CMS system and Jekyll builds of other projects. Jenkins
-will execute [build_site.sh](https://github.com/apache/mahout/blob/master/website/build_site.sh) upon merging. This will build the website and
+will execute [build_site.sh](https://github.com/apache/mahout/blob/trunk/website/build_site.sh) upon merging. This will build the website and
 copy it to the `asf-site` branch, where [mahout.apache.org](http://mahout.apache.org) is served from. 

--- a/website/developers/issue-tracker.md
+++ b/website/developers/issue-tracker.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: Issue Tracker

--- a/website/developers/patch-check-list.md
+++ b/website/developers/patch-check-list.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: Patch Check List
@@ -42,4 +26,3 @@ After the above steps are verified and completed, and the contribution is ready 
  - Remember to update the issue status in JIRA when you have completed it.
 
 
-  

--- a/website/developers/thirdparty-dependencies.md
+++ b/website/developers/thirdparty-dependencies.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
 title: Thirdparty Dependencies

--- a/website/developers/version-control.md
+++ b/website/developers/version-control.md
@@ -1,22 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: page
-title: GSOC
+title: Version Control
 
     
 ---

--- a/website/docs/latest/algorithms/clustering/canopy/index.md
+++ b/website/docs/latest/algorithms/clustering/canopy/index.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Canopy Clustering

--- a/website/docs/latest/algorithms/clustering/distance-metrics.md
+++ b/website/docs/latest/algorithms/clustering/distance-metrics.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Distance Metrics

--- a/website/docs/latest/algorithms/clustering/index.md
+++ b/website/docs/latest/algorithms/clustering/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Clustering Algorithms
-
-   
 ---
 
 [Canopy Clustering](canopy/)

--- a/website/docs/latest/algorithms/linear-algebra/d-qr.md
+++ b/website/docs/latest/algorithms/linear-algebra/d-qr.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Distributed Cholesky QR

--- a/website/docs/latest/algorithms/linear-algebra/d-spca.md
+++ b/website/docs/latest/algorithms/linear-algebra/d-spca.md
@@ -1,25 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
-
-title: Distributed Stochastic PCA
-
-    
+title: Distributed Stochastic PCA  
 ---
 
 

--- a/website/docs/latest/algorithms/linear-algebra/d-ssvd.md
+++ b/website/docs/latest/algorithms/linear-algebra/d-ssvd.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
-title: Distributed Stochastic Singular Value Decomposition
-
-    
+title: Distributed Stochastic Singular Value Decomposition  
 ---
 
 ## Intro

--- a/website/docs/latest/algorithms/linear-algebra/index.md
+++ b/website/docs/latest/algorithms/linear-algebra/index.md
@@ -1,25 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
-
 title: Distributed Linear Algebra
-
-    
 ---
 
 Mahout has a number of distributed linear algebra "algorithms" that, in concert with the mathematically expressive R-Like Scala DSL, make it possible for users to quickly "roll their own" distributed algorithms.

--- a/website/docs/latest/algorithms/map-reduce/classification/bayesian.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/bayesian.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated) 
-
-    
 ---
 
 # Naive Bayes

--- a/website/docs/latest/algorithms/map-reduce/classification/class-discovery.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/class-discovery.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Class Discovery
-
-    
 ---
 <a name="ClassDiscovery-ClassDiscovery"></a>
 # Class Discovery

--- a/website/docs/latest/algorithms/map-reduce/classification/classifyingyourdata.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/classifyingyourdata.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  ClassifyingYourData
-
-    
 ---
 
 # Classifying data from the command line

--- a/website/docs/latest/algorithms/map-reduce/classification/collocations.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/collocations.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Collocations
-
-    
 ---
 
 

--- a/website/docs/latest/algorithms/map-reduce/classification/gaussian-discriminative-analysis.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/gaussian-discriminative-analysis.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Gaussian Discriminative Analysis
-
-    
 ---
 
 <a name="GaussianDiscriminativeAnalysis-GaussianDiscriminativeAnalysis"></a>

--- a/website/docs/latest/algorithms/map-reduce/classification/hidden-markov-models.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/hidden-markov-models.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Hidden Markov Models
-
-    
 ---
 
 # Hidden Markov Models

--- a/website/docs/latest/algorithms/map-reduce/classification/independent-component-analysis.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/independent-component-analysis.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Independent Component Analysis
-
-    
 ---
 
 <a name="IndependentComponentAnalysis-IndependentComponentAnalysis"></a>

--- a/website/docs/latest/algorithms/map-reduce/classification/locally-weighted-linear-regression.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/locally-weighted-linear-regression.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Locally Weighted Linear Regression
-
-    
 ---
 
 <a name="LocallyWeightedLinearRegression-LocallyWeightedLinearRegression"></a>

--- a/website/docs/latest/algorithms/map-reduce/classification/logistic-regression.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/logistic-regression.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Logistic Regression
-
-    
 ---
 
 <a name="LogisticRegression-LogisticRegression(SGD)"></a>

--- a/website/docs/latest/algorithms/map-reduce/classification/mahout-collections.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/mahout-collections.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  mahout-collections
-
-    
 ---
 
 # Mahout collections

--- a/website/docs/latest/algorithms/map-reduce/classification/mlp.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/mlp.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Multilayer Perceptron
-
-    
 ---
 
 Multilayer Perceptron

--- a/website/docs/latest/algorithms/map-reduce/classification/naivebayes.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/naivebayes.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  NaiveBayes
-
-    
 ---
 
 <a name="NaiveBayes-NaiveBayes"></a>

--- a/website/docs/latest/algorithms/map-reduce/classification/neural-network.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/neural-network.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Neural Network
-
-    
 ---
 
 <a name="NeuralNetwork-NeuralNetworks"></a>

--- a/website/docs/latest/algorithms/map-reduce/classification/partial-implementation.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/partial-implementation.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Partial Implementation
-
-    
 ---
 
 

--- a/website/docs/latest/algorithms/map-reduce/classification/random-forests.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/random-forests.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Random Forests
-
-    
 ---
 
 <a name="RandomForests-HowtogrowaDecisionTree"></a>

--- a/website/docs/latest/algorithms/map-reduce/classification/restricted-boltzmann-machines.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/restricted-boltzmann-machines.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Restricted Boltzmann Machines
-
-    
 ---
 
 NOTE: This implementation is a Work-In-Progress, at least till September,

--- a/website/docs/latest/algorithms/map-reduce/classification/support-vector-machines.md
+++ b/website/docs/latest/algorithms/map-reduce/classification/support-vector-machines.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Support Vector Machines
-
-    
 ---
 
 <a name="SupportVectorMachines-SupportVectorMachines"></a>

--- a/website/docs/latest/algorithms/map-reduce/clustering/canopy-clustering.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/canopy-clustering.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Canopy Clustering
-
-   
 ---
 
 

--- a/website/docs/latest/algorithms/map-reduce/clustering/cluster-dumper.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/cluster-dumper.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Cluster Dumper
-
-   
 ---
 
 <a name="ClusterDumper-Introduction"></a>

--- a/website/docs/latest/algorithms/map-reduce/clustering/expectation-maximization.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/expectation-maximization.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Expectation Maximization
-
-   
 ---
 <a name="ExpectationMaximization-ExpectationMaximization"></a>
 # Expectation Maximization

--- a/website/docs/latest/algorithms/map-reduce/clustering/fuzzy-k-means.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/fuzzy-k-means.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Fuzzy K-Means
-
-   
 ---
 
 Fuzzy K-Means (also called Fuzzy C-Means) is an extension of [K-Means](http://mahout.apache.org/users/clustering/k-means-clustering.html)

--- a/website/docs/latest/algorithms/map-reduce/clustering/hierarchical-clustering.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/hierarchical-clustering.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Hierarchical Clustering
-
-   
 ---
 Hierarchical clustering is the process or finding bigger clusters, and also
 the smaller clusters inside the bigger clusters.

--- a/website/docs/latest/algorithms/map-reduce/clustering/k-means-clustering.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/k-means-clustering.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  K-Means Clustering
-
-   
 ---
 
 # k-Means clustering - basics

--- a/website/docs/latest/algorithms/map-reduce/clustering/latent-dirichlet-allocation.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/latent-dirichlet-allocation.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Latent Dirichlet Allocation
-
-   
 ---
 
 <a name="LatentDirichletAllocation-Overview"></a>

--- a/website/docs/latest/algorithms/map-reduce/clustering/llr---log-likelihood-ratio.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/llr---log-likelihood-ratio.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  LLR - Log-likelihood Ratio
-
-   
 ---
 
 # Likelihood ratio test
@@ -59,4 +41,3 @@ number of training examples and where features are highly interdependent.
 * [G-Test](http://en.wikipedia.org/wiki/G-test)
 * [Likelihood Ratio Test](http://en.wikipedia.org/wiki/Likelihood-ratio_test)
 
-      

--- a/website/docs/latest/algorithms/map-reduce/clustering/spectral-clustering.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/spectral-clustering.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Spectral Clustering
-
-   
 ---
 
 # Spectral Clustering Overview

--- a/website/docs/latest/algorithms/map-reduce/clustering/streaming-k-means.md
+++ b/website/docs/latest/algorithms/map-reduce/clustering/streaming-k-means.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Spectral Clustering
-
-   
 ---
 
 # *StreamingKMeans* algorithm 

--- a/website/docs/latest/algorithms/map-reduce/index.md
+++ b/website/docs/latest/algorithms/map-reduce/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Deprecated Map Reduce Algorithms
-
-    
 ---
 
 ### Classification

--- a/website/docs/latest/algorithms/preprocessors/AsFactor.md
+++ b/website/docs/latest/algorithms/preprocessors/AsFactor.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: AsFactor
-
-    
 ---
 
 

--- a/website/docs/latest/algorithms/preprocessors/MeanCenter.md
+++ b/website/docs/latest/algorithms/preprocessors/MeanCenter.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: MeanCenter
-
-    
 ---
 
 ### About

--- a/website/docs/latest/algorithms/preprocessors/StandardScaler.md
+++ b/website/docs/latest/algorithms/preprocessors/StandardScaler.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: StandardScaler
-
-    
 ---
 
 ### About

--- a/website/docs/latest/algorithms/preprocessors/index.md
+++ b/website/docs/latest/algorithms/preprocessors/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Preprocesors
-
-    
 ---
 
 [AsFactor](AsFactor.html) - For "one-hot-encoding"

--- a/website/docs/latest/algorithms/recommenders/cco.md
+++ b/website/docs/latest/algorithms/recommenders/cco.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Building a Mahout Recommender
-
-    
 ---
 
 # Building a Correlated Cross-Occurrence (CCO) Recommenders with the Mahout CLI

--- a/website/docs/latest/algorithms/recommenders/d-als.md
+++ b/website/docs/latest/algorithms/recommenders/d-als.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Mahout Samsara Distributed ALS
-
-    
 ---
+
 Seems like someone has jacked up this page? 
 TODO: Find the ALS Page
 

--- a/website/docs/latest/algorithms/recommenders/index.md
+++ b/website/docs/latest/algorithms/recommenders/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Recommender Overview
-
-    
 ---
 
 

--- a/website/docs/latest/algorithms/regression/fittness-tests.md
+++ b/website/docs/latest/algorithms/regression/fittness-tests.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Regression Fitness Tests
-
-    
 ---
 
 TODO: Fill this out!

--- a/website/docs/latest/algorithms/regression/index.md
+++ b/website/docs/latest/algorithms/regression/index.md
@@ -1,25 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
-
 title: Regression Algorithms
-
-    
 ---
 
 Apache Mahout implements the following regression algorithms "off the shelf".

--- a/website/docs/latest/algorithms/regression/ols.md
+++ b/website/docs/latest/algorithms/regression/ols.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Ordinary Least Squares Regression
-
-    
 ---
 
 ### About

--- a/website/docs/latest/algorithms/regression/serial-correlation/cochrane-orcutt.md
+++ b/website/docs/latest/algorithms/regression/serial-correlation/cochrane-orcutt.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Cochrane-Orcutt Procedure
-
-    
 ---
 
 ### About

--- a/website/docs/latest/algorithms/regression/serial-correlation/dw-test.md
+++ b/website/docs/latest/algorithms/regression/serial-correlation/dw-test.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Durbin-Watson Test
-
-    
 ---
 
 ### About

--- a/website/docs/latest/algorithms/template.md
+++ b/website/docs/latest/algorithms/template.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Template
-
-    
 ---
 
 TODO: Fill this out!

--- a/website/docs/latest/changelog.md
+++ b/website/docs/latest/changelog.md
@@ -1,19 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
+---
+layout: doc-page
+title: Changelog
+---
 
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ## Changelog
 
 Public releases are all root nodes.  

--- a/website/docs/latest/distributed/flink-bindings.md
+++ b/website/docs/latest/distributed/flink-bindings.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Mahout Samsara Flink Bindings
-
-    
 ---
 # Introduction
 

--- a/website/docs/latest/distributed/h2o-internals.md
+++ b/website/docs/latest/distributed/h2o-internals.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Mahout Samsara H20 Bindings
-
-    
 ---
 # Introduction
  

--- a/website/docs/latest/distributed/spark-bindings/faq.md
+++ b/website/docs/latest/distributed/spark-bindings/faq.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: FAQ
@@ -29,7 +13,7 @@ title: FAQ
 around classpath issues one way or another. 
 
 If you are getting method signature like errors, most probably you have mismatch between Mahout's Spark dependency 
-and actual Spark installed. (At the time of this writing the HEAD depends on Spark 1.1.0) but check mahout/pom.xml.
+and actual Spark installed. (At the time of this writing the HEAD depends on Spark 2.1.0) but check mahout/pom.xml.
 
 Troubleshooting general classpath issues is pretty straightforward. Since Mahout is using Spark's installation 
 and its classpath as reported by Spark itself for Spark-related dependencies, it is important to make sure 

--- a/website/docs/latest/distributed/spark-bindings/index.md
+++ b/website/docs/latest/distributed/spark-bindings/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Spark Bindings
-
-    
 ---
 
 # Scala & Spark Bindings:
@@ -117,4 +99,3 @@ TODO: Do we still want this? (I don't think so...)
 
 
 
-  

--- a/website/docs/latest/index.md
+++ b/website/docs/latest/index.md
@@ -1,19 +1,3 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Welcome to the Docs

--- a/website/docs/latest/mahout-samsara/faq.md
+++ b/website/docs/latest/mahout-samsara/faq.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Mahout Samsara
-
-    
 ---
+
 # FAQ for using Mahout with Spark
 
 **Q: Mahout Spark shell doesn't start; "ClassNotFound" problems or various classpath problems.**

--- a/website/docs/latest/mahout-samsara/in-core-reference.md
+++ b/website/docs/latest/mahout-samsara/in-core-reference.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Mahout Samsara In Core
-
-    
 ---
+
 ## Mahout-Samsara's In-Core Linear Algebra DSL Reference
 
 #### Imports

--- a/website/docs/latest/mahout-samsara/out-of-core-reference.md
+++ b/website/docs/latest/mahout-samsara/out-of-core-reference.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Mahout Samsara Out of Core
-
-    
 ---
+
 # Mahout-Samsara's Distributed Linear Algebra DSL Reference
 
 **Note: this page is meant only as a quick reference to Mahout-Samsara's R-Like DSL semantics.  For more information, including information on Mahout-Samsara's Algebraic Optimizer please see: [Mahout Scala Bindings and Mahout Spark Bindings for Linear Algebra Subroutines](http://mahout.apache.org/users/sparkbindings/ScalaSparkBindings.pdf).**

--- a/website/docs/latest/native-solvers/cuda.md
+++ b/website/docs/latest/native-solvers/cuda.md
@@ -1,22 +1,4 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Native Solvers- CUDA
-
-    
 ---

--- a/website/docs/latest/native-solvers/viennacl-omp.md
+++ b/website/docs/latest/native-solvers/viennacl-omp.md
@@ -1,22 +1,4 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Native Solvers- ViennaCL-OMP
-
-    
 ---

--- a/website/docs/latest/native-solvers/viennacl.md
+++ b/website/docs/latest/native-solvers/viennacl.md
@@ -1,22 +1,4 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Native Solvers- ViennaCL
-
-    
 ---

--- a/website/docs/latest/quickstart.md
+++ b/website/docs/latest/quickstart.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Quickstart
-
-    
 ---
+
 # Mahout Quick Start 
 # TODO : Fill this in with the bare essential basics
 

--- a/website/docs/latest/tutorials/cco-lastfm/index.md
+++ b/website/docs/latest/tutorials/cco-lastfm/index.md
@@ -1,27 +1,9 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: CCOs with Last.fm
-
-    
 ---
 
-Most reccomender examples utilize the MovieLense dataset, but that relies only on ratings (which makes the recommender being demonstrated look less trivial).  Right next to the MovieLense dataset is the LastFM data set.  The LastFM dataset has ratings by user, friends of the user, bands listened to by user, and tags by user.  This is the kind of exciting data set we’d like to work with!
+Most recommender examples utilize the MovieLense dataset, but that relies only on ratings (which makes the recommender being demonstrated look less trivial).  Right next to the MovieLense dataset is the LastFM data set.  The LastFM dataset has ratings by user, friends of the user, bands listened to by user, and tags by user.  This is the kind of exciting data set we’d like to work with!
 
 Start by downloading the LastFM dataset from 
 http://files.grouplens.org/datasets/hetrec2011/hetrec2011-lastfm-2k.zip

--- a/website/docs/latest/tutorials/eigenfaces/index.md
+++ b/website/docs/latest/tutorials/eigenfaces/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Eigenfaces Demo
-
-   
 ---
 
 *Credit: [original blog post by rawkintrevo](https://rawkintrevo.org/2016/11/10/deep-magic-volume-3-eigenfaces/). This will be maintained through version changes, blog post will not.*

--- a/website/docs/latest/tutorials/intro-cooccurrence-spark/index.md
+++ b/website/docs/latest/tutorials/intro-cooccurrence-spark/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Intro to Cooccurrence Recommenders with Spark
-
-    
 ---
 
 # Intro to Cooccurrence Recommenders with Spark

--- a/website/docs/latest/tutorials/map-reduce/classification/bankmarketing-example.md
+++ b/website/docs/latest/tutorials/map-reduce/classification/bankmarketing-example.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated) 
-
-    
 ---
 
 Notice:    Licensed to the Apache Software Foundation (ASF) under one

--- a/website/docs/latest/tutorials/map-reduce/classification/breiman-example.md
+++ b/website/docs/latest/tutorials/map-reduce/classification/breiman-example.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Breiman Example
-
-    
 ---
 
 #Breiman Example

--- a/website/docs/latest/tutorials/map-reduce/classification/twenty-newsgroups.md
+++ b/website/docs/latest/tutorials/map-reduce/classification/twenty-newsgroups.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Twenty Newsgroups
-
-    
 ---
 
 
@@ -192,4 +174,3 @@ If we wanted to use different parsing methods or transformations on the term fre
                 -c
 
  
-       

--- a/website/docs/latest/tutorials/map-reduce/classification/wikipedia-classifier-example.md
+++ b/website/docs/latest/tutorials/map-reduce/classification/wikipedia-classifier-example.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Wikipedia XML parser and Naive Bayes Example
-
-    
 ---
+
 # Wikipedia XML parser and Naive Bayes Classifier Example
 
 ## Introduction

--- a/website/docs/latest/tutorials/map-reduce/clustering/20newsgroups.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/20newsgroups.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  20Newsgroups
-
-   
 ---
 
 <a name="20Newsgroups-NaiveBayesusing20NewsgroupsData"></a>

--- a/website/docs/latest/tutorials/map-reduce/clustering/canopy-commandline.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/canopy-commandline.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  canopy-commandline
-
-   
 ---
 
 <a name="canopy-commandline-RunningCanopyClusteringfromtheCommandLine"></a>

--- a/website/docs/latest/tutorials/map-reduce/clustering/clustering-of-synthetic-control-data.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/clustering-of-synthetic-control-data.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Clustering of synthetic control data
-
-   
 ---
 
 # Clustering synthetic control data

--- a/website/docs/latest/tutorials/map-reduce/clustering/clustering-seinfeld-episodes.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/clustering-seinfeld-episodes.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Clustering Seinfeld Episodes
-
-   
 ---
 
 Below is short tutorial on how to cluster Seinfeld episode transcripts with

--- a/website/docs/latest/tutorials/map-reduce/clustering/clusteringyourdata.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/clusteringyourdata.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  ClusteringYourData
-
-   
 ---
 
 # Clustering your data

--- a/website/docs/latest/tutorials/map-reduce/clustering/fuzzy-k-means-commandline.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/fuzzy-k-means-commandline.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  fuzzy-k-means-commandline
-
-   
 ---
 
 <a name="fuzzy-k-means-commandline-RunningFuzzyk-MeansClusteringfromtheCommandLine"></a>

--- a/website/docs/latest/tutorials/map-reduce/clustering/k-means-commandline.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/k-means-commandline.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  k-means-commandline
-
-   
 ---
 
 <a name="k-means-commandline-Introduction"></a>

--- a/website/docs/latest/tutorials/map-reduce/clustering/lda-commandline.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/lda-commandline.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  lda-commandline
-
-   
 ---
 
 <a name="lda-commandline-RunningLatentDirichletAllocation(algorithm)fromtheCommandLine"></a>

--- a/website/docs/latest/tutorials/map-reduce/clustering/viewing-result.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/viewing-result.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Viewing Result
-
-   
 ---
 * [Algorithm Viewing pages](#ViewingResult-AlgorithmViewingpages)
 

--- a/website/docs/latest/tutorials/map-reduce/clustering/viewing-results.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/viewing-results.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Viewing Results
-
-   
 ---
+
 <a name="ViewingResults-Intro"></a>
 # Intro
 

--- a/website/docs/latest/tutorials/map-reduce/clustering/visualizing-sample-clusters.md
+++ b/website/docs/latest/tutorials/map-reduce/clustering/visualizing-sample-clusters.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Visualizing Sample Clusters
-
-   
 ---
 
 <a name="VisualizingSampleClusters-Introduction"></a>

--- a/website/docs/latest/tutorials/map-reduce/index.md
+++ b/website/docs/latest/tutorials/map-reduce/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Deprecated Map Reduce Based Examples
-
-    
 ---
 
 A note about the sunsetting of our support for Map Reduce.

--- a/website/docs/latest/tutorials/map-reduce/misc/mr---map-reduce.md
+++ b/website/docs/latest/tutorials/map-reduce/misc/mr---map-reduce.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  MR - Map Reduce
-
-   
 ---
 
 {excerpt}MapReduce is a framework for processing huge datasets on certain

--- a/website/docs/latest/tutorials/map-reduce/misc/parallel-frequent-pattern-mining.md
+++ b/website/docs/latest/tutorials/map-reduce/misc/parallel-frequent-pattern-mining.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Parallel Frequent Pattern Mining
-
-    
 ---
+
 Mahout has a Top K Parallel FPGrowth Implementation. Its based on the paper [http://infolab.stanford.edu/~echang/recsys08-69.pdf](http://infolab.stanford.edu/~echang/recsys08-69.pdf)
  with some optimisations in mining the data.
 

--- a/website/docs/latest/tutorials/map-reduce/misc/perceptron-and-winnow.md
+++ b/website/docs/latest/tutorials/map-reduce/misc/perceptron-and-winnow.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Perceptron and Winnow
-
-    
 ---
+
 <a name="PerceptronandWinnow-ClassificationwithPerceptronorWinnow"></a>
 # Classification with Perceptron or Winnow
 

--- a/website/docs/latest/tutorials/map-reduce/misc/testing.md
+++ b/website/docs/latest/tutorials/map-reduce/misc/testing.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Testing
-
-    
 ---
+
 <a name="Testing-Intro"></a>
 # Intro
 

--- a/website/docs/latest/tutorials/map-reduce/misc/using-mahout-with-python-via-jpype.md
+++ b/website/docs/latest/tutorials/map-reduce/misc/using-mahout-with-python-via-jpype.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Using Mahout with Python via JPype
-
-    
 ---
 
 <a name="UsingMahoutwithPythonviaJPype-overview"></a>

--- a/website/docs/latest/tutorials/map-reduce/recommender/intro-als-hadoop.md
+++ b/website/docs/latest/tutorials/map-reduce/recommender/intro-als-hadoop.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Perceptron and Winnow
-
-    
 ---
 
 # Introduction to ALS Recommendations with Hadoop

--- a/website/docs/latest/tutorials/map-reduce/recommender/intro-cooccurrence-spark.md
+++ b/website/docs/latest/tutorials/map-reduce/recommender/intro-cooccurrence-spark.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
-title: (Deprecated)  Perceptron and Winnow
-
-    
+title: Co-Occurrence With Spark
 ---
 
 #Intro to Cooccurrence Recommenders with Spark

--- a/website/docs/latest/tutorials/map-reduce/recommender/intro-itembased-hadoop.md
+++ b/website/docs/latest/tutorials/map-reduce/recommender/intro-itembased-hadoop.md
@@ -1,22 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
-title: (Deprecated)  Perceptron and Winnow
+title: (Deprecated)  Item Based Reccommenders in Hadoop
 
     
 ---

--- a/website/docs/latest/tutorials/map-reduce/recommender/matrix-factorization.md
+++ b/website/docs/latest/tutorials/map-reduce/recommender/matrix-factorization.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
-title: (Deprecated)  Perceptron and Winnow
-
-    
+title: Matrix Factorization
 ---
+
 <a name="MatrixFactorization-Intro"></a>
 # Introduction to Matrix Factorization for Recommendation Mining
 

--- a/website/docs/latest/tutorials/map-reduce/recommender/quickstart.md
+++ b/website/docs/latest/tutorials/map-reduce/recommender/quickstart.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Recommender Quickstart
-
-    
 ---
 
 # Recommender Overview

--- a/website/docs/latest/tutorials/map-reduce/recommender/recommender-documentation.md
+++ b/website/docs/latest/tutorials/map-reduce/recommender/recommender-documentation.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Recommender Documentation
-
-    
 ---
 
 <a name="RecommenderDocumentation-Overview"></a>

--- a/website/docs/latest/tutorials/map-reduce/recommender/recommender-first-timer-faq.md
+++ b/website/docs/latest/tutorials/map-reduce/recommender/recommender-first-timer-faq.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  Recommender First-Timer FAQ
-
-    
 ---
 
 # Recommender First Timer Dos and Don'ts

--- a/website/docs/latest/tutorials/map-reduce/recommender/userbased-5-minutes.md
+++ b/website/docs/latest/tutorials/map-reduce/recommender/userbased-5-minutes.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: (Deprecated)  User Based Recommender in 5 Minutes
-
-    
 ---
 
 # Creating a User-Based Recommender in 5 minutes

--- a/website/docs/latest/tutorials/misc/contributing-algos/index.md
+++ b/website/docs/latest/tutorials/misc/contributing-algos/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Contributing new algorithms
-
-    
 ---
 
 The Mahout community is driven by user contribution.  If you have implemented an algorithm and are interested in 

--- a/website/docs/latest/tutorials/misc/how-to-build-an-app.md
+++ b/website/docs/latest/tutorials/misc/how-to-build-an-app.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Mahout Samsara In Core
-
-    
 ---
+
 # How to create and App using Mahout
 
 This is an example of how to create a simple app using Mahout as a Library. The source is available on Github in the [3-input-cooc project](https://github.com/pferrel/3-input-cooc) with more explanation about what it does (has to do with collaborative filtering). For this tutorial we'll concentrate on the app rather than the data science.

--- a/website/docs/latest/tutorials/misc/mahout-in-zeppelin/index.md
+++ b/website/docs/latest/tutorials/misc/mahout-in-zeppelin/index.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Visualizing Mahout in Zeppelin
-
-    
 ---
 
 

--- a/website/docs/latest/tutorials/samsara/classify-a-doc-from-the-shell.md
+++ b/website/docs/latest/tutorials/samsara/classify-a-doc-from-the-shell.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Text Classification Example
-
-    
 ---
 
 # Building a text classifier in Mahout's Spark Shell

--- a/website/docs/latest/tutorials/samsara/play-with-shell.md
+++ b/website/docs/latest/tutorials/samsara/play-with-shell.md
@@ -1,25 +1,8 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Mahout Samsara In Core
-
-    
 ---
+
 # Playing with Mahout's Spark Shell 
 
 This tutorial will show you how to play with Mahout's scala DSL for linear algebra and its Spark shell. **Please keep in mind that this code is still in a very early experimental stage**.

--- a/website/docs/latest/tutorials/samsara/playing-with-samsara-flink-batch.md
+++ b/website/docs/latest/tutorials/samsara/playing-with-samsara-flink-batch.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: 
-
-   
 ---
 
 ## Getting Started 

--- a/website/docs/latest/tutorials/samsara/spark-naive-bayes.md
+++ b/website/docs/latest/tutorials/samsara/spark-naive-bayes.md
@@ -1,24 +1,6 @@
-<!--
- Licensed to the Apache Software Foundation (ASF) under one or more
- contributor license agreements.  See the NOTICE file distributed with
- this work for additional information regarding copyright ownership.
- The ASF licenses this file to You under the Apache License, Version 2.0
- (the "License"); you may not use this file except in compliance with
- the License.  You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
--->
 ---
 layout: doc-page
 title: Spark Naive Bayes
-
-    
 ---
 
 # Spark Naive Bayes


### PR DESCRIPTION
### Purpose of PR:
Adding ASF headers really borked the website- Removing, hopefully I got them all but may have missed a few. Will do research on how to add them back safely. 


