### PR TITLE
Enable CUDA tensor validation for iqp and iqp-z encodings

### DIFF
--- a/qdp/qdp-python/src/pytorch.rs
+++ b/qdp/qdp-python/src/pytorch.rs
@@ -182,9 +182,18 @@ pub fn validate_cuda_tensor_for_encoding(
                 )));
             }
         }
+        "iqp" | "iqp-z" => {
+            if !dtype_str_lower.contains("float64") {
+                return Err(PyRuntimeError::new_err(format!(
+                    "CUDA tensor must have dtype float64 for {} encoding, got {}. \
+                     Use tensor.to(torch.float64)",
+                    method, dtype_str
+                )));
+            }
+        }
         _ => {
             return Err(PyRuntimeError::new_err(format!(
-                "CUDA tensor encoding currently only supports 'amplitude', 'angle', or 'basis' methods, got '{}'. \
+                "CUDA tensor encoding currently only supports 'amplitude', 'angle', 'basis', 'iqp', or 'iqp-z' methods, got '{}'. \
                  Use tensor.cpu() to convert to CPU tensor for other encoding methods.",
                 encoding_method
             )));


### PR DESCRIPTION
QdpEngine.encode() supports iqp and iqp-z in qdp-core, but the CUDA tensor validation path in pytorch.rs currently rejects these methods and only allows amplitude, angle, and basis.

This creates inconsistent behavior:

CPU/list/NumPy paths can use iqp/iqp-z
CUDA tensor path fails early with an unsupported-method error
Expected behavior
CUDA tensor inputs should allow iqp and iqp-z when dtype/shape/device constraints are satisfied (same style as other supported encodings).


