### PR TITLE
docs(katex): remove custom .katex style to address math expression duplication issue

### DIFF
--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -161,7 +161,6 @@
 
 /* Math equations styling */
 .katex-display {
-  overflow-x: auto;
   padding: 1rem 0;
 }
 


### PR DESCRIPTION
## Validation

Before:

<img width="1010" height="727" alt="image" src="https://github.com/user-attachments/assets/d99049e1-1eef-481f-a1cd-daf2d02d43ee" />


After:

<img width="978" height="552" alt="image" src="https://github.com/user-attachments/assets/e934ab78-881f-40d8-85fb-e297c495fd60" />


### Related Issues

NA

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

### How

The following is in the katex CDN file:

```css
.katex .katex-mathml {
  position: absolute;
  clip: rect(1px, 1px, 1px, 1px);
  padding: 0;
  border: 0;
  height: 1px;
  width: 1px;
  overflow: hidden;
}
```

`overflow: auto` in `custom.css` is the root cause of this issue.

## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
