### PR TITLE
[QDP] I/O errors: expose underlying cause via Error::source()

### DIFF
--- a/qdp/qdp-core/src/error.rs
+++ b/qdp/qdp-core/src/error.rs
@@ -37,6 +37,14 @@ pub enum MahoutError {
     #[error("I/O error: {0}")]
     Io(String),
 
+    /// I/O error with underlying cause (enables Error::source() and downcast).
+    #[error("I/O error: {message}")]
+    IoWithSource {
+        message: String,
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error("Not implemented: {0}")]
     NotImplemented(String),
 }
@@ -62,5 +70,24 @@ pub fn cuda_error_to_string(code: i32) -> &'static str {
         400 => "cudaErrorInvalidResourceHandle",
         999 => "CUDA unavailable (non-Linux stub)",
         _ => "Unknown CUDA error",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error as StdError;
+    use std::io;
+
+    #[test]
+    fn io_with_source_provides_source_and_downcast() {
+        let inner = io::Error::new(io::ErrorKind::NotFound, "file not found");
+        let err = MahoutError::IoWithSource {
+            message: format!("open failed: {}", inner),
+            source: inner,
+        };
+        assert!(err.to_string().contains("open failed"));
+        let source = err.source().expect("IoWithSource must have source");
+        assert!(source.downcast_ref::<io::Error>().is_some());
     }
 }

--- a/qdp/qdp-core/src/io.rs
+++ b/qdp/qdp-core/src/io.rs
@@ -98,8 +98,10 @@ pub fn write_parquet<P: AsRef<Path>>(
     let batch = RecordBatch::try_new(schema.clone(), vec![array_ref])
         .map_err(|e| MahoutError::Io(format!("Failed to create RecordBatch: {}", e)))?;
 
-    let file = File::create(path.as_ref())
-        .map_err(|e| MahoutError::Io(format!("Failed to create Parquet file: {}", e)))?;
+    let file = File::create(path.as_ref()).map_err(|e| MahoutError::IoWithSource {
+        message: format!("Failed to create Parquet file: {}", e),
+        source: e,
+    })?;
 
     let props = WriterProperties::builder().build();
     let mut writer = ArrowWriter::try_new(file, schema, Some(props))
@@ -120,8 +122,10 @@ pub fn write_parquet<P: AsRef<Path>>(
 ///
 /// Returns one array per row group for zero-copy access.
 pub fn read_parquet_to_arrow<P: AsRef<Path>>(path: P) -> Result<Vec<Float64Array>> {
-    let file = File::open(path.as_ref())
-        .map_err(|e| MahoutError::Io(format!("Failed to open Parquet file: {}", e)))?;
+    let file = File::open(path.as_ref()).map_err(|e| MahoutError::IoWithSource {
+        message: format!("Failed to open Parquet file: {}", e),
+        source: e,
+    })?;
 
     let builder = ParquetRecordBatchReaderBuilder::try_new(file)
         .map_err(|e| MahoutError::Io(format!("Failed to create Parquet reader: {}", e)))?;
@@ -193,8 +197,10 @@ pub fn write_arrow_to_parquet<P: AsRef<Path>>(
     let batch = RecordBatch::try_new(schema.clone(), vec![array_ref])
         .map_err(|e| MahoutError::Io(format!("Failed to create RecordBatch: {}", e)))?;
 
-    let file = File::create(path.as_ref())
-        .map_err(|e| MahoutError::Io(format!("Failed to create Parquet file: {}", e)))?;
+    let file = File::create(path.as_ref()).map_err(|e| MahoutError::IoWithSource {
+        message: format!("Failed to create Parquet file: {}", e),
+        source: e,
+    })?;
 
     let props = WriterProperties::builder().build();
     let mut writer = ArrowWriter::try_new(file, schema, Some(props))

--- a/qdp/qdp-core/src/readers/arrow_ipc.rs
+++ b/qdp/qdp-core/src/readers/arrow_ipc.rs
@@ -49,11 +49,14 @@ impl ArrowIPCReader {
                 )));
             }
             Err(e) => {
-                return Err(MahoutError::Io(format!(
-                    "Failed to check if Arrow IPC file exists at {}: {}",
-                    path.display(),
-                    e
-                )));
+                return Err(MahoutError::IoWithSource {
+                    message: format!(
+                        "Failed to check if Arrow IPC file exists at {}: {}",
+                        path.display(),
+                        e
+                    ),
+                    source: e,
+                });
             }
             Ok(true) => {}
         }
@@ -74,8 +77,10 @@ impl DataReader for ArrowIPCReader {
         }
         self.read = true;
 
-        let file = File::open(&self.path)
-            .map_err(|e| MahoutError::Io(format!("Failed to open Arrow IPC file: {}", e)))?;
+        let file = File::open(&self.path).map_err(|e| MahoutError::IoWithSource {
+            message: format!("Failed to open Arrow IPC file: {}", e),
+            source: e,
+        })?;
 
         let reader = ArrowFileReader::try_new(file, None)
             .map_err(|e| MahoutError::Io(format!("Failed to create Arrow IPC reader: {}", e)))?;

--- a/qdp/qdp-core/src/readers/numpy.rs
+++ b/qdp/qdp-core/src/readers/numpy.rs
@@ -65,11 +65,14 @@ impl NumpyReader {
                 )));
             }
             Err(e) => {
-                return Err(MahoutError::Io(format!(
-                    "Failed to check if NumPy file exists at {}: {}",
-                    path.display(),
-                    e
-                )));
+                return Err(MahoutError::IoWithSource {
+                    message: format!(
+                        "Failed to check if NumPy file exists at {}: {}",
+                        path.display(),
+                        e
+                    ),
+                    source: e,
+                });
             }
             Ok(true) => {}
         }
