### PR TITLE
chore(qdp-python): remove deprecated PyO3 extension-module feature

### DIFF
--- a/qdp/qdp-python/Cargo.toml
+++ b/qdp/qdp-python/Cargo.toml
@@ -8,7 +8,7 @@ name = "_qdp"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = { version = "0.27", features = ["extension-module"] }
+pyo3 = { version = "0.27" }
 numpy = "0.27"
 qdp-core = { path = "../qdp-core" }
 env_logger = "0.11"


### PR DESCRIPTION
### Purpose of PR
<!-- Describe what this PR does. -->
Remove the deprecated PyO3 `extension-module` feature from qdp-python and document the change with official references.

#### References
- [PyO3 Features — extension-module](https://pyo3.rs/main/features.html) (deprecated)
- [Building and distribution — PYO3_BUILD_EXTENSION_MODULE](https://pyo3.rs/main/building-and-distribution#the-pyo3_build_extension_module-environment-variable)
- [FAQ — linker / cargo test](https://pyo3.rs/main/faq#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror)

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
<!-- - Related to #123   -->

### Changes Made
<!-- Please mark one with an "x"   -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [ ] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [ ] Code follows ASF guidelines
