### PR TITLE
Fixed Logo Alignment by Adjusting Height

### DIFF
--- a/website/_includes/posts/post-preview.html
+++ b/website/_includes/posts/post-preview.html
@@ -3,7 +3,7 @@
     <div class="row no-gutters">
       <div class="col-3 d-none d-md-flex my-auto card-post-img">
         {% if post.image %}
-          <img class="rounded-circle img-fluid d-flex mx-auto" src="{{ post.image }}">
+          <img class="rounded-circle img-fluid d-flex mx-auto" src="{{ post.image }}" style="height:200px">
         {% else %}
           <img class="rounded-circle img-fluid d-flex mx-auto" src="/assets/mahout-logo-blue.svg">
         {% endif %}

--- a/website/_includes/posts/post-preview.html
+++ b/website/_includes/posts/post-preview.html
@@ -3,7 +3,7 @@
     <div class="row no-gutters">
       <div class="col-3 d-none d-md-flex my-auto card-post-img">
         {% if post.image %}
-          <img class="rounded-circle img-fluid d-flex mx-auto" src="{{ post.image }}" style="height:200px">
+          <img class="rounded-circle img-fluid d-flex mx-auto" src="{{ post.image }}">
         {% else %}
           <img class="rounded-circle img-fluid d-flex mx-auto" src="/assets/mahout-logo-blue.svg">
         {% endif %}

--- a/website/assets/css/main.scss
+++ b/website/assets/css/main.scss
@@ -3,6 +3,11 @@
 
 @import "mahout";
 
+
+.rounded-circle{
+  height: 200px;
+}
+
 table {
   border-collapse: collapse;
   width: 100%;

--- a/website/documentation/users/index.md
+++ b/website/documentation/users/index.md
@@ -26,11 +26,11 @@ library for your machine learning projects.
 2. **Data Preparation**: Learn how to prepare your data for processing with Mahout, including importing, preprocessing, and transforming your datasets.
 3. **Algorithm Selection**: We provide an overview of the available algorithms in Mahout, along with guidance on selecting the best algorithm for your specific problem.
 4. **Model Training and Evaluation**: Understand how to train, validate, and evaluate machine learning models using Mahout's tools and best practices.
-5. **Deployment**: Explore various options for deploying your trained models, such as integrating with web services or embedding within your applications.
+5. **Deployment**: Explore various options for deploying your trained models, such as integrating with web services or embedding them within your applications.
 
 By following this User's Guide, you will gain the necessary knowledge and skills to effectively leverage Apache Mahout 
 for your machine learning projects, harnessing the power of big data processing to achieve better results.
-
+ 
 ## Index
 
 [Index](/documentation/users/index.html)


### PR DESCRIPTION
There was an issue where the logo wasn’t aligned properly, and the last word of the mahout next to it was partially visible (cut off). I fixed it by simply adjusting the height of the logo. Now everything looks good, and the logo is aligned properly.

**Before:**
![Screenshot 2025-03-11 145358](https://github.com/user-attachments/assets/8f3d3338-9ff0-46e4-be48-c0900ec46315)
Logo was misaligned, and the mahout was partially cut off.

**After:**
![Screenshot 2025-03-11 150051](https://github.com/user-attachments/assets/ff85d750-e189-4e1c-a6e5-fb825994a747)
Logo is now properly aligned, and the mahout is fully visible.