### PR TITLE
MAHOUT-632: fix qiskit measurement duplication

### DIFF
--- a/qumat/qiskit_backend.py
+++ b/qumat/qiskit_backend.py
@@ -87,7 +87,12 @@ def apply_pauli_z_gate(circuit, qubit_index):
 
 def execute_circuit(circuit, backend, backend_config):
     # Add measurements if they are not already present
-    if not circuit.cregs:
+    # Check if circuit already has measurement operations
+    has_measurements = any(
+        isinstance(inst.operation, qiskit.circuit.Measure)
+        for inst in circuit.data
+    )
+    if not has_measurements:
         circuit.measure_all()
 
     # Ensure the circuit is parameterized properly


### PR DESCRIPTION
### Purpose of PR

Prevent duplicate measurement operations when running Qiskit circuits multiple times by detecting existing `Measure` instructions before calling `measure_all()`. This keeps the circuit structure stable and ensures consistent measurement results across repeated executions.

### Related Issues or PRs

- Fixes #632 

### Changes Made

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes

- [ ] Yes
- [x] No