### PR TITLE
Add blog authors metadata

### DIFF
--- a/docs/blog/authors.yml
+++ b/docs/blog/authors.yml
@@ -1,0 +1,5 @@
+mahout-team:
+  name: Mahout Team
+  title: Apache Mahout
+  url: https://mahout.apache.org
+  image_url: /img/mahout-logo-blue.svg


### PR DESCRIPTION
### Purpose of PR
Define the `mahout-team` blog author used across posts
log error:
```
Error: Processing of blog source file path=2019-12-14-version-14-1.md failed.
[cause]: Error: Can't reference blog post authors by a key (such as 'mahout-team')
because no authors map file could be loaded.
Please double-check your blog plugin config...
```

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
<!-- - Related to #123   -->

### Changes Made
<!-- Please mark one with an "x"   -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [ ] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [ ] Code follows ASF guidelines
