### PR TITLE
hotfix: pass region parameter to Braket backend

### DIFF
--- a/qumat/amazon_braket_backend.py
+++ b/qumat/amazon_braket_backend.py
@@ -14,7 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from braket.aws import AwsDevice
+import boto3
+from braket.aws import AwsDevice, AwsSession
 from braket.devices import LocalSimulator
 from braket.circuits import Circuit, FreeParameter
 
@@ -22,15 +23,29 @@ from braket.circuits import Circuit, FreeParameter
 def initialize_backend(backend_config):
     backend_options = backend_config["backend_options"]
     simulator_type = backend_options.get("simulator_type", "default")
+    region = backend_options.get("region")
+
+    # Create AWS session with region if specified
+    aws_session = None
+    if region:
+        boto_session = boto3.Session(region_name=region)
+        aws_session = AwsSession(boto_session=boto_session)
+
     if simulator_type == "local":
         return LocalSimulator()
     elif simulator_type == "default":
-        return AwsDevice("arn:aws:braket:::device/quantum-simulator/amazon/sv1")
+        return AwsDevice(
+            "arn:aws:braket:::device/quantum-simulator/amazon/sv1",
+            aws_session=aws_session,
+        )
     else:
         print(
             f"Simulator type '{simulator_type}' is not supported in Amazon Braket. Using default."
         )
-        return AwsDevice("arn:aws:braket:::device/quantum-simulator/amazon/sv1")
+        return AwsDevice(
+            "arn:aws:braket:::device/quantum-simulator/amazon/sv1",
+            aws_session=aws_session,
+        )
 
 
 def create_empty_circuit(num_qubits: int | None = None):


### PR DESCRIPTION
## Problem

When using the Amazon Braket backend, the `region` parameter in `backend_options` was ignored, resulting in "You must specify a region" error.

## Solution

Create an `AwsSession` with a `boto3.Session` configured with the specified region, then pass it to `AwsDevice`.

## Example

```python
qm = QuMat({
    "backend_name": "amazon_braket",
    "backend_options": {
        "simulator_type": "default",
        "shots": 1024,
        "region": "us-east-1"  # Now works!
    }
})
```