### PR TITLE
Fix custom 404 page not being served on production

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -45,7 +45,7 @@ jobs:
         ./website/build_site.sh
         rm -rf *
         git checkout asf-site
-        cp -r $WORKDIR/* .
+        cp -r $WORKDIR/. .
         git add .
         git commit -m "Automatic Site Publish by Buildbot"
         git push


### PR DESCRIPTION
### Purpose of PR

**Why**

The .htaccess file wasn’t reaching production because the Bash glob * doesn’t include hidden files. As a result, the 404 redirection worked locally but failed in production since .htaccess wasn’t present on the asf-site branch.

**How**

Change CI copy from `cp -r $WORKDIR/* .` to `cp -r $WORKDIR/. .` to include hidden files

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
- Related to #835 

### Changes Made
<!-- Please mark one with an "x"   -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [x] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [x] Code follows ASF guidelines
