### PR TITLE
[QDP] Fix CUDA memory alignment errors in amplitude encoding tests

### DIFF
--- a/qdp/qdp-kernels/tests/amplitude_encode.rs
+++ b/qdp/qdp-kernels/tests/amplitude_encode.rs
@@ -540,7 +540,7 @@ fn test_amplitude_encode_small_input_large_state() {
     let inv_norm = 1.0 / norm;
     let state_len = 16;
 
-    let input_d = device.htod_copy(input.clone()).unwrap();
+    let input_d = device.htod_sync_copy(input.as_slice()).unwrap();
     let mut state_d = device.alloc_zeros::<CuDoubleComplex>(state_len).unwrap();
 
     let result = unsafe {
@@ -555,6 +555,7 @@ fn test_amplitude_encode_small_input_large_state() {
     };
 
     assert_eq!(result, 0, "Kernel launch should succeed");
+    device.synchronize().unwrap();
 
     let state_h = device.dtoh_sync_copy(&state_d).unwrap();
 
@@ -640,7 +641,7 @@ fn test_l2_norm_batch_kernel_stream() {
         .collect();
 
     let stream = device.fork_default_stream().unwrap();
-    let input_d = device.htod_copy(input).unwrap();
+    let input_d = device.htod_sync_copy(input.as_slice()).unwrap();
     let mut norms_d = device.alloc_zeros::<f64>(num_samples).unwrap();
 
     let status = unsafe {


### PR DESCRIPTION
### Purpose of PR
<!-- Describe what this PR does. -->

Fixes `CUDA_ERROR_MISALIGNED_ADDRESS` errors in two amplitude encoding tests by using `htod_sync_copy` instead of `htod_copy` and adding explicit synchronization where needed.

### Related Issues or PRs
closes #965 

### Changes Made
<!-- Please mark one with an "x"   -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [x] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [ ] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [ ] Code follows ASF guidelines
