### PR TITLE
MAHOUT-901: Fix `test_rust` by excluding qdp-python from cargo test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ setup-test-python:
 
 test_rust:
 ifeq ($(HAS_NVIDIA),yes)
-	cd qdp && cargo test
+	cd qdp && cargo test -p qdp-core -p qdp-kernels
 else
 	@echo "[SKIP] No NVIDIA GPU detected, skipping test_rust"
 endif

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ setup-test-python:
 
 test_rust:
 ifeq ($(HAS_NVIDIA),yes)
-	cd qdp && cargo test -p qdp-core -p qdp-kernels
+	cd qdp && cargo test --workspace --exclude qdp-python
 else
 	@echo "[SKIP] No NVIDIA GPU detected, skipping test_rust"
 endif


### PR DESCRIPTION
### Purpose of PR
`make test_rust` was failing with linker error `unable to find library -lpython3.10` because it runs `cargo test` for the entire `qdp` workspace, which includes the PyO3-based `qdp-python` crate. Building that crate requires linking against the Python shared library, which is often not on the default linker path or matches a different Python version. This PR scopes `test_rust` to the Rust-only crates so that Rust tests can run without a system libpython, while Python extension tests remain covered by `make test_python`.

### Related Issues or PRs
closes #1027 

### Changes Made
<!-- Please mark one with an "x"   -->
- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Breaking Changes
<!-- Does this PR introduce a breaking change? -->
- [ ] Yes
- [x] No

### Checklist
<!-- Please mark each item with an "x" when complete -->
<!-- If not all items are complete, please open this as a **Draft PR**.
Once all requirements are met, mark as ready for review. -->

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
- [x] Successfully built and ran all unit tests or manual tests locally
- [x] PR title follows "MAHOUT-XXX: Brief Description" format (if related to an issue)
- [x] Code follows ASF guidelines
