### PR TITLE
docs: better hot reload

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -41,6 +41,7 @@ const config: Config = {
       'classic',
       {
         docs: {
+          path: '../docs/',
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/apache/mahout/tree/main/docs/',
           remarkPlugins: [remarkMath],


### PR DESCRIPTION
Now Docusaurus watches `docs/`.

### Related Issues

<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [x] Other

Documentation site DX improvement

### Why

<!-- Why is this change needed? -->

### How

<!-- What was done? -->

## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
