### PR TITLE
[QDP] Refactor: Centralize CUDA Kernel Configuration Constants

### DIFF
--- a/qdp/qdp-kernels/build.rs
+++ b/qdp/qdp-kernels/build.rs
@@ -31,6 +31,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/amplitude.cu");
     println!("cargo:rerun-if-changed=src/basis.cu");
     println!("cargo:rerun-if-changed=src/angle.cu");
+    println!("cargo:rerun-if-changed=src/kernel_config.h");
 
     // Check if CUDA is available by looking for nvcc
     let has_cuda = Command::new("nvcc").arg("--version").output().is_ok();
@@ -61,6 +62,7 @@ fn main() {
     let mut build = cc::Build::new();
 
     build.include(format!("{}/include", cuda_path));
+    build.include("src"); // Include src directory for kernel_config.h
 
     build
         .cuda(true)

--- a/qdp/qdp-kernels/src/angle.cu
+++ b/qdp/qdp-kernels/src/angle.cu
@@ -22,6 +22,7 @@
 #include <cuda_runtime.h>
 #include <cuComplex.h>
 #include <math.h>
+#include "kernel_config.h"
 
 __global__ void angle_encode_kernel(
     const double* __restrict__ angles,
@@ -95,7 +96,7 @@ int launch_angle_encode(
 
     cuDoubleComplex* state_complex_d = static_cast<cuDoubleComplex*>(state_d);
 
-    const int blockSize = 256;
+    const int blockSize = DEFAULT_BLOCK_SIZE;
     const int gridSize = (state_len + blockSize - 1) / blockSize;
 
     angle_encode_kernel<<<gridSize, blockSize, 0, stream>>>(
@@ -134,10 +135,10 @@ int launch_angle_encode_batch(
 
     cuDoubleComplex* state_complex_d = static_cast<cuDoubleComplex*>(state_batch_d);
 
-    const int blockSize = 256;
+    const int blockSize = DEFAULT_BLOCK_SIZE;
     const size_t total_elements = num_samples * state_len;
     const size_t blocks_needed = (total_elements + blockSize - 1) / blockSize;
-    const size_t max_blocks = 2048;
+    const size_t max_blocks = MAX_GRID_BLOCKS;
     const size_t gridSize = (blocks_needed < max_blocks) ? blocks_needed : max_blocks;
 
     angle_encode_batch_kernel<<<gridSize, blockSize, 0, stream>>>(

--- a/qdp/qdp-kernels/src/basis.cu
+++ b/qdp/qdp-kernels/src/basis.cu
@@ -22,6 +22,7 @@
 
 #include <cuda_runtime.h>
 #include <cuComplex.h>
+#include "kernel_config.h"
 
 /// Single sample basis encoding kernel
 ///
@@ -107,7 +108,7 @@ int launch_basis_encode(
 
     cuDoubleComplex* state_complex_d = static_cast<cuDoubleComplex*>(state_d);
 
-    const int blockSize = 256;
+    const int blockSize = DEFAULT_BLOCK_SIZE;
     const int gridSize = (state_len + blockSize - 1) / blockSize;
 
     basis_encode_kernel<<<gridSize, blockSize, 0, stream>>>(
@@ -145,10 +146,10 @@ int launch_basis_encode_batch(
 
     cuDoubleComplex* state_complex_d = static_cast<cuDoubleComplex*>(state_batch_d);
 
-    const int blockSize = 256;
+    const int blockSize = DEFAULT_BLOCK_SIZE;
     const size_t total_elements = num_samples * state_len;
     const size_t blocks_needed = (total_elements + blockSize - 1) / blockSize;
-    const size_t max_blocks = 2048;
+    const size_t max_blocks = MAX_GRID_BLOCKS;
     const size_t gridSize = (blocks_needed < max_blocks) ? blocks_needed : max_blocks;
 
     basis_encode_batch_kernel<<<gridSize, blockSize, 0, stream>>>(

--- a/qdp/qdp-kernels/src/kernel_config.h
+++ b/qdp/qdp-kernels/src/kernel_config.h
@@ -1,0 +1,62 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// CUDA Kernel Configuration Header
+//
+// Centralized configuration constants for all CUDA kernels.
+// This header ensures consistency across kernel implementations and
+// simplifies maintenance and tuning of kernel launch parameters.
+
+#ifndef KERNEL_CONFIG_H
+#define KERNEL_CONFIG_H
+
+// ============================================================================
+// Block Size Configuration
+// ============================================================================
+// Default block size (threads per block)
+// 256 threads = 8 warps, optimal for most modern GPUs (SM 7.0+)
+// Provides good occupancy while maintaining low register pressure
+#define DEFAULT_BLOCK_SIZE 256
+
+// ============================================================================
+// Grid Size Limits
+// ============================================================================
+// Maximum number of blocks for general kernel launches
+// Limits grid size to avoid scheduler overhead on most GPUs
+#define MAX_GRID_BLOCKS 2048
+
+// Maximum number of blocks for L2 norm reduction kernels
+// Used for kernels that process large input arrays
+#define MAX_GRID_BLOCKS_L2_NORM 4096
+
+// Maximum blocks per sample for batch processing
+// Limits per-sample parallelism to maintain good load balancing
+#define MAX_BLOCKS_PER_SAMPLE 32
+
+// CUDA grid dimension limit for 1D launches
+// This is a hardware limitation, not a tunable parameter
+#define CUDA_MAX_GRID_DIM_1D 65535
+
+// ============================================================================
+// Convenience Macros
+// ============================================================================
+// Common block size alias for consistency
+#define BLOCK_SIZE DEFAULT_BLOCK_SIZE
+
+// Finalization kernel block size (typically same as default)
+#define FINALIZE_BLOCK_SIZE DEFAULT_BLOCK_SIZE
+
+#endif // KERNEL_CONFIG_H


### PR DESCRIPTION
### Purpose of PR
<!-- Describe what this PR does. -->
This PR addresses code duplication by consolidating repeated CUDA kernel configuration constants into a single, centralized header file. This improves maintainability, ensures consistency across all kernels, and simplifies future tuning of kernel launch parameters.

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
<!-- - Related to #123   -->

### Changes Made
<!-- Please mark one with an "x"   -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
- [x] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [ ] Code follows ASF guidelines
