### PR TITLE
[no-jira] update gitaction to build from main instead of trunk

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -21,7 +21,7 @@ name: Website
 on:
   push:
     branches:
-      - trunk
+      - main
 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel


### PR DESCRIPTION
will now build from main branch instead of trunk.

### Purpose of PR:
Please give a short description of what this PR is for.
hot fix to update website to build from `main` instead of trunk. 

if jira metrics matter I can go make a ticket. 

also- we need to update this pr template (java/scala docs no longer relvant, but other docs are)

### Important ToDos
Please mark each with an "x"
- [ ] A JIRA ticket exists (if not, please create this first)[https://issues.apache.org/jira/browse/mahout/]
- [ ] Title of PR is "MAHOUT-XXXX Brief Description of Changes" where XXXX is the JIRA number.
- [ ] Created unit tests where appropriate
- [ ] Added licenses correct on newly added files
- [ ] Assigned JIRA to self
- [ ] Added documentation in scala docs/java docs, and to website
- [ ] Successfully built and ran all unit tests, verified that all tests pass locally.

If all of these things aren't complete, but you still feel it is
appropriate to open a PR, please add [WIP] after MAHOUT-XXXX before the
descriptions- e.g. "MAHOUT-XXXX [WIP] Description of Change"

Does this change break earlier versions?

Is this the beginning of a larger project for which a feature branch should be made?
