### PR TITLE
Add default null handling to run_throughput_pipeline_py function

### DIFF
--- a/qdp/qdp-python/src/lib.rs
+++ b/qdp/qdp-python/src/lib.rs
@@ -50,6 +50,7 @@ fn run_throughput_pipeline_py(
         encoding_method,
         seed,
         warmup_batches,
+        null_handling: qdp_core::NullHandling::default(),
     };
     let result = py
         .detach(|| qdp_core::run_throughput_pipeline(&config))


### PR DESCRIPTION
### Related Issues

current ci is failing because of a previous commit! I'll fix it.

<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

### How

<!-- What was done? -->

## Checklist

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
