### PR TITLE
fix: skip DLPack tests when no CUDA device is available

### DIFF
--- a/qdp/qdp-core/tests/dlpack.rs
+++ b/qdp/qdp-core/tests/dlpack.rs
@@ -31,7 +31,10 @@ mod dlpack_tests {
 
     #[test]
     fn test_dlpack_batch_shape() {
-        let device = CudaDevice::new(0).unwrap();
+        let device = match CudaDevice::new(0) {
+            Ok(device) => device,
+            Err(_) => return,
+        };
 
         let num_samples = 4;
         let num_qubits = 2; // 2^2 = 4 elements per sample
@@ -62,7 +65,10 @@ mod dlpack_tests {
 
     #[test]
     fn test_dlpack_single_shape() {
-        let device = CudaDevice::new(0).unwrap();
+        let device = match CudaDevice::new(0) {
+            Ok(device) => device,
+            Err(_) => return,
+        };
 
         let num_qubits = 2;
         let state_vector = GpuStateVector::new(&device, num_qubits, Precision::Float64)
@@ -95,7 +101,10 @@ mod dlpack_tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_dlpack_single_shape_f32() {
-        let device = CudaDevice::new(0).unwrap();
+        let device = match CudaDevice::new(0) {
+            Ok(device) => device,
+            Err(_) => return,
+        };
 
         let num_qubits = 2;
         let state_vector = GpuStateVector::new(&device, num_qubits, Precision::Float32)
@@ -128,7 +137,10 @@ mod dlpack_tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_dlpack_batch_shape_f32() {
-        let device = CudaDevice::new(0).unwrap();
+        let device = match CudaDevice::new(0) {
+            Ok(device) => device,
+            Err(_) => return,
+        };
 
         let num_samples = 3;
         let num_qubits = 2;
@@ -176,6 +188,9 @@ mod dlpack_tests {
     #[test]
     #[cfg(target_os = "linux")]
     fn test_synchronize_stream_legacy() {
+        if CudaDevice::new(0).is_err() {
+            return;
+        }
         unsafe {
             let result = synchronize_stream(CUDA_STREAM_LEGACY);
             assert!(


### PR DESCRIPTION
### Related Issues

closes #1169 

### Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

Several GPU-dependent DLPack tests in `qdp-core` used `CudaDevice::new(0).unwrap()`. In environments without a usable CUDA device, those tests panicked instead of skipping, which was inconsistent with the rest of the GPU test suite.

### How

Updated the following tests in `qdp/qdp-core/tests/dlpack.rs` to return early when `CudaDevice::new(0)` fails:

- `test_dlpack_batch_shape`
- `test_dlpack_single_shape`
- `test_dlpack_single_shape_f32`
- `test_dlpack_batch_shape_f32`
- `test_synchronize_stream_legacy`

This aligns DLPack test behavior with other GPU-dependent tests in the repository that already treat missing CUDA devices as a skip condition.

## Verification

Ran:

```bash
cargo test -p qdp-core --test dlpack --manifest-path qdp/Cargo.toml
```

Result:

```text
test result: ok. 9 passed; 0 failed
```

## Checklist

- [x] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
