### PR TITLE
MAHOUT-831 Update backend initialization to support legacy simulator types in AerSimulator

### DIFF
--- a/qumat/qiskit_backend.py
+++ b/qumat/qiskit_backend.py
@@ -15,14 +15,27 @@
 # limitations under the License.
 #
 import qiskit
-from qiskit_aer import Aer, AerSimulator
+from qiskit_aer import AerSimulator
 
 
 def initialize_backend(backend_config):
     backend_options = backend_config["backend_options"]
     simulator_type = backend_options["simulator_type"]
     shots = backend_options["shots"]
-    backend = Aer.get_backend(simulator_type)
+
+    # Map legacy simulator types to AerSimulator methods
+    simulator_methods = {
+        "aer_simulator": "automatic",
+        "statevector_simulator": "statevector",
+        "qasm_simulator": "automatic",
+        "unitary_simulator": "unitary",
+    }
+
+    if simulator_type in simulator_methods:
+        backend = AerSimulator(method=simulator_methods[simulator_type])
+    else:
+        backend = AerSimulator(method=simulator_type)
+
     backend.shots = shots
     return backend
 


### PR DESCRIPTION
### Purpose of PR
  1. Replaced deprecated Aer.get_backend() with AerSimulator(method=...) - The StatevectorSimulator and other legacy backends are deprecated in favor of the unified AerSimulator class.
  2. Added mapping for legacy simulator types:
    - aer_simulator → automatic
    - statevector_simulator → statevector
    - qasm_simulator → automatic
    - unitary_simulator → unitary
  3. Removed unused Aer import

### Related Issues or PRs
Closes #831 

### Changes Made
<!-- Please mark one with an "x"   -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [ ] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [ ] Code follows ASF guidelines
