### PR TITLE
Add unified and configurable null handling

### DIFF
--- a/qdp/qdp-core/src/encoding/mod.rs
+++ b/qdp/qdp-core/src/encoding/mod.rs
@@ -141,7 +141,8 @@ pub(crate) fn stream_encode<E: ChunkEncoder>(
     encoder: E,
 ) -> Result<*mut DLManagedTensor> {
     // Initialize reader
-    let mut reader_core = crate::io::ParquetBlockReader::new(path, None)?;
+    let mut reader_core =
+        crate::io::ParquetBlockReader::new(path, None, crate::reader::NullHandling::FillZero)?;
     let num_samples = reader_core.total_rows;
 
     // Allocate output state vector

--- a/qdp/qdp-core/src/io.rs
+++ b/qdp/qdp-core/src/io.rs
@@ -26,7 +26,7 @@ use std::fs::File;
 use std::path::Path;
 use std::sync::Arc;
 
-use arrow::array::{Array, ArrayRef, Float64Array, RecordBatch};
+use arrow::array::{ArrayRef, Float64Array, RecordBatch};
 use arrow::datatypes::{DataType, Field, Schema};
 use parquet::arrow::ArrowWriter;
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;

--- a/qdp/qdp-core/src/io.rs
+++ b/qdp/qdp-core/src/io.rs
@@ -33,30 +33,28 @@ use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use parquet::file::properties::WriterProperties;
 
 use crate::error::{MahoutError, Result};
+use crate::reader::{NullHandling, handle_float64_nulls};
 
 /// Converts an Arrow Float64Array to Vec<f64>.
-pub fn arrow_to_vec(array: &Float64Array) -> Vec<f64> {
-    if array.null_count() == 0 {
-        array.values().to_vec()
-    } else {
-        array.iter().map(|opt| opt.unwrap_or(0.0)).collect()
-    }
+pub fn arrow_to_vec(array: &Float64Array, null_handling: NullHandling) -> Result<Vec<f64>> {
+    let mut result = Vec::with_capacity(array.len());
+    handle_float64_nulls(&mut result, array, null_handling)?;
+    Ok(result)
 }
 
 /// Flattens multiple Arrow Float64Arrays into a single Vec<f64>.
-pub fn arrow_to_vec_chunked(arrays: &[Float64Array]) -> Vec<f64> {
+pub fn arrow_to_vec_chunked(
+    arrays: &[Float64Array],
+    null_handling: NullHandling,
+) -> Result<Vec<f64>> {
     let total_len: usize = arrays.iter().map(|a| a.len()).sum();
     let mut result = Vec::with_capacity(total_len);
 
     for array in arrays {
-        if array.null_count() == 0 {
-            result.extend_from_slice(array.values());
-        } else {
-            result.extend(array.iter().map(|opt| opt.unwrap_or(0.0)));
-        }
+        handle_float64_nulls(&mut result, array, null_handling)?;
     }
 
-    result
+    Ok(result)
 }
 
 /// Reads Float64 data from a Parquet file.
@@ -64,7 +62,7 @@ pub fn arrow_to_vec_chunked(arrays: &[Float64Array]) -> Vec<f64> {
 /// Expects a single Float64 column. For zero-copy access, use [`read_parquet_to_arrow`].
 pub fn read_parquet<P: AsRef<Path>>(path: P) -> Result<Vec<f64>> {
     let chunks = read_parquet_to_arrow(path)?;
-    Ok(arrow_to_vec_chunked(&chunks))
+    arrow_to_vec_chunked(&chunks, NullHandling::FillZero)
 }
 
 /// Writes Float64 data to a Parquet file.
@@ -228,7 +226,7 @@ pub fn write_arrow_to_parquet<P: AsRef<Path>>(
 /// Add OOM protection for very large files
 pub fn read_parquet_batch<P: AsRef<Path>>(path: P) -> Result<(Vec<f64>, usize, usize)> {
     use crate::reader::DataReader;
-    let mut reader = crate::readers::ParquetReader::new(path, None)?;
+    let mut reader = crate::readers::ParquetReader::new(path, None, NullHandling::FillZero)?;
     reader.read_batch()
 }
 
@@ -244,7 +242,7 @@ pub fn read_parquet_batch<P: AsRef<Path>>(path: P) -> Result<(Vec<f64>, usize, u
 /// Add OOM protection for very large files
 pub fn read_arrow_ipc_batch<P: AsRef<Path>>(path: P) -> Result<(Vec<f64>, usize, usize)> {
     use crate::reader::DataReader;
-    let mut reader = crate::readers::ArrowIPCReader::new(path)?;
+    let mut reader = crate::readers::ArrowIPCReader::new(path, NullHandling::FillZero)?;
     reader.read_batch()
 }
 

--- a/qdp/qdp-core/src/lib.rs
+++ b/qdp/qdp-core/src/lib.rs
@@ -34,6 +34,7 @@ mod profiling;
 
 pub use error::{MahoutError, Result, cuda_error_to_string};
 pub use gpu::memory::Precision;
+pub use reader::{NullHandling, handle_float64_nulls};
 
 // Throughput/latency pipeline runner: single path using QdpEngine and encode_batch in Rust.
 #[cfg(target_os = "linux")]

--- a/qdp/qdp-core/tests/null_handling.rs
+++ b/qdp/qdp-core/tests/null_handling.rs
@@ -1,0 +1,79 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Tests for the unified NullHandling policy.
+
+use arrow::array::Float64Array;
+use qdp_core::reader::{NullHandling, handle_float64_nulls};
+
+#[test]
+fn fill_zero_replaces_nulls() {
+    let array = Float64Array::from(vec![Some(1.0), None, Some(3.0), None]);
+    let mut output = Vec::new();
+    handle_float64_nulls(&mut output, &array, NullHandling::FillZero).unwrap();
+    assert_eq!(output, vec![1.0, 0.0, 3.0, 0.0]);
+}
+
+#[test]
+fn reject_returns_error_on_null() {
+    let array = Float64Array::from(vec![Some(1.0), None, Some(3.0)]);
+    let mut output = Vec::new();
+    let result = handle_float64_nulls(&mut output, &array, NullHandling::Reject);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("Null value encountered"),
+        "unexpected error: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn no_nulls_fast_path() {
+    let array = Float64Array::from(vec![1.0, 2.0, 3.0, 4.0]);
+    let mut output = Vec::new();
+
+    // Both policies should succeed and produce the same result when no nulls present
+    handle_float64_nulls(&mut output, &array, NullHandling::FillZero).unwrap();
+    assert_eq!(output, vec![1.0, 2.0, 3.0, 4.0]);
+
+    let mut output2 = Vec::new();
+    handle_float64_nulls(&mut output2, &array, NullHandling::Reject).unwrap();
+    assert_eq!(output2, vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn default_is_fill_zero() {
+    assert_eq!(NullHandling::default(), NullHandling::FillZero);
+}
+
+#[test]
+fn fill_zero_on_all_nulls() {
+    let array = Float64Array::from(vec![None, None, None]);
+    let mut output = Vec::new();
+    handle_float64_nulls(&mut output, &array, NullHandling::FillZero).unwrap();
+    assert_eq!(output, vec![0.0, 0.0, 0.0]);
+}
+
+#[test]
+fn empty_array_is_noop() {
+    let array = Float64Array::from(Vec::<f64>::new());
+    let mut output = Vec::new();
+    handle_float64_nulls(&mut output, &array, NullHandling::FillZero).unwrap();
+    assert!(output.is_empty());
+    handle_float64_nulls(&mut output, &array, NullHandling::Reject).unwrap();
+    assert!(output.is_empty());
+}

--- a/qdp/qdp-python/qumat_qdp/loader.py
+++ b/qdp/qdp-python/qumat_qdp/loader.py
@@ -118,6 +118,7 @@ class QuantumDataLoader:
         )
         self._synthetic_requested = False  # set True only by source_synthetic()
         self._file_requested = False
+        self._null_handling: Optional[str] = None
 
     def qubits(self, n: int) -> QuantumDataLoader:
         """Set number of qubits. Returns self for chaining."""
@@ -190,6 +191,15 @@ class QuantumDataLoader:
         self._seed = s
         return self
 
+    def null_handling(self, policy: str) -> QuantumDataLoader:
+        """Set null handling policy ('fill_zero' or 'reject'). Returns self for chaining."""
+        if policy not in ("fill_zero", "reject"):
+            raise ValueError(
+                f"null_handling must be 'fill_zero' or 'reject', got {policy!r}"
+            )
+        self._null_handling = policy
+        return self
+
     def _create_iterator(self) -> Iterator[object]:
         """Build engine and return the Rust-backed loader iterator (synthetic or file)."""
         if self._synthetic_requested and self._file_requested:
@@ -237,6 +247,7 @@ class QuantumDataLoader:
                     num_qubits=self._num_qubits,
                     encoding_method=self._encoding_method,
                     batch_limit=None,
+                    null_handling=self._null_handling,
                 )
             )
         create_synthetic_loader = getattr(engine, "create_synthetic_loader", None)
@@ -251,6 +262,7 @@ class QuantumDataLoader:
                 num_qubits=self._num_qubits,
                 encoding_method=self._encoding_method,
                 seed=self._seed,
+                null_handling=self._null_handling,
             )
         )
 

--- a/qdp/qdp-python/tests/test_quantum_data_loader.py
+++ b/qdp/qdp-python/tests/test_quantum_data_loader.py
@@ -141,3 +141,46 @@ def test_streaming_parquet_extension_ok():
     # Iteration may raise RuntimeError (no CUDA) or fail on missing file; we only check builder accepts.
     assert loader._streaming_requested is True
     assert loader._file_path == "/tmp/data.parquet"
+
+
+# --- NullHandling builder tests ---
+
+
+@pytest.mark.skipif(not _loader_available(), reason="QuantumDataLoader not available")
+def test_null_handling_fill_zero():
+    """null_handling('fill_zero') sets the field correctly."""
+    loader = (
+        QuantumDataLoader(device_id=0)
+        .qubits(4)
+        .batches(10, size=4)
+        .null_handling("fill_zero")
+    )
+    assert loader._null_handling == "fill_zero"
+
+
+@pytest.mark.skipif(not _loader_available(), reason="QuantumDataLoader not available")
+def test_null_handling_reject():
+    """null_handling('reject') sets the field correctly."""
+    loader = (
+        QuantumDataLoader(device_id=0)
+        .qubits(4)
+        .batches(10, size=4)
+        .null_handling("reject")
+    )
+    assert loader._null_handling == "reject"
+
+
+@pytest.mark.skipif(not _loader_available(), reason="QuantumDataLoader not available")
+def test_null_handling_invalid_raises():
+    """null_handling with an invalid string raises ValueError."""
+    with pytest.raises(ValueError) as exc_info:
+        QuantumDataLoader(device_id=0).null_handling("invalid_policy")
+    msg = str(exc_info.value)
+    assert "fill_zero" in msg or "reject" in msg
+
+
+@pytest.mark.skipif(not _loader_available(), reason="QuantumDataLoader not available")
+def test_null_handling_default_is_none():
+    """By default, _null_handling is None (Rust will use FillZero)."""
+    loader = QuantumDataLoader(device_id=0)
+    assert loader._null_handling is None


### PR DESCRIPTION
### Related Issues

Closes #765 

### Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

### How

- Unify null value handling between batch and streaming Parquet/Arrow readers by introducing a configurable `NullHandling` enum (`FillZero` | `Reject`)
- Previously batch mode silently coerced nulls to `0.0` while streaming mode threw a runtime error — both paths now use the same `handle_float64_nulls()` helper
- Defaults to `FillZero` for backward compatibility; `Reject` returns a clear error with guidance
- Threads the policy through `PipelineConfig`, PyO3 bindings, and the Python `QuantumDataLoader` builder (`.null_handling("fill_zero" | "reject")`)

## Checklist

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
