### PR TITLE
HOTFIX: Add import to init file

### DIFF
--- a/qumat/__init__.py
+++ b/qumat/__init__.py
@@ -1,0 +1,1 @@
+from . import Qumat

--- a/qumat/__init__.py
+++ b/qumat/__init__.py
@@ -1,1 +1,1 @@
-from .qumat import Qumat
+from .qumat import QuMat

--- a/qumat/__init__.py
+++ b/qumat/__init__.py
@@ -1,1 +1,1 @@
-from . import Qumat
+from .qumat import Qumat


### PR DESCRIPTION
### Purpose of PR  

When I installed/tested RC
```python
from qumat import QuMat
```

fails but

```python
from qumat.qumat import QuMat
```

works- which would break examples. Candidly, idk how they worked before (?)

### Linked Issues  

None - hotfix

### Changes Made  
- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  

### Important ToDos
Please mark each with an "x"  

A GitHub issue exists (if not, please create one) [https://github.com/apache/mahout/issues]  
- [ ] Title of PR is "Issue #XXXX: Brief Description of Changes" where XXXX is the GitHub issue number.  
- [ ] Created unit tests where appropriate  
- [ ] Added correct licenses on newly added files  
- [ ] Assigned GitHub issue to self  
- [ ] Added documentation in ScalaDocs/JavaDocs and to the website  
- [ ] Successfully built and ran all unit tests, verified that all tests pass locally  

If all of these items are not yet complete, but you still feel it is appropriate to open a PR, please open it as a **Draft PR** instead.  
Once all requirements are met, you can mark it as ready for review.


### Breaking Changes  
Does this PR introduce a breaking change?
- [ ] Yes  
- [ ] No  

### Testing & Verification  
Describe how you tested the changes.
- [ ] Unit tests added  
- [ ] Manually tested  

### Checklist  
- [ ] The title follows the format "MAHOUT-XXXX Brief Description"  
- [ ] GitHub issue is created
- [ ] Code follows ASF guidelines  
