### PR TITLE
MAHOUT-861 Merge qdp-dev into dev dependency-groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ git clone https://github.com/apache/mahout.git
 cd mahout
 pip install uv
 uv sync                     # Core Qumat
-uv sync --group qdp         # With QDP (requires CUDA GPU)
+uv sync --extra qdp         # With QDP (requires CUDA GPU)
 ```
 
 ### Qumat: Run a quantum circuit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,10 @@ dependencies = [
 qdp = ["qumat-qdp"]
 
 [dependency-groups]
-dev = ["pytest>=9.0.1", "ruff>=0.13.1", "pre-commit>=3.0.0"]
-qdp-dev = [
+dev = [
+    "pytest>=9.0.1",
+    "ruff>=0.13.1",
+    "pre-commit>=3.0.0",
     "maturin>=1.10.2",
     "patchelf>=0.17.2.4",
     "torch>=2.2",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -1679,14 +1679,12 @@ qdp = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "pre-commit" },
-    { name = "pytest" },
-    { name = "ruff" },
-]
-qdp-dev = [
     { name = "maturin" },
     { name = "numpy" },
     { name = "patchelf" },
+    { name = "pre-commit" },
+    { name = "pytest" },
+    { name = "ruff" },
     { name = "torch" },
 ]
 
@@ -1703,14 +1701,12 @@ provides-extras = ["qdp"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pre-commit", specifier = ">=3.0.0" },
-    { name = "pytest", specifier = ">=9.0.1" },
-    { name = "ruff", specifier = ">=0.13.1" },
-]
-qdp-dev = [
     { name = "maturin", specifier = ">=1.10.2" },
     { name = "numpy", specifier = ">=1.24,<2.0" },
     { name = "patchelf", specifier = ">=0.17.2.4" },
+    { name = "pre-commit", specifier = ">=3.0.0" },
+    { name = "pytest", specifier = ">=9.0.1" },
+    { name = "ruff", specifier = ">=0.13.1" },
     { name = "torch", specifier = ">=2.2" },
 ]
 


### PR DESCRIPTION
### Purpose of PR

Merge qdp-dev into dev dependency-groups to make the dev dep be more clear
Minor: it should be `uv sync --extra qdp` ref: https://peps.python.org/pep-0508/ and https://peps.python.org/pep-0735/

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
- Closes #861
<!-- - Related to #123   -->

### Changes Made
<!-- Please mark one with an "x"   -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [x] Yes
- [ ] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
- [x] Successfully built and ran all unit tests or manual tests locally
- [x] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [x] Code follows ASF guidelines
