### PR TITLE
Include .htaccess in Jekyll build for custom 404

### DIFF
--- a/website/_config.yml
+++ b/website/_config.yml
@@ -50,6 +50,9 @@ plugins:
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list
 # to override the default setting.
+include:
+  - .htaccess
+
 exclude:
   - Gemfile
   - Gemfile.lock


### PR DESCRIPTION
### Purpose of PR

**Why**

Jekyll excludes dotfiles by default. The `.htaccess` file containing `ErrorDocument 404
 /404.html` was not being copied to `_site/`, so Apache served its default 404 instead of our custom page.

**How**

Added `.htaccess` to the `include` list in `_config.yml` so it gets copied to the build output.

https://github.com/user-attachments/assets/9ed4c7b1-154f-4b40-99c9-0f1ac34ef80e

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
- Related to #835

### Changes Made
<!-- Please mark one with an "x"   -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [x] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [x] Code follows ASF guidelines
