### PR TITLE
MAHOUT-682 : add missing QuMat APIs

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -84,7 +84,7 @@
 
 ## `get_final_state_vector(self)`
 - **Purpose**: Returns the final state vector of the circuit from the configured backend.
-- **Usage**: Retrieve the full quantum state for simulation and analysis workflows.
+- **Usage**: Retrieves the full quantum state for simulation and analysis workflows.
 
 ## `draw_circuit(self)`
 - **Purpose**: Visualizes the quantum circuit.


### PR DESCRIPTION
### Purpose of PR
document missing QuMat APIs: `apply_cswap_gate`, `apply_t_gate`, `get_final_state_vector`, `apply_u_gate`, `swap_test`, `measure_overlap`; align API docs with currently implemented methods in `qumat.QuMat`

### Related Issues or PRs
Closes #682

### Changes Made
<!-- Please mark one with an "x"   -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
- [ ] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [x] Code follows ASF guidelines