@@ -92,9 +95,10 @@ impl DataReader for NumpyReader {
 
         // Read the .npy file
         let array: Array2<f64> = ndarray_npy::read_npy(&self.path).map_err(|e| match e {
-            ReadNpyError::Io(io_err) => {
-                MahoutError::Io(format!("Failed to read NumPy file: {}", io_err))
-            }
+            ReadNpyError::Io(io_err) => MahoutError::IoWithSource {
+                message: format!("Failed to read NumPy file: {}", io_err),
+                source: io_err,
+            },
             _ => MahoutError::InvalidInput(format!("Failed to parse NumPy file: {}", e)),
         })?;
 

--- a/qdp/qdp-core/src/readers/parquet.rs
+++ b/qdp/qdp-core/src/readers/parquet.rs
@@ -51,17 +51,22 @@ impl ParquetReader {
                 )));
             }
             Err(e) => {
-                return Err(MahoutError::Io(format!(
-                    "Failed to check if Parquet file exists at {}: {}",
-                    path.display(),
-                    e
-                )));
+                return Err(MahoutError::IoWithSource {
+                    message: format!(
+                        "Failed to check if Parquet file exists at {}: {}",
+                        path.display(),
+                        e
+                    ),
+                    source: e,
+                });
             }
             Ok(true) => {}
         }
 
-        let file = File::open(path)
-            .map_err(|e| MahoutError::Io(format!("Failed to open Parquet file: {}", e)))?;
+        let file = File::open(path).map_err(|e| MahoutError::IoWithSource {
+            message: format!("Failed to open Parquet file: {}", e),
+            source: e,
+        })?;
 
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)
             .map_err(|e| MahoutError::Io(format!("Failed to create Parquet reader: {}", e)))?;
@@ -262,17 +267,22 @@ impl ParquetStreamingReader {
                 )));
             }
             Err(e) => {
-                return Err(MahoutError::Io(format!(
-                    "Failed to check if Parquet file exists at {}: {}",
-                    path.display(),
-                    e
-                )));
+                return Err(MahoutError::IoWithSource {
+                    message: format!(
+                        "Failed to check if Parquet file exists at {}: {}",
+                        path.display(),
+                        e
+                    ),
+                    source: e,
+                });
             }
             Ok(true) => {}
         }
 
-        let file = File::open(path)
-            .map_err(|e| MahoutError::Io(format!("Failed to open Parquet file: {}", e)))?;
+        let file = File::open(path).map_err(|e| MahoutError::IoWithSource {
+            message: format!("Failed to open Parquet file: {}", e),
+            source: e,
+        })?;
 
         let builder = ParquetRecordBatchReaderBuilder::try_new(file)
             .map_err(|e| MahoutError::Io(format!("Failed to create Parquet reader: {}", e)))?;

--- a/qdp/qdp-core/src/readers/tensorflow.rs
+++ b/qdp/qdp-core/src/readers/tensorflow.rs
@@ -49,12 +49,17 @@ impl TensorFlowReader {
     /// Create a new TensorFlow reader from a file path.
     pub fn new<P: AsRef<Path>>(path: P) -> Result<Self> {
         // Read entire file into memory (single read to avoid multiple I/O operations)
-        let mut file = File::open(path.as_ref())
-            .map_err(|e| MahoutError::Io(format!("Failed to open TensorFlow file: {}", e)))?;
+        let mut file = File::open(path.as_ref()).map_err(|e| MahoutError::IoWithSource {
+            message: format!("Failed to open TensorFlow file: {}", e),
+            source: e,
+        })?;
 
         let mut buffer = Vec::new();
         file.read_to_end(&mut buffer)
-            .map_err(|e| MahoutError::Io(format!("Failed to read TensorFlow file: {}", e)))?;
+            .map_err(|e| MahoutError::IoWithSource {
+                message: format!("Failed to read TensorFlow file: {}", e),
+                source: e,
+            })?;
 
         // Use Bytes for decode input; with build.rs config.bytes(...) this avoids copying tensor_content during decode
         let buffer = Bytes::from(buffer);

--- a/qdp/qdp-core/src/readers/torch.rs
+++ b/qdp/qdp-core/src/readers/torch.rs
@@ -51,11 +51,14 @@ impl TorchReader {
                 )));
             }
             Err(e) => {
-                return Err(MahoutError::Io(format!(
-                    "Failed to check if PyTorch file exists at {}: {}",
-                    path.display(),
-                    e
-                )));
+                return Err(MahoutError::IoWithSource {
+                    message: format!(
+                        "Failed to check if PyTorch file exists at {}: {}",
+                        path.display(),
+                        e
+                    ),
+                    source: e,
+                });
             }
             Ok(true) => {}
         }


### PR DESCRIPTION
### Purpose of PR
<!-- Describe what this PR does. -->
Adopt Rust’s standard error convention for I/O: add a new `MahoutError::IoWithSource` variant that wraps `std::io::Error` and implements `Error::source()`. Callers can now downcast or walk the cause chain for file/read errors instead of losing the underlying error in a string.
#### References
- **Rust:** [std::error::Error](https://doc.rust-lang.org/std/error/trait.Error.html) ([Error::source](https://doc.rust-lang.org/std/error/trait.Error.html#method.source))
- **thiserror:** [docs.rs thiserror](https://docs.rs/thiserror/latest/thiserror/) (derive, `#[source]`, struct variant for custom message + source)

### Related Issues or PRs
<!-- Add links to related issues or PRs. -->
<!-- - Closes #123  -->
<!-- - Related to #123   -->

### Changes Made
<!-- Please mark one with an "x"   -->
- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [x] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [x] Successfully built and ran all unit tests or manual tests locally
- [ ] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [x] Code follows ASF guidelines
