### PR TITLE
docs: fix doc version inconsistency in navbar

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -145,8 +145,9 @@ const config: Config = {
               href: 'https://www.apache.org/foundation/how-it-works.html',
             },
             {
+              type: 'doc',
+              docId: 'about/how-to-contribute',
               label: 'How to Contribute',
-              to: '/docs/about/how-to-contribute',
             },
           ],
         },
@@ -157,30 +158,36 @@ const config: Config = {
           position: 'left',
           items: [
             {
+              type: 'doc',
+              docId: 'qumat/index',
               label: 'Overview',
-              to: '/docs/qumat',
             },
             {
+              type: 'doc',
+              docId: 'qumat/getting-started',
               label: 'Getting Started',
-              to: '/docs/qumat/getting-started',
             },
             {
+              type: 'doc',
+              docId: 'qdp/index',
               label: 'QDP (Data Encoding)',
-              to: '/docs/qdp',
             },
             {
+              type: 'doc',
+              docId: 'learning/quantum-computing-primer/index',
               label: 'Quantum Computing Primer',
-              to: '/docs/learning/quantum-computing-primer',
             },
             {
+              type: 'doc',
+              docId: 'learning/papers/index',
               label: 'Research Papers',
-              to: '/docs/learning/papers',
             },
           ],
         },
         // Download
         {
-          to: '/docs/qumat/getting-started',
+          type: 'doc',
+          docId: 'qumat/getting-started',
           label: 'Download',
           position: 'left',
         },
@@ -191,24 +198,28 @@ const config: Config = {
           position: 'left',
           items: [
             {
+              type: 'doc',
+              docId: 'community/index',
               label: 'Overview',
-              to: '/docs/community',
             },
             {
+              type: 'doc',
+              docId: 'community/who-we-are',
               label: 'Who We Are',
-              to: '/docs/community/who-we-are',
             },
             {
+              type: 'doc',
+              docId: 'community/mailing-lists',
               label: 'Mailing Lists',
-              to: '/docs/community/mailing-lists',
             },
             {
               label: 'Issue Tracker',
               href: 'https://issues.apache.org/jira/browse/MAHOUT',
             },
             {
+              type: 'doc',
+              docId: 'community/code-of-conduct',
               label: 'Code of Conduct',
-              to: '/docs/community/code-of-conduct',
             },
           ],
         },

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -109,6 +109,11 @@
   color: var(--ifm-font-color-base);
 }
 
+/* Remove background color from active dropdown links, probably a bug in Docusaurus */
+.dropdown__link--active:not(:hover) {
+  background-color: unset;
+}
+
 /* Dark mode navbar adjustments */
 [data-theme='dark'] .navbar {
   background-color: #00838f;


### PR DESCRIPTION
The internal doc links in the navbar always pointed to **latest** doc due to hard-coded absolute path. After this PR, the links will point to correct version doc.

Before:

<img width="1903" height="956" alt="image" src="https://github.com/user-attachments/assets/8a10c9a6-719a-417f-86f9-c920f5946362" />

After (notice the difference at the lower left corner):

<img width="1890" height="953" alt="image" src="https://github.com/user-attachments/assets/c20feb26-e49a-454c-9846-2a3b3a08637b" />

However, you may notice that the dropdown items are active after the change... I suspect that this is an issue of docusaurus... I found a blog post [here](https://www.hwchiu.com/2023/10/08/docusaurus-link-active) that is a similar but different issue.

**Edit:** updated custom.css as a workaround for the above issue. Now the dropdown menu looks good again.

latest

<img width="1348" height="318" alt="image" src="https://github.com/user-attachments/assets/2ece21fd-0447-48ec-8eb1-0188e1a6694c" />

next

<img width="1350" height="374" alt="image" src="https://github.com/user-attachments/assets/5be41476-0c41-4856-aa78-d6033346972e" />


### Related Issues

<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

### How

<!-- What was done? -->

## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
