### PR TITLE
MAHOUT-608: handle 0-qubit circuits in cirq backend to prevent crash

### DIFF
--- a/qumat/cirq_backend.py
+++ b/qumat/cirq_backend.py
@@ -96,6 +96,11 @@ def apply_pauli_z_gate(circuit, qubit_index):
 
 
 def execute_circuit(circuit, backend, backend_config):
+    # handle 0-qubit circuits before adding measurements
+    if not circuit.all_qubits():
+        shots = backend_config["backend_options"].get("shots", 1)
+        return [{0: shots}]
+
     # Ensure measurement is added to capture the results
     if not circuit.has_measurements():
         circuit.append(cirq.measure(*circuit.all_qubits(), key="result"))


### PR DESCRIPTION
### Purpose
Fixes crash in Cirq backend when executing 0-qubit circuits with measurements.

### Related Issues
closes #608 

### Changes Made
- Added guard in `execute_circuit()` to handle empty circuits before adding measurements
- Returns Cirq-formatted result `[{0: shots}]` for 0-qubit case
- Prevents crash when `cirq.measure()` is called on empty qubit list

### Technical Details
The issue occurred at line 106 where `circuit.append(cirq.measure(*circuit.all_qubits(), key="result"))` crashes on empty circuits because `circuit.all_qubits()` returns an empty list.

This fix aligns with existing behavior in the main `QuMat` class (lines 92-97 in `qumat.py`) which already handles 0-qubit circuits. Moving this logic to the backend makes it self-contained and robust.

### Breaking Changes
None. This is a bug fix that maintains existing behavior.

### Checklist
- [x] Code follows project style guidelines
- [x] Changes are minimal and focused on the issue
- [x] Implementation aligns with maintainer feedback
- [x] No breaking changes introduced