### PR TITLE
[Bug] Fix website Redirect

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -106,6 +106,11 @@ const config: Config = {
           if (existingPath === '/blog') {
             return ['/news.html', '/news'];
           }
+          // Keep /downloads as the canonical public download entry URL.
+          if (existingPath === '/downloads') {
+            return [
+            ];
+          }
           return undefined;
         },
       },
@@ -171,7 +176,7 @@ const config: Config = {
         },
         // Download
         {
-          to: '/docs/download',
+          to: '/downloads',
           label: 'Download',
           position: 'left',
         },

--- a/website/src/pages/download.tsx
+++ b/website/src/pages/download.tsx
@@ -1,0 +1,6 @@
+import type {ReactElement} from 'react';
+import {Redirect} from '@docusaurus/router';
+
+export default function DownloadPage(): ReactElement {
+  return <Redirect to="/downloads" />;
+}

--- a/website/src/pages/downloads.tsx
+++ b/website/src/pages/downloads.tsx
@@ -1,0 +1,55 @@
+import type {ReactElement} from 'react';
+import Layout from '@theme/Layout';
+import Heading from '@theme/Heading';
+
+export default function DownloadsPage(): ReactElement {
+  return (
+    <Layout title="Downloads" description="Apache Mahout download and install instructions">
+      <main className="container margin-vert--lg">
+        <Heading as="h1">Downloads</Heading>
+        <p>Install Qumat from PyPI:</p>
+        <pre>
+          <code>pip install qumat</code>
+        </pre>
+        <p>Install with QDP (Quantum Data Plane) support:</p>
+        <pre>
+          <code>pip install qumat[qdp]</code>
+        </pre>
+
+        <Heading as="h2">From Source</Heading>
+        <pre>
+          <code>
+            git clone https://github.com/apache/mahout.git{'\n'}
+            cd mahout{'\n'}
+            pip install uv{'\n'}
+            uv sync                     # Core Qumat{'\n'}
+            uv sync --extra qdp         # With QDP (requires CUDA GPU)
+          </code>
+        </pre>
+
+        <Heading as="h2">Apache Release</Heading>
+        <p>
+          Official source releases are available at{' '}
+          <a href="http://www.apache.org/dist/mahout">apache.org/dist/mahout</a>.
+        </p>
+        <p>To verify the integrity of a downloaded release:</p>
+        <pre>
+          <code>
+            gpg --import KEYS{'\n'}
+            gpg --verify mahout-qumat-0.5.zip.asc mahout-qumat-0.5.zip
+          </code>
+        </pre>
+
+        <Heading as="h2">Links</Heading>
+        <ul>
+          <li>
+            <a href="https://pypi.org/project/qumat/">PyPI</a>
+          </li>
+          <li>
+            <a href="http://www.apache.org/dist/mahout">Apache SVN</a>
+          </li>
+        </ul>
+      </main>
+    </Layout>
+  );
+}

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -58,7 +58,7 @@ function Sidebar() {
         <div className={styles.cardHeader}>Qumat 0.5 Released!</div>
         <div className={styles.cardBody}>
           <p>Mahout's new quantum computing layer for building ML circuits on simulators and real quantum hardware.</p>
-          <Link to="/docs/download">Download Qumat 0.5 →</Link>
+          <Link to="/downloads">Download Qumat 0.5 →</Link>
         </div>
       </div>
 

--- a/website/static/download/downloads.html
+++ b/website/static/download/downloads.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url=/downloads">
+  <meta name="robots" content="noindex">
+  <link rel="canonical" href="https://mahout.apache.org/downloads">
+  <title>Redirecting to Downloads</title>
+  <script>window.location.replace('/downloads');</script>
+</head>
+<body>
+  <p>Redirecting to <a href="/downloads">/downloads</a>...</p>
+</body>
+</html>


### PR DESCRIPTION
### Summary
Currently the old  https://mahout.apache.org/download/downloads.html page is 404 and it needs to be fixed.
I redirect https://mahout.apache.org/download/downloads.html & https://mahout.apache.org/download to all redirect to https://mahout.apache.org/downloads as discussed on slack.

Screenshot:
<img width="1440" height="900" alt="Screenshot 2026-02-12 at 10 41 36 AM" src="https://github.com/user-attachments/assets/327f196f-07d6-4096-9d59-094320823457" />

### Related Issues
Closes #1039 

### Changes

- [x] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

### How

<!-- What was done? -->

## Checklist

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
