### PR TITLE
[QDP] Enhance benchmark's installation journey

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ pre-commit: setup-test-python
 setup-benchmark: setup-test-python
 ifeq ($(HAS_NVIDIA),yes)
 	@echo "[INFO] Setting up benchmark environment..."
+	uv sync --group dev --extra qdp
 	uv sync --project qdp/qdp-python --group benchmark --active
 	unset CONDA_PREFIX && uv run --active maturin develop --manifest-path qdp/qdp-python/Cargo.toml
 else

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: test_rust test_python tests pre-commit setup-test-python install-llvm-cov benchmark setup-benchmark
+.PHONY: test_rust test_python tests pre-commit setup-test-python install-llvm-cov setup-benchmark
 
 # Detect NVIDIA GPU
 HAS_NVIDIA := $(shell command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1 && echo yes || echo no)
@@ -51,14 +51,6 @@ ifeq ($(HAS_NVIDIA),yes)
 	uv sync --group dev --extra qdp
 	uv sync --project qdp/qdp-python --group benchmark --active
 	unset CONDA_PREFIX && uv run --active maturin develop --manifest-path qdp/qdp-python/Cargo.toml
-else
-	@echo "[SKIP] No NVIDIA GPU detected, skipping maturin develop"
-	@echo "[INFO] Setting up benchmark environment (CPU-only)..."
-	uv sync --project qdp/qdp-python --group benchmark --active
-endif
-
-benchmark: setup-benchmark
-ifeq ($(HAS_NVIDIA),yes)
 	@echo "[INFO] Benchmark environment ready. The following benchmarks are available:"
 	@echo "[INFO] Available benchmark scripts:"
 	@echo "  - benchmark_e2e.py: End-to-end latency (Disk -> GPU VRAM)"
@@ -72,6 +64,8 @@ ifeq ($(HAS_NVIDIA),yes)
 	@echo ""
 	@echo "[INFO] See qdp/qdp-python/benchmark/README.md for more options."
 else
-	@echo "[SKIP] No NVIDIA GPU detected, skipping benchmarks"
+	@echo "[SKIP] No NVIDIA GPU detected, skipping maturin develop"
+	@echo "[INFO] Setting up benchmark environment (CPU-only)..."
+	uv sync --project qdp/qdp-python --group benchmark --active
 	@echo "[INFO] Benchmarks require NVIDIA GPU. Setup completed for manual execution."
 endif

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ endif
 
 benchmark: setup-benchmark
 ifeq ($(HAS_NVIDIA),yes)
-	@echo "[INFO] Running benchmarks..."
+	@echo "[INFO] Benchmark environment ready. The following benchmarks are available:"
 	@echo "[INFO] Available benchmark scripts:"
 	@echo "  - benchmark_e2e.py: End-to-end latency (Disk -> GPU VRAM)"
 	@echo "  - benchmark_latency.py: Data-to-State latency (CPU RAM -> GPU VRAM)"

--- a/Makefile
+++ b/Makefile
@@ -66,9 +66,9 @@ ifeq ($(HAS_NVIDIA),yes)
 	@echo "  - benchmark_throughput.py: DataLoader-style throughput"
 	@echo ""
 	@echo "[INFO] Run specific benchmarks with:"
-	@echo "  uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_e2e.py"
-	@echo "  uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_latency.py"
-	@echo "  uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_throughput.py"
+	@echo "  uv run --active python qdp/qdp-python/benchmark/benchmark_e2e.py"
+	@echo "  uv run --active python qdp/qdp-python/benchmark/benchmark_latency.py"
+	@echo "  uv run --active python qdp/qdp-python/benchmark/benchmark_throughput.py"
 	@echo ""
 	@echo "[INFO] See qdp/qdp-python/benchmark/README.md for more options."
 else

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-.PHONY: test_rust test_python tests pre-commit setup-test-python install-llvm-cov
+.PHONY: test_rust test_python tests pre-commit setup-test-python install-llvm-cov benchmark setup-benchmark
 
 # Detect NVIDIA GPU
 HAS_NVIDIA := $(shell command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi -L >/dev/null 2>&1 && echo yes || echo no)
@@ -44,3 +44,33 @@ tests: test_rust test_python
 
 pre-commit: setup-test-python
 	uv run pre-commit run --all-files
+
+setup-benchmark: setup-test-python
+ifeq ($(HAS_NVIDIA),yes)
+	@echo "[INFO] Setting up benchmark environment..."
+	uv sync --project qdp/qdp-python --group benchmark --active
+	unset CONDA_PREFIX && uv run --active maturin develop --manifest-path qdp/qdp-python/Cargo.toml
+else
+	@echo "[SKIP] No NVIDIA GPU detected, skipping maturin develop"
+	@echo "[INFO] Setting up benchmark environment (CPU-only)..."
+	uv sync --project qdp/qdp-python --group benchmark --active
+endif
+
+benchmark: setup-benchmark
+ifeq ($(HAS_NVIDIA),yes)
+	@echo "[INFO] Running benchmarks..."
+	@echo "[INFO] Available benchmark scripts:"
+	@echo "  - benchmark_e2e.py: End-to-end latency (Disk -> GPU VRAM)"
+	@echo "  - benchmark_latency.py: Data-to-State latency (CPU RAM -> GPU VRAM)"
+	@echo "  - benchmark_throughput.py: DataLoader-style throughput"
+	@echo ""
+	@echo "[INFO] Run specific benchmarks with:"
+	@echo "  uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_e2e.py"
+	@echo "  uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_latency.py"
+	@echo "  uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_throughput.py"
+	@echo ""
+	@echo "[INFO] See qdp/qdp-python/benchmark/README.md for more options."
+else
+	@echo "[SKIP] No NVIDIA GPU detected, skipping benchmarks"
+	@echo "[INFO] Benchmarks require NVIDIA GPU. Setup completed for manual execution."
+endif

