### PR TITLE
Updated Basic Gates section and Q3 roadmap to include Cirq, Qiskit, and Braket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For additional information about Mahout, visit the [Mahout Home Page](http://mah
 
 QuMat is a POC of a high level Python library for intefacing with multiple quantum computing backends. It is designed to be easy to use and to abstract the particularities of each backend, so that you may 'write once, run anywhere.' Like the Java of quantum computing, but Java is the new COBOL so we're trying to distance ourselves from that comparison :P
 
-Check out [basic gates](docs/basic_gates.md) for a quick introduction to the basic gates which are basically all that exist right now (and even those only exist for `qiskit`).
+Check out [basic gates](docs/basic_gates.md) for a quick introduction to the basic gates. These are now supported across multiple quantum computing frameworks, including Qiskit, Cirq, and Amazon Braket.
 
 ## Getting started
 
@@ -44,7 +44,7 @@ poetry install
 - [x] Transition of Classic to maintenance mode
 
 ### Q3
-- [ ] Integration of Qumat with hardened (tests, docs, CI/CD) cirq and qiskit backends
+- [ ] Integration of Qumat with hardened (tests, docs, CI/CD) Cirq, Qiskit, and Amazon Braket backends
 - [ ] Initiation of kernel methods
 - [x] Integration with Amazon Braket
 - [x] [Public talk about Qumat](https://2024.fossy.us/schedule/presentation/265/)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ For additional information about Mahout, visit the [Mahout Home Page](http://mah
 
 QuMat is a POC of a high level Python library for intefacing with multiple quantum computing backends. It is designed to be easy to use and to abstract the particularities of each backend, so that you may 'write once, run anywhere.' Like the Java of quantum computing, but Java is the new COBOL so we're trying to distance ourselves from that comparison :P
 
-Check out [basic gates](docs/basic_gates.md) for a quick introduction to the basic gates. These are now supported across multiple quantum computing frameworks, including Qiskit, Cirq, and Amazon Braket.
+Check out [basic gates](docs/basic_gates.md) for a quick introduction to the basic gates. These are now supported across multiple quantum computing frameworks, including Qiskit, Cirq, and Braket.
 
 ## Getting started
 
@@ -44,7 +44,7 @@ poetry install
 - [x] Transition of Classic to maintenance mode
 
 ### Q3
-- [ ] Integration of Qumat with hardened (tests, docs, CI/CD) Cirq, Qiskit, and Amazon Braket backends
+- [ ] Integration of Qumat with hardened (tests, docs, CI/CD) Cirq, Qiskit, and Braket backends
 - [ ] Initiation of kernel methods
 - [x] Integration with Amazon Braket
 - [x] [Public talk about Qumat](https://2024.fossy.us/schedule/presentation/265/)


### PR DESCRIPTION
### Purpose of PR:
This pull request updates the documentation to reflect recent changes in the supported quantum computing frameworks for basic gates and backend integrations.

Changes made:
1. **Basic Gates Section**: Updated the section to clarify that basic gates are no longer exclusive to Qiskit. Now, they are supported across multiple quantum computing frameworks, including **Qiskit**, **Cirq**, and **Amazon Braket**. This ensures that users are aware of the broader support for basic gates in various platforms.
   
2. **Q3 Roadmap**: The roadmap for Q3 has been modified to reflect that **Amazon Braket** is now also supported along with **Cirq** and **Qiskit**. This update ensures the documentation is consistent with the latest developments and integrations.

These changes help keep the documentation aligned with the actual state of the project and support for multiple quantum computing platforms.
