### PR TITLE
Fix LaTeX rendering on website

### DIFF
--- a/website/_includes/head.html
+++ b/website/_includes/head.html
@@ -24,14 +24,15 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title | escape }}" href="{{'/feed.xml' | relative_url }}">
 
-  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML">
+  <script type="text/x-mathjax-config">
     MathJax.Hub.Config({
       "HTML-CSS": {
         availableFonts: ["TeX"],
       },
       tex2jax: {
-        inlineMath: [['$','$'],["\\(","\\)"]]},
-      displayMath: [ ['$$','$$'], ['\[','\]'] ],
+        inlineMath: [['$','$'],["\\(","\\)"]],
+        displayMath: [['$$','$$'],['\\[','\\]']]
+      },
       TeX: {
         extensions: ["AMSmath.js", "AMSsymbols.js", "color.js"],
         equationNumbers: {
@@ -44,4 +45,5 @@
       "AssistiveMML": { disabled: true }
     });
   </script>
+  <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_HTML"></script>
 </head>

--- a/website/_layouts/default.html
+++ b/website/_layouts/default.html
@@ -13,6 +13,5 @@
   <script src="/assets/vendor/popper/popper.min.js"></script>
   <script src="/assets/vendor/bootstrap/js/bootstrap.min.js"></script>
   <script src="/assets/header.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
 </body>
 </html>

--- a/website/_layouts/doc-default.html
+++ b/website/_layouts/doc-default.html
@@ -15,8 +15,6 @@
   <script src="/assets/vendor/popper/popper.min.js"></script>
   <script src="/assets/vendor/bootstrap/js/bootstrap.min.js"></script>
   <script src="/assets/header.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML" type="text/javascript"></script>
-
 </body>
 
 </html>

--- a/website/qumat/qdp/concepts/index.md
+++ b/website/qumat/qdp/concepts/index.md
@@ -30,9 +30,9 @@ Python (qumat.qdp)  →  _qdp (PyO3)  →  qdp-core (Rust)  →  qdp-kernels (CU
 
 ## 2. What QDP produces: a GPU-resident state vector
 
-QDP encodes classical data into a **state vector** \(|\psi\rangle\) for \(n\) qubits.
+QDP encodes classical data into a **state vector** $\vert\psi\rangle$ for $n$ qubits.
 
-- **State length**: \(2^{n}\)
+- **State length**: $2^{n}$
 - **Type**: complex numbers (on GPU)
 - **Shape exposed via DLPack**:
   - Single sample: `[1, 2^n]` (always 2D)
@@ -54,11 +54,11 @@ QDP uses a strategy pattern for encoding methods:
 
 All encoders perform input validation (at minimum):
 
-- \(1 \le n \le 30\)
+- $1 \le n \le 30$
 - input is not empty
 - for vector-based encodings: `len(data) <= 2^n`
 
-Note: \(n=30\) is already very large—just the output state for a single sample is on the order of \(2^{30}\) complex numbers.
+Note: $n=30$ is already very large—just the output state for a single sample is on the order of $2^{30}$ complex numbers.
 
 ---
 
@@ -66,15 +66,15 @@ Note: \(n=30\) is already very large—just the output state for a single sample
 
 ### 4.1 Amplitude encoding
 
-**Goal**: represent a real-valued feature vector \(x\) as quantum amplitudes:
+**Goal**: represent a real-valued feature vector $x$ as quantum amplitudes:
 
-\[
-|\psi\rangle = \sum_{i=0}^{2^{n}-1} \frac{x_i}{\|x\|_2}\,|i\rangle
-\]
+$$
+\vert\psi\rangle = \sum_{i=0}^{2^{n}-1} \frac{x_i}{\|x\|_2}\,\vert i\rangle
+$$
 
 Key properties in QDP:
 
-- **Normalization**: QDP computes \(\|x\|_2\) and rejects zero-norm inputs.
+- **Normalization**: QDP computes $\|x\|_2$ and rejects zero-norm inputs.
 - **Padding**: if `len(x) < 2^n`, the remaining amplitudes are treated as zeros.
 - **GPU execution**: the normalization and write into the GPU state vector is performed by CUDA kernels.
 - **Batch support**: amplitude encoding supports a batch path to reduce kernel launch / allocation overhead (recommended when encoding many samples).
@@ -85,16 +85,16 @@ When to use it:
 
 Trade-offs:
 
-- Output size grows exponentially with `num_qubits` (\(2^n\)), so it can become memory-heavy quickly.
+- Output size grows exponentially with `num_qubits` ($2^n$), so it can become memory-heavy quickly.
 
 ### 4.2 Basis encoding
 
-**Goal**: map an integer index \(i\) into a computational basis state \(|i\rangle\).
+**Goal**: map an integer index $i$ into a computational basis state $\vert i\rangle$.
 
-For \(n\) qubits with \(0 \le i < 2^n\):
+For $n$ qubits with $0 \le i < 2^n$:
 
-- \(\psi[i] = 1\)
-- \(\psi[j] = 0\) for all \(j \ne i\)
+- $\psi[i] = 1$
+- $\psi[j] = 0$ for all $j \ne i$
 
 Key properties in QDP:
 
@@ -110,7 +110,7 @@ When to use it:
 
 ### 4.3 Angle encoding (planned)
 
-Angle encoding typically maps features to rotation angles (e.g., via \(R_x(\theta)\), \(R_y(\theta)\), \(R_z(\theta)\)) and constructs a state by applying rotations across qubits.
+Angle encoding typically maps features to rotation angles (e.g., via $R_x(\theta)$, $R_y(\theta)$, $R_z(\theta)$) and constructs a state by applying rotations across qubits.
 
 **Current status in this codebase**:
 
@@ -125,12 +125,12 @@ QDP is designed to keep the encoded states on the GPU and to avoid unnecessary a
 
 ### 5.1 Output state vector allocation
 
-For each encoded sample, QDP allocates a state vector of size \(2^n\). Memory usage grows exponentially:
+For each encoded sample, QDP allocates a state vector of size $2^n$. Memory usage grows exponentially:
 
 - complex128 uses 16 bytes per element
 - rough output size (single sample) is:
-  - \(2^n \times 16\) bytes for complex128
-  - \(2^n \times 8\) bytes for complex64
+  - $2^n \times 16$ bytes for complex128
+  - $2^n \times 8$ bytes for complex64
 
 QDP performs **pre-flight checks** before large allocations to fail fast with an OOM-aware message (e.g., suggesting smaller `num_qubits` or batch size).
 
@@ -174,7 +174,7 @@ Conceptually:
 1. Rust allocates GPU memory for the state vector.
 2. Rust wraps it into a DLPack `DLManagedTensor`.
 3. Python returns an object that implements `__dlpack__`.
-4. PyTorch calls `torch.from_dlpack(qtensor)` and takes ownership via DLPack’s deleter.
+4. PyTorch calls `torch.from_dlpack(qtensor)` and takes ownership via DLPack's deleter.
 
 Important details:
 
@@ -194,7 +194,7 @@ Important details:
 ### 7.2 Choosing parameters wisely
 
 - **Prefer batch encoding** when encoding many samples (lower overhead, better GPU utilization).
-- **Keep `num_qubits` realistic**. Output size is \(2^n\) and becomes the dominant cost quickly.
+- **Keep `num_qubits` realistic**. Output size is $2^n$ and becomes the dominant cost quickly.
 - **Pick the right encoding**:
   - amplitude: dense real-valued vectors
   - basis: discrete indices / categorical states

--- a/website/qumat/quantum-computing-primer/03_qubits/index.md
+++ b/website/qumat/quantum-computing-primer/03_qubits/index.md
@@ -9,36 +9,32 @@ title: Quantum Bits (Qubits)
 
 In classical computing, the fundamental unit of information is the **bit**, which can exist in one of two states: `0` or `1`. Quantum computing, however, introduces the concept of a **qubit**, which can exist in a **superposition** of both states simultaneously. This means a qubit can be in a state that is a combination of `0` and `1`, represented as:
 
-$$|\psi\rangle = \alpha|0\rangle + \beta|1\rangle$$
+$$\vert\psi\rangle = \alpha\vert 0\rangle + \beta\vert 1\rangle$$
 
-{% raw %}
 where $\alpha$ and $\beta$ are complex numbers representing the probability
-amplitudes of the qubit being in the $|0\rangle$ and $|1\rangle$ states,
+amplitudes of the qubit being in the $\vert 0\rangle$ and $\vert 1\rangle$ states,
 respectively. The probabilities of measuring the qubit in either state are given
-by $|\alpha|^2$ and $|\beta|^2$, and they must satisfy the normalization condition:
-{% endraw %}
+by $\vert\alpha\vert^2$ and $\vert\beta\vert^2$, and they must satisfy the normalization condition:
 
-$$|\alpha|^2 + |\beta|^2 = 1$$
+$$\vert\alpha\vert^2 + \vert\beta\vert^2 = 1$$
 
 ## 3.2 Representing Qubits
 
 Qubits can be visualized using the **Bloch sphere**, a geometric representation
 of the quantum state of a single qubit. The Bloch sphere is a unit sphere where
-the north and south poles represent the $|0\rangle$ and $|1\rangle$ states,
+the north and south poles represent the $\vert 0\rangle$ and $\vert 1\rangle$ states,
 respectively. Any point on the surface of the sphere represents a valid quantum
 state of the qubit.
 
 The state of a qubit can also be described using a **state vector** in a
-two-dimensional complex vector space. For example, the state $|0\rangle$ is
+two-dimensional complex vector space. For example, the state $\vert 0\rangle$ is
 represented as:
 
-$$|0\rangle = \begin{pmatrix} 1 \\ 0 \end{pmatrix}$$
+$$\vert 0\rangle = \begin{pmatrix} 1 \\ 0 \end{pmatrix}$$
 
-{% raw %}
-and the state $|1\rangle$ is represented as:
-{% endraw %}
+and the state $\vert 1\rangle$ is represented as:
 
-$$|1\rangle = \begin{pmatrix} 0 \\ 1 \end{pmatrix}$$
+$$\vert 1\rangle = \begin{pmatrix} 0 \\ 1 \end{pmatrix}$$
 
 ## 3.3 Creating Qubits with `qumat`
 
@@ -64,11 +60,11 @@ In this example, we initialize a quantum circuit with one qubit using the qiskit
 
 ### Example: Applying a Hadamard Gate
 
-The Hadamard gate ((H)) is a fundamental quantum gate that puts a qubit into a
+The Hadamard gate ($H$) is a fundamental quantum gate that puts a qubit into a
 superposition state. Applying the Hadamard gate to a qubit initially in the
-$|0\rangle$ state results in the state:
+$\vert 0\rangle$ state results in the state:
 
-$$H|0\rangle = \frac{1}{\sqrt{2}}(|0\rangle + |1\rangle)$$
+$$H\vert 0\rangle = \frac{1}{\sqrt{2}}(\vert 0\rangle + \vert 1\rangle)$$
 
 Here's how you can apply a Hadamard gate to a qubit using qumat:
 
@@ -83,7 +79,7 @@ print(result)
 
 In this example, the Hadamard gate is applied to the qubit at index 0, and the
 circuit is executed to obtain the measurement results. The output will show the
-probabilities of measuring the qubit in the $|0\rangle$ and $|1\rangle$ states.
+probabilities of measuring the qubit in the $\vert 0\rangle$ and $\vert 1\rangle$ states.
 
 ### Visualizing the Circuit
 

--- a/website/qumat/quantum-computing-primer/04_quantum_gates/index.md
+++ b/website/qumat/quantum-computing-primer/04_quantum_gates/index.md
@@ -40,9 +40,9 @@ Multi-qubit gates operate on two or more qubits, enabling entanglement and more
 complex quantum operations. Some of the most common multi-qubit gates include:
 
 - **CNOT Gate (Controlled-NOT)**: Flips the target qubit if the control qubit is
-in the state $|1\rangle$.
+in the state $\vert 1\rangle$.
 - **Toffoli Gate (CCNOT)**: A controlled-controlled-NOT gate that flips the
-target qubit if both control qubits are in the state $|1\rangle$.
+target qubit if both control qubits are in the state $\vert 1\rangle$.
 - **SWAP Gate**: Exchanges the states of two qubits.
 
 ### Example: Applying a CNOT Gate

--- a/website/qumat/quantum-computing-primer/07_quantum_algorithms/index.md
+++ b/website/qumat/quantum-computing-primer/07_quantum_algorithms/index.md
@@ -118,7 +118,7 @@ print(result)
 ```
 
 ### Explanation
-- The oracle marks the desired state (e.g., $|110\rangle$).
+- The oracle marks the desired state (e.g., $\vert 110\rangle$).
 - The diffusion operator amplifies the probability of measuring the marked state.
 - After running the algorithm, the marked state will have a higher probability of being measured.
 


### PR DESCRIPTION
### Purpose of PR
**Why**                                                                                                                                                
LaTeX math formulas were displaying as raw text instead of rendered equations.                                                                        
                                                                                                                                                      
**How**                                                                                                                                                
1. Fixed MathJax config - was inside `<script src>` tag (browsers ignore inline code when src is present)                                             
2. Converted `\(...\)` to `$...$` and `\[...\]` to `$$...$$` for kramdown compatibility                                                               
3. Replaced `|` with `\vert` in ket notation to prevent markdown table parsing

before
<img width="729" height="584" alt="image" src="https://github.com/user-attachments/assets/e556087b-1e7c-4d25-a92c-695a420e1709" />

after
<img width="730" height="629" alt="image" src="https://github.com/user-attachments/assets/06ab35be-ce81-40ab-9812-6230b2851570" />


### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
- Related to #884

### Changes Made
<!-- Please mark one with an "x"   -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
- [x] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [x] Code follows ASF guidelines
