### PR TITLE
ci: add automated link checker

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -1,0 +1,44 @@
+# To run similar tasks locally, install lychee and run the following at the root of the repository:
+# lychee .
+
+name: Links
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: "00 18 * * *"
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write # required for Broken Links Report
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Link Checker
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: --config lychee.toml .
+          fail: false
+
+      - name: Broken Links Report
+        if: steps.lychee.outputs.exit_code != 0 && github.event_name == 'schedule'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs');
+
+            // Read the markdown file
+            // Ensure the path is correct relative to the workspace root
+            const reportBody = fs.readFileSync('./lychee/out.md', 'utf8');
+
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Broken Links Report',
+              body: reportBody
+            });

--- a/docs/qdp/getting-started.md
+++ b/docs/qdp/getting-started.md
@@ -72,9 +72,9 @@ engine.encode("data.parquet", num_qubits=10, encoding_method="amplitude")  # als
 
 ## Next Steps
 
-- [Concepts](../concepts/) - Learn about quantum encoding concepts
-- [API Reference](../api/) - Detailed API documentation
-- [Examples](../examples/) - More usage examples
+- [Concepts](./concepts/) - Learn about quantum encoding concepts
+- [API Reference](./api/) - Detailed API documentation
+- [Examples](./examples/) - More usage examples
 
 ## Help
 

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,10 @@
+exclude_path = [
+    "./docs/adr", # ADRs are not part of the core documentation
+    "./docs/blog", # Let's not check blog links for now
+    "./website/versioned*", # Focus on next version
+    "./website/static/download/downloads.html", # Should we fix in the future?
+    "./dev/rc-email-template.md", # Should we fix in the future?
+    "./docs/about/how-to-contribute.md", # TODO: fix the links in this file
+    "./qdp/docs/readers/README.md", # TODO: fix the links in this file
+]
+fallback_extensions = ["md"]


### PR DESCRIPTION
We have similar setup in commitizen-tools/commitizen.

https://github.com/commitizen-tools/commitizen/blob/master/.github/workflows/links.yml

Also left some comments in `lychee.toml` as future tasks.

### Related Issues

<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [x] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

### How

<!-- What was done? -->

## Checklist

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
