### PR TITLE
[QDP] Fix unused field warning in TorchReader

### DIFF
--- a/qdp/qdp-core/src/readers/torch.rs
+++ b/qdp/qdp-core/src/readers/torch.rs
@@ -27,6 +27,8 @@ use crate::reader::DataReader;
 
 /// Reader for PyTorch `.pt`/`.pth` tensor files.
 pub struct TorchReader {
+    /// Path to the PyTorch file. Used only when the `pytorch` feature is enabled.
+    #[allow(dead_code)]
     path: std::path::PathBuf,
     read: bool,
     num_samples: Option<usize>,


### PR DESCRIPTION
### Purpose of PR

Suppress the dead_code warning for the `path` field in TorchReader. The field is used when the `pytorch` feature is enabled, but the compiler doesn't see it due to conditional compilation.

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
- Related to #815 

### Changes Made
<!-- Please mark one with an "x"   -->
- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [x] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
- [x] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [x] Code follows ASF guidelines
