### PR TITLE
[bug] In-place Circuit Mutation

### DIFF
--- a/qumat/qiskit_backend.py
+++ b/qumat/qiskit_backend.py
@@ -92,11 +92,12 @@ def apply_t_gate(circuit, qubit_index):
 
 def execute_circuit(circuit, backend, backend_config):
     working_circuit = circuit.copy()
-    
+
     # Add measurements if they are not already present
     # Check if circuit already has measurement operations
     has_measurements = any(
-        isinstance(inst.operation, qiskit.circuit.Measure) for inst in working_circuit.data
+        isinstance(inst.operation, qiskit.circuit.Measure)
+        for inst in working_circuit.data
     )
     if not has_measurements:
         working_circuit.measure_all()
@@ -127,7 +128,7 @@ def execute_circuit(circuit, backend, backend_config):
 # placeholder method for use in the testing suite
 def get_final_state_vector(circuit, backend, backend_config):
     working_circuit = circuit.copy()
-    
+
     simulator = AerSimulator(method="statevector")
 
     # Add save_statevector instruction


### PR DESCRIPTION
### Purpose of PR
<!-- Describe what this PR does. -->
This is a common pitfall in Qiskit development. Because QuantumCircuit objects are passed by reference in Python, methods like measure_all() or save_statevector() modify the original object, which can break iterative workflows (like Variational Quantum Eigensolvers or Trotterization) where the same base circuit is reused.
### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
<!-- - Related to #123   -->
Closes #770 

### Changes Made
<!-- Please mark one with an "x"   -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [ ] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [ ] Code follows ASF guidelines
