### PR TITLE
make test_rust will automatically install cargo-llvm-cov if it's not found

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: test_rust test_python tests pre-commit setup-test-python
+.PHONY: test_rust test_python tests pre-commit setup-test-python install-llvm-cov
 
 # Detect NVIDIA GPU
 HAS_NVIDIA := $(shell command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1 && echo yes || echo no)
@@ -22,7 +22,10 @@ HAS_NVIDIA := $(shell command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/d
 setup-test-python:
 	uv sync --group dev
 
-test_rust:
+install-llvm-cov:
+	@cargo llvm-cov --version >/dev/null 2>&1 || (echo "[INFO] Installing cargo-llvm-cov..." && cargo install cargo-llvm-cov)
+
+test_rust: install-llvm-cov
 ifeq ($(HAS_NVIDIA),yes)
 	cd qdp && cargo llvm-cov test --workspace --exclude qdp-python --html --output-dir target/llvm-cov/html
 	cd qdp && cargo llvm-cov report --summary-only


### PR DESCRIPTION
### Related Issues
Closes #1097 
<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

### How

<!-- What was done? -->
make sure cargo-llvm-cov is installed in makefile to make it more robust

## Checklist

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
