### PR TITLE
docs: use relative path to avoid link to docs with different version

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ anywhere.'
 ## Documentation
 
 ### Getting Started
-- [Getting Started with QuMat](/docs/qumat/getting-started) - Introduction and setup guide
+- [Getting Started with QuMat](./qumat/getting-started) - Introduction and setup guide
 
 ### Core Concepts
 - [Basic Gates](./qumat/basic-gates) - Introduction to fundamental quantum gates (NOT, Hadamard, CNOT, Toffoli, SWAP, Pauli gates, CSWAP, U gate)

--- a/docs/qumat/getting-started.md
+++ b/docs/qumat/getting-started.md
@@ -70,6 +70,6 @@ Refer to repository examples:
 
 ## Next Steps
 
-- [Basic Gates](/docs/qumat/basic-gates)
-- [API Reference](/docs/qumat/api)
-- [QDP Getting Started](/docs/qdp/getting-started)
+- [Basic Gates](./basic-gates)
+- [API Reference](./api)
+- [QDP Getting Started](../qdp/getting-started)


### PR DESCRIPTION
Before the change, the destination of the link is still **latest** doc, even I'm on **next**. This PR fixes it.

<img width="1909" height="955" alt="image" src="https://github.com/user-attachments/assets/639349db-4aa9-42dd-9c59-d9b2eed20711" />


### Related Issues

<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

### How

<!-- What was done? -->

## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
