### PR TITLE
Fix devcontainer workspace path in setup.sh

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -21,6 +21,6 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 source $HOME/.local/bin/env
 
 # setup pre-commit hooks
-cd /workspaces/mahout
+cd /workspace
 uv sync --group dev
 uv run pre-commit install


### PR DESCRIPTION
Fixes #1103. Corrects workspace path from /workspaces/mahout to /workspace to match devcontainer.json configuration.