### PR TITLE
[QDP]Remove duplicate cuda_error_to_string in gpu/memory.rs and reuse crate error mapping

### DIFF
--- a/qdp/qdp-core/src/gpu/memory.rs
+++ b/qdp/qdp-core/src/gpu/memory.rs
@@ -25,6 +25,9 @@ use std::ffi::c_void;
 #[cfg(target_os = "linux")]
 use std::sync::Arc;
 
+#[cfg(target_os = "linux")]
+use crate::error::cuda_error_to_string;
+
 /// Precision of the GPU state vector.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Precision {
@@ -38,17 +41,6 @@ use crate::gpu::cuda_ffi::{cudaFreeHost, cudaHostAlloc, cudaMemGetInfo};
 #[cfg(target_os = "linux")]
 fn bytes_to_mib(bytes: usize) -> f64 {
     bytes as f64 / (1024.0 * 1024.0)
-}
-
-#[cfg(target_os = "linux")]
-fn cuda_error_to_string(code: i32) -> &'static str {
-    match code {
-        0 => "cudaSuccess",
-        2 => "cudaErrorMemoryAllocation",
-        3 => "cudaErrorInitializationError",
-        30 => "cudaErrorUnknown",
-        _ => "Unknown CUDA error",
-    }
 }
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
### Related Issues

<!-- Closes #123 -->
Closes #1123 

### Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->
This PR refactors CUDA error handling in qdp-core/src/gpu/memory.rs by replacing its limited internal error-to-string logic with the more comprehensive implementation in qdp-core/src/error.rs.

### How

<!-- What was done? -->
Removed the redundant and incomplete private `cuda_error_to_string` function in `qdp-core/src/gpu/memory.rs`.
Integrated the existing pub fn `cuda_error_to_string` from `qdp-core/src/error.rs`.