### PR TITLE
[QDP] Fix latency benchmark to use batch encoding

### DIFF
--- a/qdp/Cargo.lock
+++ b/qdp/Cargo.lock
@@ -938,6 +938,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "numpy"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7aac2e6a6e4468ffa092ad43c39b81c79196c2bb773b8db4085f695efe3bba17"
+dependencies = [
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "pyo3",
+ "pyo3-build-config",
+ "rustc-hash",
+]
+
+[[package]]
 name = "nvtx"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1174,6 +1190,7 @@ dependencies = [
 name = "qdp-python"
 version = "0.1.0"
 dependencies = [
+ "numpy",
  "pyo3",
  "qdp-core",
 ]
@@ -1247,6 +1264,12 @@ name = "regex-syntax"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"

--- a/qdp/qdp-python/Cargo.toml
+++ b/qdp/qdp-python/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 pyo3 = { version = "0.27", features = ["extension-module"] }
+numpy = "0.27"
 qdp-core = { path = "../qdp-core" }
 
 [features]


### PR DESCRIPTION
### Purpose of PR

- Added encode_batch() method to Python bindings accepting NumPy 2D array directly (zero-copy)
- Updated `run_mahout()` to process entire batch in single GPU kernel call

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
<!-- - Related to #123   -->

### Changes Made
<!-- Please mark one with an "x"   -->
- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
- [x] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [x] Code follows ASF guidelines
