### PR TITLE
Pin lychee-action to ASF-approved SHA

### DIFF
--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Link Checker
         id: lychee
-        uses: lycheeverse/lychee-action@v2
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 # v2.8.0
         with:
           args: --config lychee.toml .
           fail: false


### PR DESCRIPTION
### Related Issues

https://github.com/apache/infrastructure-actions/pull/518

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [x] CI/CD pipeline
- [ ] Other

### Why

ASF infrastructure-actions now requires pinned SHA for lychee-action.

### How

<!-- What was done? -->

Pin lycheeverse/lychee-action to 8646ba30535128ac92d33dfc9133794bfdd9b411 (v2.8.0)

## Checklist

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
