### PR TITLE
docs(basic-gates.md): fix broken LaTeX math in GitHub Markdown

### DIFF
--- a/docs/qumat/basic-gates.md
+++ b/docs/qumat/basic-gates.md
@@ -56,7 +56,19 @@ $$\text{CSWAP}|c\rangle|t_1\rangle|t_2\rangle = \begin{cases} |c\rangle|t_1\rang
 
 In matrix form (for the 8-dimensional space of three qubits), the CSWAP gate is:
 
-$$\text{CSWAP} = \begin{pmatrix} 1 & 0 & 0 & 0 & 0 & 0 & 0 & 0 \\ 0 & 1 & 0 & 0 & 0 & 0 & 0 & 0 \\ 0 & 0 & 1 & 0 & 0 & 0 & 0 & 0 \\ 0 & 0 & 0 & 1 & 0 & 0 & 0 & 0 \\ 0 & 0 & 0 & 0 & 1 & 0 & 0 & 0 \\ 0 & 0 & 0 & 0 & 0 & 0 & 1 & 0 \\ 0 & 0 & 0 & 0 & 0 & 1 & 0 & 0 \\ 0 & 0 & 0 & 0 & 0 & 0 & 0 & 1 \end{pmatrix}$$
+$$
+\text{CSWAP} =
+\begin{pmatrix}
+1 & 0 & 0 & 0 & 0 & 0 & 0 & 0 \\
+0 & 1 & 0 & 0 & 0 & 0 & 0 & 0 \\
+0 & 0 & 1 & 0 & 0 & 0 & 0 & 0 \\
+0 & 0 & 0 & 1 & 0 & 0 & 0 & 0 \\
+0 & 0 & 0 & 0 & 1 & 0 & 0 & 0 \\
+0 & 0 & 0 & 0 & 0 & 0 & 1 & 0 \\
+0 & 0 & 0 & 0 & 0 & 1 & 0 & 0 \\
+0 & 0 & 0 & 0 & 0 & 0 & 0 & 1
+\end{pmatrix}
+$$
 
 The CSWAP gate is fundamental in quantum algorithms such as the swap test, quantum error correction, and quantum state comparison. The CSWAP gate is reversible and preserves the number of $|1\rangle$ states in the system (conserves the Hamming weight).
 
@@ -67,7 +79,13 @@ The U gate is a **universal single-qubit gate** parameterized by three angles ($
 
 The U gate matrix representation is:
 
-$$U(\theta, \phi, \lambda) = \begin{pmatrix} \cos(\theta/2) & -e^{i\lambda}\sin(\theta/2) \\ e^{i\phi}\sin(\theta/2) & e^{i(\phi+\lambda)}\cos(\theta/2) \end{pmatrix}$$
+$$
+U(\theta, \phi, \lambda) =
+\begin{pmatrix}
+\cos(\theta/2)          & -e^{i\lambda}\sin(\theta/2) \\
+e^{i\phi}\sin(\theta/2) & e^{i(\phi+\lambda)}\cos(\theta/2)
+\end{pmatrix}
+$$
 
 The U gate can be decomposed into rotations around the Z, Y, and Z axes:
 


### PR DESCRIPTION
The matrix representation is broken with GitHub Markdown renderer.

### Related Issues

NA

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

It's broken and unreadable.

### How

Add more new lines.

## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes

## Validation of changes

Before:

<img width="1075" height="813" alt="image" src="https://github.com/user-attachments/assets/dc06f10f-efec-4606-a10d-10b5cacf95c8" />


After:

<img width="1062" height="706" alt="image" src="https://github.com/user-attachments/assets/17331dc3-8fba-4cc2-a7c4-fe4264e78d2f" />
