### PR TITLE
docs(README): update basic-gates link to point to the documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ For additional information about Mahout, visit the [Mahout Home Page](http://mah
 
 Qumat is a high-level Python library for quantum computing that provides:
 
-- **Quantum Circuit Abstraction** - Build quantum circuits with standard gates (Hadamard, CNOT, Pauli, etc.) and run them on Qiskit, Cirq, or Amazon Braket with a single unified API. Write once, execute anywhere. Check out [basic gates](docs/qumat/basic-gates.md) for a quick introduction to the basic gates supported across all backends.
+- **Quantum Circuit Abstraction** - Build quantum circuits with standard gates (Hadamard, CNOT, Pauli, etc.) and run them on Qiskit, Cirq, or Amazon Braket with a single unified API. Write once, execute anywhere. Check out [basic gates](https://mahout.apache.org/docs/qumat/basic-gates/) for a quick introduction to the basic gates supported across all backends.
 - **QDP (Quantum Data Plane)** - Encode classical data into quantum states using GPU-accelerated kernels. Zero-copy tensor transfer via DLPack lets you move data between PyTorch, NumPy, and TensorFlow without overhead.
 
 ## Quick Start


### PR DESCRIPTION
Ok a better option is to make the link point to the documentation site (I didn't know there is a documentation site in the previous PRs)

### Related Issues

Related to #1126

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

### How

<!-- What was done? -->

## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
