### PR TITLE
Fix quantum teleportation example to use explicit Pauli gate

### DIFF
--- a/examples/quantum_teleportation.py
+++ b/examples/quantum_teleportation.py
@@ -46,9 +46,9 @@ receiver_quantum_computer.create_empty_circuit(3)
 # Apply X and Z gates based on the received measurement results
 received_measurement_results = [0, 1]  # Simulated measurement results
 if received_measurement_results[1] == 1:
-    receiver_quantum_computer.apply_x_gate(2)
+    receiver_quantum_computer.apply_pauli_x_gate(2)
 if received_measurement_results[0] == 1:
-    receiver_quantum_computer.apply_z_gate(2)
+    receiver_quantum_computer.apply_pauli_z_gate(2)
 
 # The state on qubit 2 now matches the original state on qubit 0
 


### PR DESCRIPTION
### Purpose of PR  

Fix the quantum teleportation example to use the correct method names for Pauli gates. The example was using incorrect method names (`apply_x_gate` and `apply_z_gate`) instead of the existing API methods (`apply_pauli_x_gate` and `apply_pauli_z_gate`).

### Linked Issues  
Add links to related issues.

### Changes Made  
- [x] Bug fix  
- [ ] New feature  
- [ ] Documentation update  

### Important ToDos
Please mark each with an "x"  

A GitHub issue exists (if not, please create one) [https://github.com/apache/mahout/issues]  
- [ ] Title of PR is "Issue #XXXX: Brief Description of Changes" where XXXX is the GitHub issue number.  
- [ ] Created unit tests where appropriate  
- [ ] Added correct licenses on newly added files  
- [ ] Assigned GitHub issue to self  
- [ ] Added documentation in ScalaDocs/JavaDocs and to the website  
- [x] Successfully built and ran all unit tests, verified that all tests pass locally  

If all of these items are not yet complete, but you still feel it is appropriate to open a PR, please open it as a **Draft PR** instead.  
Once all requirements are met, you can mark it as ready for review.


### Breaking Changes  
Does this PR introduce a breaking change?
- [ ] Yes  
- [x] No  

### Testing & Verification  
Describe how you tested the changes.
- [ ] Unit tests added  
- [x] Manually tested  

### Checklist  
- [ ] The title follows the format "MAHOUT-XXXX Brief Description"  
- [ ] GitHub issue is created
- [x] Code follows ASF guidelines  
