### PR TITLE
Improve coverage for qumat/qdp.py by testing stub fallback behavior

### DIFF
--- a/testing/qumat/test_qdp_stub.py
+++ b/testing/qumat/test_qdp_stub.py
@@ -1,0 +1,62 @@
+import pytest
+import warnings
+import importlib
+import sys
+
+
+def test_qdp_import_without_extension_warns():
+    # Force fresh import
+    sys.modules.pop("qumat.qdp", None)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+
+        module = importlib.import_module("qumat.qdp")
+
+        # Ensure fallback stubs exist
+        assert hasattr(module, "QdpEngine")
+        assert hasattr(module, "QuantumTensor")
+
+        # Ensure warning was emitted
+        assert any(
+            "QDP module not available" in str(warn.message)
+            and warn.category is ImportWarning
+            for warn in w
+        )
+
+
+def test_qdp_stub_engine_raises_import_error():
+    import qumat.qdp as qdp
+
+    with pytest.raises(ImportError) as exc:
+        qdp.QdpEngine()
+
+    assert "qumat-qdp native extension" in str(exc.value)
+
+
+def test_qdp_stub_tensor_raises_import_error():
+    import qumat.qdp as qdp
+
+    with pytest.raises(ImportError):
+        qdp.QuantumTensor()
+
+
+def test_qdp_all_exports():
+    import qumat.qdp as qdp
+
+    assert "QdpEngine" in qdp.__all__
+    assert "QuantumTensor" in qdp.__all__
+
+
+def test_make_stub_creates_class():
+    # Force fresh import
+    sys.modules.pop("qumat.qdp", None)
+    module = importlib.import_module("qumat.qdp")
+
+    # Directly test stub factory
+    stub_class = module._make_stub("TestStub")
+
+    assert stub_class.__name__ == "TestStub"
+
+    with pytest.raises(ImportError):
+        stub_class()


### PR DESCRIPTION
### Related Issues

N/A

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

`qumat/qdp.py` provides a fallback stub implementation when the native `_qdp`
extension is not available. This behavior is important for environments
without GPU/native builds, but it was not explicitly covered by tests.

Adding dedicated tests ensures that the fallback mechanism works as expected
and remains stable over time.

### How

- Added `testing/qumat/test_qdp_stub.py`
- Forced a fresh import of `qumat.qdp` to trigger the fallback code path
- Verified that:
  - An `ImportWarning` is emitted when `_qdp` is unavailable
  - Stub classes (`QdpEngine`, `QuantumTensor`) raise `ImportError` on instantiation
  - `__all__` exports are correctly defined

All existing tests pass locally:

- 561 passed
- 91 skipped
- Total coverage: 93% (442 statements, 32 missed)

This change improves coverage for `qumat/qdp.py` without modifying runtime behavior or affecting the native extension logic.

## Checklist

- [x] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes