### PR TITLE
Update deprecated-docs.html

### DIFF
--- a/website/_layouts/deprecated-docs.html
+++ b/website/_layouts/deprecated-docs.html
@@ -1,7 +1,7 @@
 ---
 layout: doc-default
 ---
-<div style="background-color: #fff3cd; color: #856404; border: 1px solid #ffeeba; padding: 15px; border-radius: 5px; margin-bottom: 20px;"> <strong>⚠️ Deprecation Notice:</strong> This component (<em>Mahout/Samsara</em>) is no longer actively maintained. It remains accessible for historical reference but is not recommended for new development. Please check out <a href="https://mahout.apache.org/quantum-computing-primer/" style="color: #0c5460; text-decoration: underline;">Qumat - Mahout's Quantum Computing Primer</a> for the latest innovations.</div>
+<div style="background-color: #fff3cd; color: #856404; border: 1px solid #ffeeba; padding: 15px; border-radius: 5px; margin-bottom: 20px;"> <strong>⚠️ Deprecation Notice:</strong> This component (<em>MapReduce/Samsara</em>) is no longer actively maintained. It remains accessible for historical reference but is not recommended for new development. Please check out <a href="https://mahout.apache.org/quantum-computing-primer/" style="color: #0c5460; text-decoration: underline;">Qumat - Mahout's Quantum Computing Primer</a> for the latest innovations.</div>
 <div class="container mt-5 pb-4">
 
   <div class="row">


### PR DESCRIPTION
This PR fixes a small but important typo in the deprecation banner used across legacy documentation pages #529  .

Previously, the banner incorrectly read:

“This component (Mahout/Samsara) is no longer actively maintained...”

It has now been corrected to:

“This component (MapReduce/Samsara) is no longer actively maintained...”

The term "Mahout" was mistakenly used instead of "MapReduce," which could cause confusion since Mahout as a whole is still active and evolving (especially with Qumat).

✅ The fix is live in the shared layout to ensure consistency across all deprecated pages.