### PR TITLE
[QDP] Fix Route Error in Makefile

### DIFF
--- a/qdp/Makefile
+++ b/qdp/Makefile
@@ -43,7 +43,7 @@ test_rust:
 	cargo test --workspace
 
 install_benchmark:
-	cd qdp/qdp-python && uv sync --group benchmark
+	cd qdp-python && uv sync --group benchmark
 
 benchmark: install install_benchmark
 	@echo "Running e2e benchmark tests..."


### PR DESCRIPTION
### Purpose of PR
as title

error:
make install_benchmark
```
cd qdp/qdp-python && uv sync --group benchmark
/bin/sh: 1: cd: can't cd to qdp/qdp-python
make: *** [Makefile:46: install_benchmark] Error 2
```

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
<!-- - Related to #123   -->

### Changes Made
<!-- Please mark one with an "x"   -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [ ] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [ ] Code follows ASF guidelines
