### PR TITLE
document hardcoded NullHandling::FillZero in stream_encode

### DIFF
--- a/qdp/qdp-core/src/encoding/mod.rs
+++ b/qdp/qdp-core/src/encoding/mod.rs
@@ -134,6 +134,14 @@ pub(crate) trait ChunkEncoder {
 ///
 /// This function handles all the common IO, buffering, and GPU memory
 /// management logic. The actual encoding is delegated to the `ChunkEncoder`.
+///
+/// # Null handling
+///
+/// The streaming Parquet path always uses [`crate::reader::NullHandling::FillZero`]
+/// when constructing the [`crate::io::ParquetBlockReader`]. This replaces any
+/// null values in the input with `0.0`, matching Mahout's historical behavior
+/// and keeping the API backward compatible. Callers that require stricter
+/// validation should ensure the input data contains no nulls.
 pub(crate) fn stream_encode<E: ChunkEncoder>(
     engine: &QdpEngine,
     path: &str,

--- a/qdp/qdp-core/src/lib.rs
+++ b/qdp/qdp-core/src/lib.rs
@@ -261,6 +261,13 @@ impl QdpEngine {
     /// * `num_qubits` - Number of qubits
     /// * `encoding_method` - Strategy: "amplitude", "angle", or "basis"
     ///
+    /// # Null handling
+    ///
+    /// When reading from Parquet, the streaming encoder always uses
+    /// [`NullHandling::FillZero`] for the underlying `ParquetBlockReader`. This
+    /// replaces any null values with `0.0`, matching the behavior of the batch
+    /// readers and preserving backward compatibility.
+    ///
     /// # Returns
     /// DLPack pointer to encoded states [num_samples, 2^num_qubits]
     pub fn encode_from_parquet(


### PR DESCRIPTION
### Related Issues



<!-- Closes #123 -->

Closes #1109 

follow up of [#1101 (comment)](https://github.com/apache/mahout/pull/1101#discussion_r2868916951)

### Changes



- [ ] Bug fix

- [ ] New feature

- [ ] Refactoring

- [x] Documentation

- [ ] Test

- [ ] CI/CD pipeline

- [ ] Other



### Why



<!-- Why is this change needed? -->

This PR addresses the missing documentation regarding null handling in the streaming reader path, as discussed in [#1101 (comment)](https://github.com/apache/mahout/pull/1101#discussion_r2868916951) . 



Currently, `stream_encode()` uses hardcoded `NullHandling::FillZero` for `ParquetBlockReader` because the streaming API does not yet accept configuration options. To avoid confusion, this PR adds explicit docstrings to clarify this behavior for callers.

### How

- Added a section on **Null handling** in `lib.rs` to explain that the streaming encoder replaces null values with `0.0` for backward compatibility.

- Added detailed documentation to the `stream_encode` function in `mod.rs`, noting the historical behavior of Mahout and advising callers requiring stricter validation to ensure their input data is free of nulls.

<!-- What was done? -->



## Checklist



- [ ] Added or updated unit tests for all changes

- [x] Added or updated documentation for all changes

