### PR TITLE
[QDP] Add TensorFlow .pb support to unified encode() path

### DIFF
--- a/qdp/qdp-python/README.md
+++ b/qdp/qdp-python/README.md
@@ -44,6 +44,8 @@ uv run maturin develop
 - **Parquet** - `.parquet` files
 - **Arrow IPC** - `.arrow` or `.feather` files
 - **NumPy** - `.npy` files
+- **PyTorch** - `.pt` or `.pth` files
+- **TensorFlow** - `.pb` files (TensorProto format)
 
 ## Adding new bindings
 

--- a/qdp/qdp-python/src/lib.rs
+++ b/qdp/qdp-python/src/lib.rs
@@ -218,7 +218,7 @@ impl QdpEngine {
     ///         - Python list: [1.0, 2.0, 3.0, 4.0]
     ///         - NumPy array: 1D (single sample) or 2D (batch) array
     ///         - PyTorch tensor: CPU tensor (float64 recommended; will be copied to GPU)
-    ///         - String path: .parquet, .arrow, .npy, .pt, .pth file
+    ///         - String path: .parquet, .arrow, .feather, .npy, .pt, .pth, .pb file
     ///         - pathlib.Path: Path object (converted via os.fspath())
     ///     num_qubits: Number of qubits for encoding
     ///     encoding_method: Encoding strategy ("amplitude" default, "angle", or "basis")
@@ -450,9 +450,15 @@ impl QdpEngine {
                 .map_err(|e| {
                     PyRuntimeError::new_err(format!("Encoding from PyTorch failed: {}", e))
                 })?
+        } else if path.ends_with(".pb") {
+            self.engine
+                .encode_from_tensorflow(path, num_qubits, encoding_method)
+                .map_err(|e| {
+                    PyRuntimeError::new_err(format!("Encoding from TensorFlow failed: {}", e))
+                })?
         } else {
             return Err(PyRuntimeError::new_err(format!(
-                "Unsupported file format. Expected .parquet, .arrow, .feather, .npy, .pt, or .pth, got: {}",
+                "Unsupported file format. Expected .parquet, .arrow, .feather, .npy, .pt, .pth, or .pb, got: {}",
                 path
             )));
         };


### PR DESCRIPTION
## Description
This PR adds TensorFlow `.pb` (TensorProto) file support to the unified `QdpEngine.encode()` path. Previously, users had to explicitly call `encode_from_tensorflow()` to process `.pb` files, but now `.pb` files are automatically detected and routed to the TensorFlow reader, matching the behavior of other supported formats.

fixes : #880 
tested on collab 
<img width="1550" height="178" alt="image" src="https://github.com/user-attachments/assets/72f00688-79ee-40a1-9038-6c1a71ce6726" />
