### PR TITLE
MAHOUT-621: Error message in execute_circuit() is not clear 

### DIFF
--- a/qumat/qumat.py
+++ b/qumat/qumat.py
@@ -98,7 +98,25 @@ class QuMat:
 
         if parameter_values:
             self.bind_parameters(parameter_values)
-        self.backend_config["parameter_values"] = self.parameters  # Pass parameters
+
+        # Only pass bound parameters (non-None values) to backend
+        bound_parameters = {
+            param: value
+            for param, value in self.parameters.items()
+            if value is not None
+        }
+
+        # Check if there are unbound parameters in the circuit
+        if self.parameters and not bound_parameters:
+            unbound_params = [
+                p for p in self.parameters.keys() if self.parameters[p] is None
+            ]
+            raise ValueError(
+                f"Circuit contains unbound parameters: {unbound_params}. "
+                f"Please provide parameter_values when executing the circuit."
+            )
+
+        self.backend_config["parameter_values"] = bound_parameters
         return self.backend_module.execute_circuit(
             self.circuit, self.backend, self.backend_config
         )


### PR DESCRIPTION
### Purpose of PR
<!-- Describe what this PR does. -->
If a circuit contains parameterized gates but no parameter_values is provided.
self.parameters will contain {'theta': None}.
Original code passes all parameters (including None values) to backend.
Backend receives None and throws unclear error:`TypeError: Cannot wrap None into literal type`
This PR is for fixing the problem.

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
<!-- - Related to #123   -->
Closes #621 

### Changes Made
<!-- Please mark one with an "x"   -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [ ] Successfully built and ran all unit tests or manual tests locally
- [x] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [ ] Code follows ASF guidelines
