### PR TITLE
Fix Qiskit deprecation warnings by replacing deprecated execute()

### DIFF
--- a/qumat/qiskit_backend.py
+++ b/qumat/qiskit_backend.py
@@ -76,13 +76,13 @@ def execute_circuit(circuit, backend, backend_config):
         # Parse the global parameter configuration
         parameter_bindings = {param: backend_config['parameter_values'][str(param)] for param in circuit.parameters}
         transpiled_circuit = qiskit.transpile(circuit, backend)
-        qobj = qiskit.assemble(transpiled_circuit, parameter_binds=[parameter_bindings], shots=backend_config['backend_options']['shots'])
-        job = backend.run(qobj)
+        bound_circuit = transpiled_circuit.assign_parameters(parameter_bindings)
+        job = backend.run(bound_circuit, shots=backend_config['backend_options']['shots'])
         result = job.result()
         return result.get_counts()
     else:
         transpiled_circuit = qiskit.transpile(circuit, backend)
-        job = qiskit.execute(transpiled_circuit, backend, shots=backend_config['backend_options']['shots'])
+        job = backend.run(transpiled_circuit, shots=backend_config['backend_options']['shots'])
         result = job.result()
         return result.get_counts()
 
@@ -91,7 +91,8 @@ def get_final_state_vector(circuit, backend, backend_config):
     simulator = qiskit.Aer.get_backend('statevector_simulator')
 
     # Simulate the circuit
-    job = qiskit.execute(circuit, simulator)
+    transpiled_circuit = qiskit.transpile(circuit, simulator)
+    job = simulator.run(transpiled_circuit)
     result = job.result()
 
     return result.get_statevector()

--- a/testing/qiskit_helpers.py
+++ b/testing/qiskit_helpers.py
@@ -16,7 +16,7 @@
 #
 
 # Import necessary Qiskit libraries
-from qiskit import Aer, QuantumCircuit, execute
+from qiskit import Aer, QuantumCircuit, transpile
 from qiskit.quantum_info import Statevector
 
 def get_qumat_backend_config(test_type: str = "get_final_state_vector"):
@@ -59,7 +59,8 @@ def get_native_example_final_state_vector(initial_state_ket_str: str = "000") ->
     qc.h(0)  # Apply Hadamard gate on qubit 0
 
     # Simulate the circuit
-    job = execute(qc, simulator)
+    transpiled_qc = transpile(qc, simulator)
+    job = simulator.run(transpiled_qc)
     result = job.result()
 
     # Get the state vector


### PR DESCRIPTION
### Purpose of PR  
- Replace deprecated qiskit.execute() calls with modern transpile() + backend.run() approach
- Update parameter binding to use assign_parameters() instead of deprecated assemble()
- Modernize test helper functions to follow current Qiskit best practices