--- a/qdp/DEVELOPMENT.md
+++ b/qdp/DEVELOPMENT.md
@@ -96,7 +96,7 @@ uv run pytest qdp/qdp-python/tests -v
 From the repo root, set up and prepare benchmarks:
 
 ```bash
-make benchmark
+make setup-benchmark
 ```
 
 This will:
@@ -119,7 +119,7 @@ uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_e2e.py
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_throughput.py --qubits 16 --batches 200 --batch-size 64 --prefetch 16
 ```
 
-For manual setup (if `make benchmark` is not available):
+For manual setup (if `make setup-benchmark` is not available):
 
 ```bash
 source .venv/bin/activate

--- a/qdp/DEVELOPMENT.md
+++ b/qdp/DEVELOPMENT.md
@@ -93,14 +93,18 @@ uv run pytest qdp/qdp-python/tests -v
 
 ## 4. Benchmarks
 
-Install benchmark dependency group into the same root venv:
+From the repo root, set up and prepare benchmarks:
 
 ```bash
-source .venv/bin/activate
-uv sync --project qdp/qdp-python --group benchmark --active
+make benchmark
 ```
 
-Run benchmark scripts:
+This will:
+1. Install benchmark dependencies into the unified root venv
+2. Build the QDP extension (if GPU available)
+3. Display instructions for running specific benchmarks
+
+Then run benchmark scripts:
 
 ```bash
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_e2e.py
@@ -114,6 +118,15 @@ Examples:
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_e2e.py --frameworks all
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_throughput.py --qubits 16 --batches 200 --batch-size 64 --prefetch 16
 ```
+
+For manual setup (if `make benchmark` is not available):
+
+```bash
+source .venv/bin/activate
+uv sync --project qdp/qdp-python --group benchmark --active
+```
+
+See [qdp/qdp-python/benchmark/README.md](qdp-python/benchmark/README.md) for detailed benchmark documentation.
 
 ## 5. NVTX / nsys Profiling
 

--- a/qdp/qdp-python/benchmark/README.md
+++ b/qdp/qdp-python/benchmark/README.md
@@ -37,8 +37,11 @@ This keeps all benchmark dependencies in the unified repo root venv (`mahout/.ve
 If you prefer to set up manually (or if `make benchmark` is not available):
 
 ```bash
+# First-time setup: install dependencies and build QDP extension
+uv sync --group dev --extra qdp
 source .venv/bin/activate
 uv sync --project qdp/qdp-python --group benchmark --active
+unset CONDA_PREFIX && uv run --active maturin develop --manifest-path qdp/qdp-python/Cargo.toml
 ```
 
 Then run benchmarks with `uv run --project qdp/qdp-python python ...`.

--- a/qdp/qdp-python/benchmark/README.md
+++ b/qdp/qdp-python/benchmark/README.md
@@ -11,12 +11,20 @@ scripts:
 
 ## Quick Start
 
-From the repo root:
+From the repo root, the easiest way to set up and run benchmarks is:
 
 ```bash
-uv sync --group dev --extra qdp
-source .venv/bin/activate
-uv sync --project qdp/qdp-python --group benchmark --active
+make benchmark
+```
+
+This will:
+1. Set up the benchmark environment in the unified root venv (`mahout/.venv`)
+2. Build the QDP extension (if GPU available)
+3. Display instructions for running specific benchmarks
+
+Then run individual benchmarks:
+
+```bash
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_e2e.py
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_latency.py
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_throughput.py
@@ -25,6 +33,8 @@ uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_throug
 This keeps all benchmark dependencies in the unified repo root venv (`mahout/.venv`).
 
 ## Manual Setup
+
+If you prefer to set up manually (or if `make benchmark` is not available):
 
 ```bash
 source .venv/bin/activate

--- a/qdp/qdp-python/benchmark/README.md
+++ b/qdp/qdp-python/benchmark/README.md
@@ -11,7 +11,7 @@ scripts:
 
 ## Quick Start
 
-From the repo root, the easiest way to set up and run benchmarks is:
+From the repo root, the easiest way to set up the benchmark environment is:
 
 ```bash
 make benchmark
@@ -19,10 +19,14 @@ make benchmark
 
 This will:
 1. Set up the benchmark environment in the unified root venv (`mahout/.venv`)
-2. Build the QDP extension (if GPU available)
-3. Display instructions for running specific benchmarks
+2. Attempt to build the QDP GPU extension (skipped on CPU-only systems)
+3. Display instructions for running specific benchmarks manually
 
-Then run individual benchmarks:
+> Note: These benchmarks require an NVIDIA GPU with compatible CUDA drivers. On
+> CPU-only systems, `make benchmark` will only prepare the environment and print
+> instructions; the GPU benchmarks themselves will not run.
+
+To run individual benchmarks after setup:
 
 ```bash
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_e2e.py


### PR DESCRIPTION
### Related Issues

<!-- Closes #123 -->
Closes #1141 

### Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->
Currently, `make benchmark` doesn't exist, and setting up benchmarks requires multiple manual steps. Since the Python environment has been unified to use the root `.venv`, we should provide a simple `make benchmark` command from the root directory to streamline the benchmark setup and execution process.
### How

<!-- What was done? -->
- Added `benchmark` and `setup-benchmark` targets to the root `Makefile`
  - `setup-benchmark`: Installs benchmark dependencies and builds QDP extension
  - `benchmark`: Sets up environment and displays instructions for running benchmarks
- Updated `qdp/qdp-python/benchmark/README.md` to document `make benchmark` as the recommended way
- Updated `qdp/DEVELOPMENT.md` to include `make benchmark` in the benchmarks section


## Checklist

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
