### PR TITLE
Improve test coverage for qiskit_backend.py to 99%

### DIFF
--- a/testing/qumat/test_create_circuit.py
+++ b/testing/qumat/test_create_circuit.py
@@ -206,3 +206,21 @@ class TestBackendConfigValidation:
 
         assert qumat.backend is not None
         assert qumat.backend.options.method == "matrix_product_state"
+
+
+@pytest.mark.parametrize("backend_name", TESTING_BACKENDS)
+class TestCircuitDrawing:
+    """Test class for circuit drawing functionality."""
+
+    def test_draw_circuit_returns_output(self, backend_name):
+        """Test that draw_circuit runs successfully and returns an output."""
+        backend_config = get_backend_config(backend_name)
+        qumat = QuMat(backend_config)
+
+        qumat.create_empty_circuit(num_qubits=2)
+        qumat.apply_hadamard_gate(0)
+        qumat.apply_cnot_gate(0, 1)
+
+        drawing = qumat.draw_circuit()
+
+        assert drawing is not None

--- a/testing/qumat/test_create_circuit.py
+++ b/testing/qumat/test_create_circuit.py
@@ -194,3 +194,15 @@ class TestBackendConfigValidation:
 
         with pytest.raises(KeyError, match="missing required key.*backend_options"):
             QuMat(config)
+
+    def test_qiskit_custom_simulator_fallback(self):
+        """Test that Qiskit backend accepts simulator types outside the legacy map."""
+        config = {
+            "backend_name": "qiskit",
+            "backend_options": {"simulator_type": "matrix_product_state"},
+        }
+
+        qumat = QuMat(config)
+
+        assert qumat.backend is not None
+        assert qumat.backend.options.method == "matrix_product_state"

--- a/testing/qumat/test_multi_qubit_gates.py
+++ b/testing/qumat/test_multi_qubit_gates.py
@@ -490,3 +490,19 @@ class TestMultiQubitGatesEdgeCases:
                 assert abs(probabilities[i] - probabilities[j]) < 0.05, (
                     f"Backends have inconsistent CNOT results: {results_dict}"
                 )
+
+
+@pytest.mark.parametrize("backend_name", TESTING_BACKENDS)
+def test_apply_swap_gate(backend_name):
+    """Test that the SWAP gate applies correctly across backends."""
+    backend_config = get_backend_config(backend_name)
+    qumat = QuMat(backend_config)
+
+    qumat.create_empty_circuit(num_qubits=2)
+
+    qumat.apply_pauli_x_gate(0)
+
+    qumat.apply_swap_gate(0, 1)
+
+    results = qumat.execute_circuit()
+    assert results is not None


### PR DESCRIPTION
### Related Issues

Related to #1058 

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

This PR improves the test coverage for the `qiskit_backend.py` module by addressing few previously untested code paths.
and also improves some test coverage for all backends(cirq_backend.py, amazon_braket_backend.py).

### How

Add unit tests covering: 

* Backend Initialization (add test_qiskit_custom_simulator_fallback): 

    * Triggered the else block of initialize_backend using a mock setup ("simulator_type": "matrix_product_state"). Evaluates the correct propagation of the configuration parameter through to the underlying AerSimulator.

* Circuit Visualization (add test_draw_circuit_returns_output): 

    * Validated the rendering function (draw_circuit) in multiple backend configurations by creating class TestCircuitDrawing. Testing all backends as well.

* Swap Operation (add test_apply_swap_gate): 

    * Tested the swap gate function (apply_swap_gate) by initiating state (|10⟩ by a Pauli-X), executing apply_swap_gate, and then checked the operation returned successfully in qumat execution contexts. Testing all backends as well.

Coverage Improve: 

* qiskit_backend.py: 95% → 99%
* amazon_braket_backend.py: 99% → 100%
* cirq_backend.py: 93% → 97%
* qumat.py: 92% → 97%

## Checklist

- [x] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
