### PR TITLE
Fix/dynamic cuda encoding method list

### DIFF
--- a/qdp/qdp-python/src/constants.rs
+++ b/qdp/qdp-python/src/constants.rs
@@ -1,0 +1,32 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+pub const CUDA_ENCODING_METHODS: &[&str] = &["amplitude", "angle", "basis", "iqp", "iqp-z"];
+
+pub fn format_supported_cuda_encoding_methods() -> String {
+    match CUDA_ENCODING_METHODS.split_last() {
+        None => String::new(),
+        Some((last, [])) => format!("'{}'", last),
+        Some((last, rest)) => {
+            let rest = rest
+                .iter()
+                .map(|method| format!("'{}'", method))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{}, or '{}'", rest, last)
+        }
+    }
+}

--- a/qdp/qdp-python/src/lib.rs
+++ b/qdp/qdp-python/src/lib.rs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod constants;
 mod dlpack;
 mod engine;
 mod loader;

--- a/qdp/qdp-python/src/pytorch.rs
+++ b/qdp/qdp-python/src/pytorch.rs
@@ -182,9 +182,18 @@ pub fn validate_cuda_tensor_for_encoding(
                 )));
             }
         }
+        "iqp" | "iqp-z" => {
+            if !dtype_str_lower.contains("float64") {
+                return Err(PyRuntimeError::new_err(format!(
+                    "CUDA tensor must have dtype float64 for {} encoding, got {}. \
+                     Use tensor.to(torch.float64)",
+                    method, dtype_str
+                )));
+            }
+        }
         _ => {
             return Err(PyRuntimeError::new_err(format!(
-                "CUDA tensor encoding currently only supports 'amplitude', 'angle', or 'basis' methods, got '{}'. \
+                "CUDA tensor encoding currently only supports 'amplitude', 'angle', 'basis', 'iqp', or 'iqp-z' methods, got '{}'. \
                  Use tensor.cpu() to convert to CPU tensor for other encoding methods.",
                 encoding_method
             )));

--- a/qdp/qdp-python/src/pytorch.rs
+++ b/qdp/qdp-python/src/pytorch.rs
@@ -59,15 +59,18 @@ pub fn is_cuda_tensor(tensor: &Bound<'_, PyAny>) -> PyResult<bool> {
 const CUDA_ENCODING_METHODS: &[&str] = &["amplitude", "angle", "basis", "iqp", "iqp-z"];
 
 fn format_supported_cuda_encoding_methods() -> String {
-    let quoted: Vec<String> = CUDA_ENCODING_METHODS
-        .iter()
-        .map(|method| format!("'{}'", method))
-        .collect();
-    let len = quoted.len();
-    if len == 1 {
-        return quoted[0].clone();
+    match CUDA_ENCODING_METHODS.split_last() {
+        None => String::new(),
+        Some((last, [])) => format!("'{}'", last),
+        Some((last, rest)) => {
+            let rest = rest
+                .iter()
+                .map(|method| format!("'{}'", method))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("{}, or '{}'", rest, last)
+        }
     }
-    format!("{}, or {}", quoted[..len - 1].join(", "), quoted[len - 1])
 }
 
 /// Validate array/tensor shape (must be 1D or 2D)

--- a/qdp/qdp-python/src/pytorch.rs
+++ b/qdp/qdp-python/src/pytorch.rs
@@ -18,6 +18,8 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use std::ffi::c_void;
 
+use crate::constants::format_supported_cuda_encoding_methods;
+
 /// Helper to detect PyTorch tensor
 pub fn is_pytorch_tensor(obj: &Bound<'_, PyAny>) -> PyResult<bool> {
     let type_obj = obj.get_type();
@@ -54,23 +56,6 @@ pub fn is_cuda_tensor(tensor: &Bound<'_, PyAny>) -> PyResult<bool> {
     let device = tensor.getattr("device")?;
     let device_type: String = device.getattr("type")?.extract()?;
     Ok(device_type == "cuda")
-}
-
-const CUDA_ENCODING_METHODS: &[&str] = &["amplitude", "angle", "basis", "iqp", "iqp-z"];
-
-fn format_supported_cuda_encoding_methods() -> String {
-    match CUDA_ENCODING_METHODS.split_last() {
-        None => String::new(),
-        Some((last, [])) => format!("'{}'", last),
-        Some((last, rest)) => {
-            let rest = rest
-                .iter()
-                .map(|method| format!("'{}'", method))
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!("{}, or '{}'", rest, last)
-        }
-    }
 }
 
 /// Validate array/tensor shape (must be 1D or 2D)

--- a/qdp/qdp-python/src/pytorch.rs
+++ b/qdp/qdp-python/src/pytorch.rs
@@ -18,7 +18,7 @@ use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
 use std::ffi::c_void;
 
-use crate::constants::format_supported_cuda_encoding_methods;
+use crate::constants::{CUDA_ENCODING_METHODS, format_supported_cuda_encoding_methods};
 
 /// Helper to detect PyTorch tensor
 pub fn is_pytorch_tensor(obj: &Bound<'_, PyAny>) -> PyResult<bool> {
@@ -152,6 +152,15 @@ pub fn validate_cuda_tensor_for_encoding(
 ) -> PyResult<()> {
     let method = encoding_method.to_ascii_lowercase();
 
+    if !CUDA_ENCODING_METHODS.contains(&method.as_str()) {
+        return Err(PyRuntimeError::new_err(format!(
+            "CUDA tensor encoding currently only supports {} methods, got '{}'. \
+             Use tensor.cpu() to convert to CPU tensor for other encoding methods.",
+            format_supported_cuda_encoding_methods(),
+            encoding_method
+        )));
+    }
+
     // Check encoding method support and dtype (ASCII lowercase for case-insensitive match).
     let dtype = tensor.getattr("dtype")?;
     let dtype_str: String = dtype.str()?.extract()?;
@@ -186,10 +195,8 @@ pub fn validate_cuda_tensor_for_encoding(
         }
         _ => {
             return Err(PyRuntimeError::new_err(format!(
-                "CUDA tensor encoding currently only supports {} methods, got '{}'. \
-                 Use tensor.cpu() to convert to CPU tensor for other encoding methods.",
-                format_supported_cuda_encoding_methods(),
-                encoding_method
+                "Internal error: missing CUDA validation branch for supported method '{}'",
+                method
             )));
         }
     }


### PR DESCRIPTION
Summary
This PR addresses [#1096] by making the CUDA unknown-encoding error message in QDP dynamic and maintainable, instead of hard-coding method names in [pytorch.rs].

This is a follow-up refactor to the CUDA iqp/iqp-z support work from [#1093].

Problem
Previously, the CUDA validation path returned an error string with a manually written list of supported methods.
When new encodings are added, this message can drift from actual support unless manually updated in multiple places.

What changed - 
1) Centralized CUDA method list and formatter
Added [constants.rs]:
CUDA_ENCODING_METHODS
format_supported_cuda_encoding_methods()
2) Updated CUDA validation error path
In [pytorch.rs], unknown-method errors now use:
format_supported_cuda_encoding_methods()
This keeps the message synchronized with the centralized method list.
3) Small cleanup included
Merged duplicated float64 dtype validation logic for:
angle
iqp
iqp-z
No behavior change intended, only reduced duplication.


Behavior impact -
No API change in method signatures.
No functional change to which methods are supported.
Only improves maintainability and reduces risk of stale/incorrect error text.



Why this is better - 
Single source of truth for CUDA-supported encoding names.
Lower maintenance cost when adding new encodings.
Clearer, less brittle validation code.
