### PR TITLE
Add pure-PyTorch reference implementations

### DIFF
--- a/qdp/qdp-python/benchmark/benchmark_pytorch_ref.py
+++ b/qdp/qdp-python/benchmark/benchmark_pytorch_ref.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Benchmark: QDP Rust+CUDA vs PyTorch reference implementation.
+
+Compares encoding throughput in two modes:
+
+* **encode-only** (default): Data is pre-generated on the target device
+  before the timer starts.  Both PyTorch and Mahout time encoding kernels
+  only, giving the fairest kernel-vs-kernel comparison.
+
+* **end-to-end**: Data generation, CPU→GPU transfer, and encoding are all
+  inside the timer.  Matches the full pipeline cost users actually pay.
+
+Usage:
+    # Fair kernel comparison (default):
+    python benchmark_pytorch_ref.py --qubits 16 --batches 100 --batch-size 64
+
+    # Full pipeline comparison:
+    python benchmark_pytorch_ref.py --mode end-to-end --qubits 16 --batches 100
+
+    # Specific frameworks:
+    python benchmark_pytorch_ref.py --encoding-method angle --frameworks pytorch-gpu,mahout
+"""
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import torch
+from utils import generate_batch_data
+
+FRAMEWORK_CHOICES = ("pytorch-cpu", "pytorch-gpu", "mahout")
+
+
+def _parse_frameworks(raw: str) -> list[str]:
+    """Parse comma-separated framework list; ``'all'`` expands to all choices."""
+    if raw.strip().lower() == "all":
+        return list(FRAMEWORK_CHOICES)
+    names = [s.strip() for s in raw.split(",")]
+    for n in names:
+        if n not in FRAMEWORK_CHOICES:
+            raise argparse.ArgumentTypeError(
+                f"Unknown framework {n!r}. Choose from: {', '.join(FRAMEWORK_CHOICES)}"
+            )
+    return names
+
+
+def _sample_dim(encoding_method: str, num_qubits: int) -> int:
+    if encoding_method == "basis":
+        return 1
+    if encoding_method == "angle":
+        return num_qubits
+    if encoding_method == "iqp":
+        return num_qubits + num_qubits * (num_qubits - 1) // 2
+    return 1 << num_qubits
+
+
+def _generate_batches(
+    total: int,
+    batch_size: int,
+    sample_dim: int,
+    encoding_method: str,
+    device: str,
+) -> list[torch.Tensor]:
+    """Pre-generate batch data using the shared utility (deterministic)."""
+    batches = []
+    for b in range(total):
+        np_data = generate_batch_data(
+            batch_size,
+            sample_dim,
+            encoding_method,
+            seed=42 + b,
+        )
+        if encoding_method == "basis":
+            t = torch.tensor(np_data.flatten(), dtype=torch.float64, device=device)
+        else:
+            t = torch.tensor(np_data, dtype=torch.float64, device=device)
+        batches.append(t)
+    return batches
+
+
+def run_pytorch(
+    *,
+    num_qubits: int,
+    total_batches: int,
+    batch_size: int,
+    encoding_method: str,
+    warmup_batches: int,
+    device: str,
+) -> tuple[float, float]:
+    """Run PyTorch reference encoding and return (duration_sec, vectors_per_sec)."""
+    from qumat_qdp.torch_ref import encode
+
+    dim = _sample_dim(encoding_method, num_qubits)
+    all_batches = _generate_batches(
+        warmup_batches + total_batches,
+        batch_size,
+        dim,
+        encoding_method,
+        device,
+    )
+
+    # Warmup.
+    for b in range(warmup_batches):
+        encode(all_batches[b], num_qubits, encoding_method, device=device)
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+
+    # Timed run.
+    start = time.perf_counter()
+    for b in range(warmup_batches, len(all_batches)):
+        encode(all_batches[b], num_qubits, encoding_method, device=device)
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+    duration = time.perf_counter() - start
+
+    total_vectors = total_batches * batch_size
+    vps = total_vectors / duration if duration > 0 else 0.0
+    return duration, vps
+
+
+def run_mahout(
+    *,
+    num_qubits: int,
+    total_batches: int,
+    batch_size: int,
+    encoding_method: str,
+    warmup_batches: int,
+    device_id: int,
+) -> tuple[float, float]:
+    """Run QDP Rust+CUDA pipeline and return (duration_sec, vectors_per_sec)."""
+    from qumat_qdp.api import QdpBenchmark
+
+    result = (
+        QdpBenchmark(device_id=device_id)
+        .backend("rust")
+        .qubits(num_qubits)
+        .encoding(encoding_method)
+        .batches(total_batches, size=batch_size)
+        .warmup(warmup_batches)
+        .run_throughput()
+    )
+    return result.duration_sec, result.vectors_per_sec
+
+
+def run_mahout_encode_only(
+    *,
+    num_qubits: int,
+    total_batches: int,
+    batch_size: int,
+    encoding_method: str,
+    warmup_batches: int,
+    device_id: int,
+) -> tuple[float, float]:
+    """Run Mahout encoding from pre-generated CUDA tensors (encode-only)."""
+    from _qdp import QdpEngine
+
+    engine = QdpEngine(device_id)
+    device = f"cuda:{device_id}"
+    dim = _sample_dim(encoding_method, num_qubits)
+    all_batches = _generate_batches(
+        warmup_batches + total_batches,
+        batch_size,
+        dim,
+        encoding_method,
+        device,
+    )
+
+    # Rust basis encoding expects int64 CUDA tensors.
+    if encoding_method == "basis":
+        all_batches = [b.to(torch.int64) for b in all_batches]
+
+    # Warmup.
+    for b in range(warmup_batches):
+        qt = engine.encode(all_batches[b], num_qubits, encoding_method)
+        _ = torch.utils.dlpack.from_dlpack(qt)
+    torch.cuda.synchronize()
+
+    # Timed run.
+    start = time.perf_counter()
+    for b in range(warmup_batches, len(all_batches)):
+        qt = engine.encode(all_batches[b], num_qubits, encoding_method)
+        _ = torch.utils.dlpack.from_dlpack(qt)
+    torch.cuda.synchronize()
+    duration = time.perf_counter() - start
+
+    total_vectors = total_batches * batch_size
+    return duration, total_vectors / duration if duration > 0 else 0.0
+
+
+def run_pytorch_end_to_end(
+    *,
+    num_qubits: int,
+    total_batches: int,
+    batch_size: int,
+    encoding_method: str,
+    warmup_batches: int,
+    device: str,
+) -> tuple[float, float]:
+    """Run PyTorch encoding with data generation inside the timer (end-to-end)."""
+    from qumat_qdp.torch_ref import encode
+
+    dim = _sample_dim(encoding_method, num_qubits)
+
+    # Warmup (data gen outside timer is OK for warmup).
+    for b in range(warmup_batches):
+        np_data = generate_batch_data(batch_size, dim, encoding_method, seed=42 + b)
+        t = torch.tensor(
+            np_data.flatten() if encoding_method == "basis" else np_data,
+            dtype=torch.float64,
+            device=device,
+        )
+        encode(t, num_qubits, encoding_method, device=device)
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+
+    # Timed run: data gen + transfer + encode.
+    start = time.perf_counter()
+    for b in range(total_batches):
+        np_data = generate_batch_data(
+            batch_size,
+            dim,
+            encoding_method,
+            seed=42 + warmup_batches + b,
+        )
+        t = torch.tensor(
+            np_data.flatten() if encoding_method == "basis" else np_data,
+            dtype=torch.float64,
+            device=device,
+        )
+        encode(t, num_qubits, encoding_method, device=device)
+    if device.startswith("cuda"):
+        torch.cuda.synchronize()
+    duration = time.perf_counter() - start
+
+    total_vectors = total_batches * batch_size
+    return duration, total_vectors / duration if duration > 0 else 0.0
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="QDP vs PyTorch reference benchmark")
+    parser.add_argument(
+        "--mode",
+        default="encode-only",
+        choices=["encode-only", "end-to-end"],
+        help="'encode-only': data pre-generated on GPU, times encoding only. "
+        "'end-to-end': data generation + transfer + encoding all timed.",
+    )
+    parser.add_argument("--qubits", type=int, default=16)
+    parser.add_argument("--batches", type=int, default=100)
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument(
+        "--encoding-method",
+        default="amplitude",
+        choices=["amplitude", "angle", "basis", "iqp"],
+    )
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--trials", type=int, default=3)
+    parser.add_argument("--device-id", type=int, default=0)
+    parser.add_argument(
+        "--frameworks",
+        type=_parse_frameworks,
+        default=list(FRAMEWORK_CHOICES),
+    )
+    args = parser.parse_args()
+
+    enc = args.encoding_method
+    mode = args.mode
+
+    print(f"\n{'=' * 60}")
+    print(f"QDP vs PyTorch Reference Benchmark ({mode})")
+    print(f"{'=' * 60}")
+    print(f"  Mode:        {mode}")
+    print(f"  Qubits:      {args.qubits}")
+    print(f"  Batches:     {args.batches}")
+    print(f"  Batch size:  {args.batch_size}")
+    print(f"  Encoding:    {enc}")
+    print(f"  Warmup:      {args.warmup}")
+    print(f"  Trials:      {args.trials}")
+    print(f"  Total vecs:  {args.batches * args.batch_size:,}")
+    print(f"{'=' * 60}")
+    if mode == "encode-only":
+        print("  Note: 'encode-only' times encoding kernels only;")
+        print("        data is pre-generated on the target device.")
+    else:
+        print("  Note: 'end-to-end' times data generation + transfer + encoding.")
+    print()
+
+    results: dict[str, float] = {}  # framework -> median vps
+
+    for fw in args.frameworks:
+        trial_vps: list[float] = []
+        try:
+            for trial in range(args.trials):
+                if fw == "pytorch-cpu":
+                    pytorch_fn = (
+                        run_pytorch if mode == "encode-only" else run_pytorch_end_to_end
+                    )
+                    dur, vps = pytorch_fn(
+                        num_qubits=args.qubits,
+                        total_batches=args.batches,
+                        batch_size=args.batch_size,
+                        encoding_method=enc,
+                        warmup_batches=args.warmup,
+                        device="cpu",
+                    )
+                elif fw == "pytorch-gpu":
+                    if not torch.cuda.is_available():
+                        print(f"  {fw:20s}  SKIPPED (no CUDA)")
+                        break
+                    pytorch_fn = (
+                        run_pytorch if mode == "encode-only" else run_pytorch_end_to_end
+                    )
+                    dur, vps = pytorch_fn(
+                        num_qubits=args.qubits,
+                        total_batches=args.batches,
+                        batch_size=args.batch_size,
+                        encoding_method=enc,
+                        warmup_batches=args.warmup,
+                        device=f"cuda:{args.device_id}",
+                    )
+                elif fw == "mahout":
+                    if not torch.cuda.is_available():
+                        print(f"  {fw:20s}  SKIPPED (no CUDA)")
+                        break
+                    if mode == "encode-only":
+                        dur, vps = run_mahout_encode_only(
+                            num_qubits=args.qubits,
+                            total_batches=args.batches,
+                            batch_size=args.batch_size,
+                            encoding_method=enc,
+                            warmup_batches=args.warmup,
+                            device_id=args.device_id,
+                        )
+                    else:
+                        dur, vps = run_mahout(
+                            num_qubits=args.qubits,
+                            total_batches=args.batches,
+                            batch_size=args.batch_size,
+                            encoding_method=enc,
+                            warmup_batches=args.warmup,
+                            device_id=args.device_id,
+                        )
+                else:
+                    continue
+                trial_vps.append(vps)
+
+            if trial_vps:
+                median = statistics.median(trial_vps)
+                results[fw] = median
+                print(
+                    f"  {fw:20s}  {median:>12,.0f} vec/s  (median of {len(trial_vps)} trials)"
+                )
+        except Exception as e:
+            print(f"  {fw:20s}  ERROR: {e}")
+
+    # Speedup ratios.
+    if len(results) > 1:
+        print(f"\n{'Speedup Ratios':^60}")
+        print(f"{'-' * 60}")
+        baselines = [k for k in ("pytorch-gpu", "pytorch-cpu") if k in results]
+        for base in baselines:
+            base_vps = results[base]
+            for fw in results:
+                if fw != base and fw not in baselines and base_vps > 0:
+                    ratio = results[fw] / base_vps
+                    print(f"  {fw} vs {base}: {ratio:.1f}x")
+
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/qdp/qdp-python/qumat_qdp/__init__.py
+++ b/qdp/qdp-python/qumat_qdp/__init__.py
@@ -30,7 +30,7 @@ Usage:
 from __future__ import annotations
 
 # Backend detection: gracefully degrade when _qdp (Rust extension) is unavailable.
-from qumat_qdp._backend import Backend, get_backend, get_qdp
+from qumat_qdp._backend import Backend, force_backend, get_backend, get_qdp
 
 _qdp_mod = get_qdp()
 if _qdp_mod is not None:
@@ -60,5 +60,6 @@ __all__ = [
     "QuantumDataLoader",
     "QuantumTensor",
     "ThroughputResult",
+    "force_backend",
     "run_throughput_pipeline_py",
 ]

--- a/qdp/qdp-python/qumat_qdp/__init__.py
+++ b/qdp/qdp-python/qumat_qdp/__init__.py
@@ -29,9 +29,20 @@ Usage:
 
 from __future__ import annotations
 
-# Rust extension (built by maturin). QdpEngine/QuantumTensor are public for
-# advanced use; QdpBenchmark and QuantumDataLoader are the recommended high-level API.
-import _qdp
+# Backend detection: gracefully degrade when _qdp (Rust extension) is unavailable.
+from qumat_qdp._backend import Backend, get_backend, get_qdp
+
+_qdp_mod = get_qdp()
+if _qdp_mod is not None:
+    QdpEngine = getattr(_qdp_mod, "QdpEngine")
+    QuantumTensor = getattr(_qdp_mod, "QuantumTensor")
+    run_throughput_pipeline_py = getattr(_qdp_mod, "run_throughput_pipeline_py", None)
+else:
+    QdpEngine = None
+    QuantumTensor = None
+    run_throughput_pipeline_py = None
+
+BACKEND = get_backend()
 
 from qumat_qdp.api import (
     LatencyResult,
@@ -40,12 +51,9 @@ from qumat_qdp.api import (
 )
 from qumat_qdp.loader import QuantumDataLoader
 
-# Re-export Rust extension types (getattr for compiled extension module)
-QdpEngine = getattr(_qdp, "QdpEngine")
-QuantumTensor = getattr(_qdp, "QuantumTensor")
-run_throughput_pipeline_py = getattr(_qdp, "run_throughput_pipeline_py", None)
-
 __all__ = [
+    "BACKEND",
+    "Backend",
     "LatencyResult",
     "QdpBenchmark",
     "QdpEngine",

--- a/qdp/qdp-python/qumat_qdp/_backend.py
+++ b/qdp/qdp-python/qumat_qdp/_backend.py
@@ -1,0 +1,99 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Backend detection and selection for QDP.
+
+Priority order:
+1. _qdp (Rust+CUDA) -- native extension, highest performance
+2. torch (PyTorch) -- fallback, optional dependency
+3. None -- neither available
+"""
+
+from __future__ import annotations
+
+import enum
+from functools import lru_cache
+from types import ModuleType
+
+
+class Backend(enum.Enum):
+    """Available QDP encoding backends."""
+
+    RUST_CUDA = "rust_cuda"
+    PYTORCH = "pytorch"
+    NONE = "none"
+
+
+# Module-level override; set via force_backend().
+_forced_backend: Backend | None = None
+
+
+@lru_cache(maxsize=1)
+def get_qdp() -> ModuleType | None:
+    """Return the ``_qdp`` Rust extension module, or ``None`` if unavailable."""
+    try:
+        import _qdp as m
+
+        return m
+    except ImportError:
+        return None
+
+
+@lru_cache(maxsize=1)
+def get_torch() -> ModuleType | None:
+    """Return the ``torch`` module, or ``None`` if unavailable."""
+    try:
+        import torch as m
+
+        return m
+    except ImportError:
+        return None
+
+
+def get_backend() -> Backend:
+    """Return the highest-priority available backend.
+
+    Respects :func:`force_backend` overrides.
+    """
+    if _forced_backend is not None:
+        return _forced_backend
+    if get_qdp() is not None:
+        return Backend.RUST_CUDA
+    if get_torch() is not None:
+        return Backend.PYTORCH
+    return Backend.NONE
+
+
+def force_backend(backend: Backend | None) -> None:
+    """Override automatic backend detection.
+
+    Pass ``None`` to restore auto-detection.  Primarily useful for
+    testing and benchmarking.
+    """
+    global _forced_backend
+    _forced_backend = backend
+
+
+def require_backend() -> Backend:
+    """Return the current backend or raise if none is available."""
+    b = get_backend()
+    if b is Backend.NONE:
+        raise RuntimeError(
+            "No QDP encoding backend available. "
+            "Install PyTorch (pip install torch) or build the Rust extension (maturin develop)."
+        )
+    return b

--- a/qdp/qdp-python/qumat_qdp/_backend.py
+++ b/qdp/qdp-python/qumat_qdp/_backend.py
@@ -17,10 +17,14 @@
 """
 Backend detection and selection for QDP.
 
-Priority order:
+Available backends:
 1. _qdp (Rust+CUDA) -- native extension, highest performance
-2. torch (PyTorch) -- fallback, optional dependency
-3. None -- neither available
+2. torch (PyTorch) -- reference implementation, must be explicitly selected
+
+Auto-detection only activates the Rust backend.  To use the PyTorch
+reference backend, call ``force_backend(Backend.PYTORCH)`` or use
+the ``.backend("pytorch")`` builder method on ``QdpBenchmark`` /
+``QuantumDataLoader``.
 """
 
 from __future__ import annotations
@@ -65,16 +69,15 @@ def get_torch() -> ModuleType | None:
 
 
 def get_backend() -> Backend:
-    """Return the highest-priority available backend.
+    """Return the active backend.
 
-    Respects :func:`force_backend` overrides.
+    Only the Rust backend is auto-detected.  The PyTorch reference
+    backend must be selected explicitly via :func:`force_backend`.
     """
     if _forced_backend is not None:
         return _forced_backend
     if get_qdp() is not None:
         return Backend.RUST_CUDA
-    if get_torch() is not None:
-        return Backend.PYTORCH
     return Backend.NONE
 
 
@@ -94,6 +97,7 @@ def require_backend() -> Backend:
     if b is Backend.NONE:
         raise RuntimeError(
             "No QDP encoding backend available. "
-            "Install PyTorch (pip install torch) or build the Rust extension (maturin develop)."
+            "Build the Rust extension (maturin develop) or explicitly select the "
+            "PyTorch reference backend with force_backend(Backend.PYTORCH)."
         )
     return b

--- a/qdp/qdp-python/qumat_qdp/api.py
+++ b/qdp/qdp-python/qumat_qdp/api.py
@@ -124,9 +124,7 @@ class QdpBenchmark:
     def backend(self, name: str) -> QdpBenchmark:
         """Set benchmark backend: ``'rust'`` or ``'pytorch'``."""
         if name not in ("rust", "pytorch"):
-            raise ValueError(
-                f"backend must be 'rust' or 'pytorch', got {name!r}"
-            )
+            raise ValueError(f"backend must be 'rust' or 'pytorch', got {name!r}")
         self._backend_name = name
         return self
 

--- a/qdp/qdp-python/qumat_qdp/api.py
+++ b/qdp/qdp-python/qumat_qdp/api.py
@@ -20,11 +20,11 @@ Benchmark API: supports Rust-optimized pipeline and PyTorch reference backend.
 Usage:
     from qumat_qdp import QdpBenchmark, ThroughputResult, LatencyResult
 
+    # Rust backend (default):
     result = (QdpBenchmark(device_id=0).qubits(16).encoding("amplitude")
               .batches(100, size=64).warmup(2).run_throughput())
-    # result.duration_sec, result.vectors_per_sec
 
-    # PyTorch reference benchmark:
+    # PyTorch reference (must be explicitly selected):
     result = (QdpBenchmark(device_id=0).backend("pytorch").qubits(16)
               .encoding("amplitude").batches(100, size=64).run_throughput())
 """
@@ -82,24 +82,13 @@ def _get_run_throughput_pipeline_py():
     return fn
 
 
-def _rust_available() -> bool:
-    """Check if the Rust pipeline is available without raising."""
-    from qumat_qdp._backend import get_qdp
-
-    qdp = get_qdp()
-    return (
-        qdp is not None and getattr(qdp, "run_throughput_pipeline_py", None) is not None
-    )
-
-
 class QdpBenchmark:
     """
     Builder for throughput/latency benchmarks.
 
     Supports two backends:
-    - ``"rust"``: Rust-optimized pipeline (no Python for-loop, GIL released).
-    - ``"pytorch"``: Pure PyTorch reference implementation.
-    - ``"auto"`` (default): use Rust if available, else PyTorch.
+    - ``"rust"`` (default): Rust-optimized pipeline (no Python for-loop, GIL released).
+    - ``"pytorch"``: Pure PyTorch reference implementation (must be explicitly selected).
     """
 
     def __init__(self, device_id: int = 0) -> None:
@@ -109,7 +98,7 @@ class QdpBenchmark:
         self._total_batches: int | None = None
         self._batch_size: int = 64
         self._warmup_batches: int = 0
-        self._backend_name: str = "auto"
+        self._backend_name: str = "rust"
 
     def qubits(self, n: int) -> QdpBenchmark:
         self._num_qubits = n
@@ -133,19 +122,13 @@ class QdpBenchmark:
         return self
 
     def backend(self, name: str) -> QdpBenchmark:
-        """Set benchmark backend: ``'auto'``, ``'rust'``, or ``'pytorch'``."""
-        if name not in ("auto", "rust", "pytorch"):
+        """Set benchmark backend: ``'rust'`` or ``'pytorch'``."""
+        if name not in ("rust", "pytorch"):
             raise ValueError(
-                f"backend must be 'auto', 'rust', or 'pytorch', got {name!r}"
+                f"backend must be 'rust' or 'pytorch', got {name!r}"
             )
         self._backend_name = name
         return self
-
-    def _resolve_backend(self) -> str:
-        """Return the effective backend name."""
-        if self._backend_name == "auto":
-            return "rust" if _rust_available() else "pytorch"
-        return self._backend_name
 
     def _validate(self) -> None:
         if self._num_qubits is None or self._total_batches is None:
@@ -156,14 +139,14 @@ class QdpBenchmark:
     def run_throughput(self) -> ThroughputResult:
         """Run throughput benchmark using the selected backend."""
         self._validate()
-        if self._resolve_backend() == "pytorch":
+        if self._backend_name == "pytorch":
             return self._run_throughput_pytorch()
         return self._run_throughput_rust()
 
     def run_latency(self) -> LatencyResult:
         """Run latency benchmark using the selected backend."""
         self._validate()
-        if self._resolve_backend() == "pytorch":
+        if self._backend_name == "pytorch":
             return self._run_latency_pytorch()
         return self._run_latency_rust()
 

--- a/qdp/qdp-python/qumat_qdp/api.py
+++ b/qdp/qdp-python/qumat_qdp/api.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 """
-Benchmark API: Rust-optimized pipeline only (no Python for loop).
+Benchmark API: supports Rust-optimized pipeline and PyTorch reference backend.
 
 Usage:
     from qumat_qdp import QdpBenchmark, ThroughputResult, LatencyResult
@@ -24,13 +24,14 @@ Usage:
               .batches(100, size=64).warmup(2).run_throughput())
     # result.duration_sec, result.vectors_per_sec
 
-    lat = (QdpBenchmark(device_id=0).qubits(16).encoding("amplitude")
-           .batches(100, size=64).run_latency())
-    # lat.latency_ms_per_vector
+    # PyTorch reference benchmark:
+    result = (QdpBenchmark(device_id=0).backend("pytorch").qubits(16)
+              .encoding("amplitude").batches(100, size=64).run_throughput())
 """
 
 from __future__ import annotations
 
+import time
 from dataclasses import dataclass
 
 
@@ -59,9 +60,17 @@ def _get_run_throughput_pipeline_py():
     global _run_throughput_pipeline_py
     if _run_throughput_pipeline_py is not None:
         return _run_throughput_pipeline_py
-    import _qdp
 
-    fn = getattr(_qdp, "run_throughput_pipeline_py", None)
+    from qumat_qdp._backend import get_qdp
+
+    qdp = get_qdp()
+    if qdp is None:
+        raise RuntimeError(
+            "Rust pipeline not available: _qdp extension not found. "
+            "Build the extension with: maturin develop"
+        )
+
+    fn = getattr(qdp, "run_throughput_pipeline_py", None)
     if fn is None:
         raise RuntimeError(
             "Rust pipeline not available: _qdp.run_throughput_pipeline_py is missing. "
@@ -73,13 +82,24 @@ def _get_run_throughput_pipeline_py():
     return fn
 
 
+def _rust_available() -> bool:
+    """Check if the Rust pipeline is available without raising."""
+    from qumat_qdp._backend import get_qdp
+
+    qdp = get_qdp()
+    return (
+        qdp is not None and getattr(qdp, "run_throughput_pipeline_py", None) is not None
+    )
+
+
 class QdpBenchmark:
     """
-    Builder for throughput/latency benchmarks. Backend is Rust optimized pipeline only.
+    Builder for throughput/latency benchmarks.
 
-    No Python for loop; run_throughput_pipeline_py runs the full pipeline in Rust
-    (single Python boundary, GIL released). Requires _qdp.run_throughput_pipeline_py
-    (Linux/CUDA build).
+    Supports two backends:
+    - ``"rust"``: Rust-optimized pipeline (no Python for-loop, GIL released).
+    - ``"pytorch"``: Pure PyTorch reference implementation.
+    - ``"auto"`` (default): use Rust if available, else PyTorch.
     """
 
     def __init__(self, device_id: int = 0) -> None:
@@ -89,6 +109,7 @@ class QdpBenchmark:
         self._total_batches: int | None = None
         self._batch_size: int = 64
         self._warmup_batches: int = 0
+        self._backend_name: str = "auto"
 
     def qubits(self, n: int) -> QdpBenchmark:
         self._num_qubits = n
@@ -111,13 +132,44 @@ class QdpBenchmark:
         self._warmup_batches = n
         return self
 
-    def run_throughput(self) -> ThroughputResult:
-        """Run throughput via Rust optimized pipeline (no Python for loop)."""
+    def backend(self, name: str) -> QdpBenchmark:
+        """Set benchmark backend: ``'auto'``, ``'rust'``, or ``'pytorch'``."""
+        if name not in ("auto", "rust", "pytorch"):
+            raise ValueError(
+                f"backend must be 'auto', 'rust', or 'pytorch', got {name!r}"
+            )
+        self._backend_name = name
+        return self
+
+    def _resolve_backend(self) -> str:
+        """Return the effective backend name."""
+        if self._backend_name == "auto":
+            return "rust" if _rust_available() else "pytorch"
+        return self._backend_name
+
+    def _validate(self) -> None:
         if self._num_qubits is None or self._total_batches is None:
             raise ValueError(
                 "Set qubits and batches (e.g. .qubits(16).batches(100, 64))"
             )
 
+    def run_throughput(self) -> ThroughputResult:
+        """Run throughput benchmark using the selected backend."""
+        self._validate()
+        if self._resolve_backend() == "pytorch":
+            return self._run_throughput_pytorch()
+        return self._run_throughput_rust()
+
+    def run_latency(self) -> LatencyResult:
+        """Run latency benchmark using the selected backend."""
+        self._validate()
+        if self._resolve_backend() == "pytorch":
+            return self._run_latency_pytorch()
+        return self._run_latency_rust()
+
+    # -- Rust backend --
+
+    def _run_throughput_rust(self) -> ThroughputResult:
         run_rust = _get_run_throughput_pipeline_py()
         duration_sec, vectors_per_sec, _ = run_rust(
             device_id=self._device_id,
@@ -132,13 +184,7 @@ class QdpBenchmark:
             duration_sec=duration_sec, vectors_per_sec=vectors_per_sec
         )
 
-    def run_latency(self) -> LatencyResult:
-        """Run latency via Rust optimized pipeline (no Python for loop)."""
-        if self._num_qubits is None or self._total_batches is None:
-            raise ValueError(
-                "Set qubits and batches (e.g. .qubits(16).batches(100, 64))"
-            )
-
+    def _run_latency_rust(self) -> LatencyResult:
         run_rust = _get_run_throughput_pipeline_py()
         duration_sec, _, latency_ms_per_vector = run_rust(
             device_id=self._device_id,
@@ -152,4 +198,73 @@ class QdpBenchmark:
         return LatencyResult(
             duration_sec=duration_sec,
             latency_ms_per_vector=latency_ms_per_vector,
+        )
+
+    # -- PyTorch backend --
+
+    def _run_throughput_pytorch(self) -> ThroughputResult:
+        import torch
+
+        from qumat_qdp.torch_ref import encode
+
+        device = f"cuda:{self._device_id}" if torch.cuda.is_available() else "cpu"
+        # _validate() guarantees these are not None.
+        assert self._num_qubits is not None
+        assert self._total_batches is not None
+        num_qubits = self._num_qubits
+        encoding_method = self._encoding_method
+        batch_size = self._batch_size
+
+        if encoding_method == "basis":
+            sample_dim = 1
+        elif encoding_method == "angle":
+            sample_dim = num_qubits
+        elif encoding_method == "iqp":
+            sample_dim = num_qubits + num_qubits * (num_qubits - 1) // 2
+        else:
+            sample_dim = 1 << num_qubits
+
+        # Generate all batch data upfront.
+        batches = []
+        for b in range(self._total_batches + self._warmup_batches):
+            if encoding_method == "basis":
+                data = torch.randint(
+                    0, 1 << num_qubits, (batch_size,), device=device
+                ).to(torch.float64)
+            else:
+                data = torch.randn(
+                    batch_size, sample_dim, dtype=torch.float64, device=device
+                )
+            batches.append(data)
+
+        # Warmup.
+        for b in range(self._warmup_batches):
+            encode(batches[b], num_qubits, encoding_method, device=device)
+        if device.startswith("cuda"):
+            torch.cuda.synchronize()
+
+        # Timed run.
+        start = time.perf_counter()
+        for b in range(self._warmup_batches, len(batches)):
+            encode(batches[b], num_qubits, encoding_method, device=device)
+        if device.startswith("cuda"):
+            torch.cuda.synchronize()
+        duration = time.perf_counter() - start
+
+        total_vectors = self._total_batches * batch_size
+        return ThroughputResult(
+            duration_sec=duration,
+            vectors_per_sec=total_vectors / duration if duration > 0 else 0.0,
+        )
+
+    def _run_latency_pytorch(self) -> LatencyResult:
+        result = self._run_throughput_pytorch()
+        assert self._total_batches is not None
+        total_vectors = self._total_batches * self._batch_size
+        ms_per_vector = (
+            (result.duration_sec * 1000.0) / total_vectors if total_vectors > 0 else 0.0
+        )
+        return LatencyResult(
+            duration_sec=result.duration_sec,
+            latency_ms_per_vector=ms_per_vector,
         )

--- a/qdp/qdp-python/qumat_qdp/api.py
+++ b/qdp/qdp-python/qumat_qdp/api.py
@@ -188,7 +188,15 @@ class QdpBenchmark:
 
         from qumat_qdp.torch_ref import encode
 
-        device = f"cuda:{self._device_id}" if torch.cuda.is_available() else "cpu"
+        if torch.cuda.is_available():
+            if self._device_id < 0 or self._device_id >= torch.cuda.device_count():
+                raise ValueError(
+                    f"Invalid CUDA device_id {self._device_id}; "
+                    f"{torch.cuda.device_count()} device(s) available."
+                )
+            device = f"cuda:{self._device_id}"
+        else:
+            device = "cpu"
         # _validate() guarantees these are not None.
         assert self._num_qubits is not None
         assert self._total_batches is not None
@@ -205,9 +213,11 @@ class QdpBenchmark:
         else:
             sample_dim = 1 << num_qubits
 
-        # Generate all batch data upfront.
-        batches = []
-        for b in range(self._total_batches + self._warmup_batches):
+        # Pre-generate a small pool of batch tensors and cycle through them
+        # to keep memory bounded at high qubit counts while still varying data.
+        pool_size = min(8, self._total_batches + self._warmup_batches)
+        pool: list[torch.Tensor] = []
+        for _ in range(pool_size):
             if encoding_method == "basis":
                 data = torch.randint(
                     0, 1 << num_qubits, (batch_size,), device=device
@@ -216,18 +226,18 @@ class QdpBenchmark:
                 data = torch.randn(
                     batch_size, sample_dim, dtype=torch.float64, device=device
                 )
-            batches.append(data)
+            pool.append(data)
 
         # Warmup.
         for b in range(self._warmup_batches):
-            encode(batches[b], num_qubits, encoding_method, device=device)
+            encode(pool[b % pool_size], num_qubits, encoding_method, device=device)
         if device.startswith("cuda"):
             torch.cuda.synchronize()
 
         # Timed run.
         start = time.perf_counter()
-        for b in range(self._warmup_batches, len(batches)):
-            encode(batches[b], num_qubits, encoding_method, device=device)
+        for b in range(self._total_batches):
+            encode(pool[b % pool_size], num_qubits, encoding_method, device=device)
         if device.startswith("cuda"):
             torch.cuda.synchronize()
         duration = time.perf_counter() - start

--- a/qdp/qdp-python/qumat_qdp/loader.py
+++ b/qdp/qdp-python/qumat_qdp/loader.py
@@ -30,7 +30,6 @@ Usage:
 from __future__ import annotations
 
 import math
-import warnings
 from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
@@ -144,6 +143,7 @@ class QuantumDataLoader:
         self._synthetic_requested = False  # set True only by source_synthetic()
         self._file_requested = False
         self._null_handling: str | None = None
+        self._backend_name: str = "rust"
 
     def qubits(self, n: int) -> QuantumDataLoader:
         """Set number of qubits. Returns self for chaining."""
@@ -233,6 +233,17 @@ class QuantumDataLoader:
         self._null_handling = policy
         return self
 
+    def backend(self, name: str) -> QuantumDataLoader:
+        """Set encoding backend: ``'rust'`` or ``'pytorch'``.
+
+        The PyTorch reference backend is intended for testing and must be
+        explicitly selected.  Returns self for chaining.
+        """
+        if name not in ("rust", "pytorch"):
+            raise ValueError(f"backend must be 'rust' or 'pytorch', got {name!r}")
+        self._backend_name = name
+        return self
+
     def _create_iterator(self) -> Iterator[object]:
         """Build engine and return a loader iterator (Rust-backed or PyTorch fallback)."""
         if self._synthetic_requested and self._file_requested:
@@ -253,12 +264,18 @@ class QuantumDataLoader:
                 encoding_method=self._encoding_method,
                 seed=self._seed,
             )
+        if self._backend_name == "pytorch":
+            return self._create_pytorch_iterator(use_synthetic)
+        # Rust backend (default).
         qdp = _get_qdp()
         QdpEngine = getattr(qdp, "QdpEngine", None) if qdp else None
-        if QdpEngine is not None:
-            return self._create_rust_iterator(QdpEngine, use_synthetic)
-        # Rust extension unavailable – fall back to PyTorch.
-        return self._create_pytorch_iterator(use_synthetic)
+        if QdpEngine is None:
+            raise RuntimeError(
+                "Rust extension (_qdp) is not available. "
+                "Build with: maturin develop, or explicitly select the PyTorch "
+                "reference backend with .backend('pytorch')."
+            )
+        return self._create_rust_iterator(QdpEngine, use_synthetic)
 
     def _create_rust_iterator(self, QdpEngine, use_synthetic: bool) -> Iterator[object]:
         """Create the Rust-backed loader iterator (original path)."""
@@ -303,7 +320,7 @@ class QuantumDataLoader:
         )
 
     def _create_pytorch_iterator(self, use_synthetic: bool) -> Iterator[object]:
-        """Fallback iterator using pure-PyTorch encoding when _qdp is unavailable.
+        """PyTorch reference iterator (explicitly selected via ``.backend('pytorch')``).
 
         Yields ``torch.Tensor`` (not ``QuantumTensor``).
 
@@ -314,17 +331,11 @@ class QuantumDataLoader:
             import torch
         except ImportError:
             raise RuntimeError(
-                "Neither _qdp (Rust extension) nor torch (PyTorch) is available. "
-                "Install PyTorch with: pip install torch, or build _qdp with: maturin develop"
+                "PyTorch backend selected but torch is not installed. "
+                "Install PyTorch with: pip install torch"
             ) from None
 
         from qumat_qdp.torch_ref import encode
-
-        warnings.warn(
-            "Using PyTorch fallback backend. Iteration yields torch.Tensor "
-            "instead of QuantumTensor (no torch.from_dlpack() needed).",
-            stacklevel=3,
-        )
 
         device = f"cuda:{self._device_id}" if torch.cuda.is_available() else "cpu"
 
@@ -417,8 +428,8 @@ class QuantumDataLoader:
     def __iter__(self) -> Iterator[object]:
         """Return iterator that yields one encoded batch per step.
 
-        When the ``_qdp`` Rust extension is available, yields ``QuantumTensor``
-        (use ``torch.from_dlpack(qt)``).  When falling back to PyTorch, yields
-        ``torch.Tensor`` directly.
+        With the default ``"rust"`` backend, yields ``QuantumTensor``
+        (use ``torch.from_dlpack(qt)``).  With ``.backend("pytorch")``,
+        yields ``torch.Tensor`` directly.
         """
         return self._create_iterator()

--- a/qdp/qdp-python/qumat_qdp/loader.py
+++ b/qdp/qdp-python/qumat_qdp/loader.py
@@ -29,9 +29,12 @@ Usage:
 
 from __future__ import annotations
 
+import math
+import warnings
 from collections.abc import Iterator
-from functools import lru_cache
 from typing import TYPE_CHECKING
+
+from qumat_qdp._backend import get_qdp as _get_qdp
 
 if TYPE_CHECKING:
     import _qdp
@@ -39,12 +42,10 @@ if TYPE_CHECKING:
 # Seed must fit Rust u64: 0 <= seed <= 2^64 - 1.
 _U64_MAX = 2**64 - 1
 
-
-@lru_cache(maxsize=1)
-def _get_qdp():
-    import _qdp as m
-
-    return m
+# Fallback-supported file extensions (loadable without _qdp).
+_TORCH_FILE_EXTS = frozenset({".pt", ".pth"})
+_NUMPY_FILE_EXTS = frozenset({".npy"})
+_FALLBACK_FILE_EXTS = _TORCH_FILE_EXTS | _NUMPY_FILE_EXTS
 
 
 def _validate_loader_args(
@@ -80,6 +81,29 @@ def _validate_loader_args(
             raise ValueError(
                 f"seed must be in range [0, {_U64_MAX}] (Rust u64), got {seed!r}"
             )
+
+
+def _build_sample(seed: int, vector_len: int, encoding_method: str) -> list[float]:
+    """Build a single deterministic sample vector (mirrors benchmark/utils.py:build_sample)."""
+    import numpy as np
+
+    if encoding_method == "basis":
+        mask = np.uint64(vector_len - 1)
+        idx = np.uint64(seed) & mask
+        return [float(idx)]
+    if encoding_method == "angle":
+        if vector_len == 0:
+            return []
+        scale = (2.0 * math.pi) / vector_len
+        idx = np.arange(vector_len, dtype=np.uint64)
+        mixed = (idx + np.uint64(seed)) % np.uint64(vector_len)
+        return (mixed.astype(np.float64) * scale).tolist()
+    # amplitude / iqp
+    mask = np.uint64(vector_len - 1)
+    scale = 1.0 / vector_len
+    idx = np.arange(vector_len, dtype=np.uint64)
+    mixed = (idx + np.uint64(seed)) & mask
+    return (mixed.astype(np.float64) * scale).tolist()
 
 
 class QuantumDataLoader:
@@ -210,7 +234,7 @@ class QuantumDataLoader:
         return self
 
     def _create_iterator(self) -> Iterator[object]:
-        """Build engine and return the Rust-backed loader iterator (synthetic or file)."""
+        """Build engine and return a loader iterator (Rust-backed or PyTorch fallback)."""
         if self._synthetic_requested and self._file_requested:
             raise ValueError(
                 "Cannot set both synthetic and file sources; use either .source_synthetic() or .source_file(path), not both."
@@ -230,11 +254,14 @@ class QuantumDataLoader:
                 seed=self._seed,
             )
         qdp = _get_qdp()
-        QdpEngine = getattr(qdp, "QdpEngine", None)
-        if QdpEngine is None:
-            raise RuntimeError(
-                "_qdp.QdpEngine not found. Build the extension with maturin develop."
-            )
+        QdpEngine = getattr(qdp, "QdpEngine", None) if qdp else None
+        if QdpEngine is not None:
+            return self._create_rust_iterator(QdpEngine, use_synthetic)
+        # Rust extension unavailable – fall back to PyTorch.
+        return self._create_pytorch_iterator(use_synthetic)
+
+    def _create_rust_iterator(self, QdpEngine, use_synthetic: bool) -> Iterator[object]:
+        """Create the Rust-backed loader iterator (original path)."""
         engine = QdpEngine(device_id=self._device_id)
         if not use_synthetic:
             if self._streaming_requested:
@@ -275,6 +302,123 @@ class QuantumDataLoader:
             )
         )
 
+    def _create_pytorch_iterator(self, use_synthetic: bool) -> Iterator[object]:
+        """Fallback iterator using pure-PyTorch encoding when _qdp is unavailable.
+
+        Yields ``torch.Tensor`` (not ``QuantumTensor``).
+
+        Supports synthetic data and ``.npy`` / ``.pt`` / ``.pth`` files.
+        Parquet, Arrow, and streaming sources require the Rust extension.
+        """
+        try:
+            import torch
+        except ImportError:
+            raise RuntimeError(
+                "Neither _qdp (Rust extension) nor torch (PyTorch) is available. "
+                "Install PyTorch with: pip install torch, or build _qdp with: maturin develop"
+            ) from None
+
+        from qumat_qdp.torch_ref import encode
+
+        warnings.warn(
+            "Using PyTorch fallback backend. Iteration yields torch.Tensor "
+            "instead of QuantumTensor (no torch.from_dlpack() needed).",
+            stacklevel=3,
+        )
+
+        device = f"cuda:{self._device_id}" if torch.cuda.is_available() else "cpu"
+
+        if use_synthetic:
+            return self._pytorch_synthetic_iter(torch, encode, device)
+        return self._pytorch_file_iter(torch, encode, device)
+
+    def _pytorch_synthetic_iter(
+        self, torch, encode_fn, device: str
+    ) -> Iterator[object]:
+        """Generate synthetic data and encode with PyTorch."""
+        import numpy as np
+
+        num_qubits = self._num_qubits
+        encoding_method = self._encoding_method
+        batch_size = self._batch_size
+        seed = self._seed if self._seed is not None else 0
+
+        if encoding_method == "basis":
+            sample_size = 1
+        elif encoding_method == "angle":
+            sample_size = num_qubits
+        elif encoding_method == "iqp":
+            sample_size = num_qubits + num_qubits * (num_qubits - 1) // 2
+        else:
+            sample_size = 1 << num_qubits
+
+        for batch_idx in range(self._total_batches):
+            base = batch_idx * batch_size
+            samples = []
+            for i in range(batch_size):
+                samples.append(
+                    _build_sample(base + i + seed, sample_size, encoding_method)
+                )
+            batch_np = np.stack(samples)
+            batch_tensor = torch.tensor(batch_np, dtype=torch.float64, device=device)
+            yield encode_fn(batch_tensor, num_qubits, encoding_method, device=device)
+
+    def _pytorch_file_iter(self, torch, encode_fn, device: str) -> Iterator[object]:
+        """Load file data and encode with PyTorch."""
+        import os
+
+        path = self._file_path
+        assert path is not None
+        ext = os.path.splitext(path)[1].lower()
+
+        if self._streaming_requested:
+            raise RuntimeError(
+                "Streaming file loading requires the _qdp Rust extension. "
+                "Build with: maturin develop"
+            )
+
+        if ext not in _FALLBACK_FILE_EXTS:
+            raise RuntimeError(
+                f"PyTorch fallback only supports {', '.join(sorted(_FALLBACK_FILE_EXTS))} files. "
+                f"Got {ext!r}. Build the _qdp extension for full format support: maturin develop"
+            )
+
+        # Load all data into memory.
+        if ext in _TORCH_FILE_EXTS:
+            raw = torch.load(path, weights_only=True)
+            if not isinstance(raw, torch.Tensor):
+                raise RuntimeError(
+                    f"Expected torch.Tensor in {path}, got {type(raw).__name__}"
+                )
+            all_data = raw.to(dtype=torch.float64, device=device)
+        else:
+            import numpy as np
+
+            arr = np.load(path)
+            all_data = torch.tensor(arr, dtype=torch.float64, device=device)
+
+        if all_data.ndim == 1:
+            all_data = all_data.unsqueeze(0)
+
+        num_qubits = self._num_qubits
+        encoding_method = self._encoding_method
+        batch_size = self._batch_size
+        total_samples = all_data.shape[0]
+        total_batches = min(
+            self._total_batches, (total_samples + batch_size - 1) // batch_size
+        )
+
+        for batch_idx in range(total_batches):
+            start = batch_idx * batch_size
+            end = min(start + batch_size, total_samples)
+            batch = all_data[start:end]
+            yield encode_fn(batch, num_qubits, encoding_method, device=device)
+
     def __iter__(self) -> Iterator[object]:
-        """Return Rust-backed iterator that yields one QuantumTensor per batch."""
+        """Return iterator that yields one encoded batch per step.
+
+        When the ``_qdp`` Rust extension is available, yields ``QuantumTensor``
+        (use ``torch.from_dlpack(qt)``).  When falling back to PyTorch, yields
+        ``torch.Tensor`` directly.
+        """
         return self._create_iterator()

--- a/qdp/qdp-python/qumat_qdp/loader.py
+++ b/qdp/qdp-python/qumat_qdp/loader.py
@@ -83,7 +83,11 @@ def _validate_loader_args(
 
 
 def _build_sample(seed: int, vector_len: int, encoding_method: str) -> list[float]:
-    """Build a single deterministic sample vector (mirrors benchmark/utils.py:build_sample)."""
+    """Build a single deterministic sample vector for the given encoding method.
+
+    Supports amplitude, angle, basis, and iqp (iqp uses the same mask-and-scale
+    logic as amplitude).
+    """
     import numpy as np
 
     if encoding_method == "basis":
@@ -337,7 +341,15 @@ class QuantumDataLoader:
 
         from qumat_qdp.torch_ref import encode
 
-        device = f"cuda:{self._device_id}" if torch.cuda.is_available() else "cpu"
+        if torch.cuda.is_available():
+            if self._device_id < 0 or self._device_id >= torch.cuda.device_count():
+                raise ValueError(
+                    f"Invalid CUDA device_id {self._device_id}; "
+                    f"{torch.cuda.device_count()} device(s) available."
+                )
+            device = f"cuda:{self._device_id}"
+        else:
+            device = "cpu"
 
         if use_synthetic:
             return self._pytorch_synthetic_iter(torch, encode, device)

--- a/qdp/qdp-python/qumat_qdp/torch_ref.py
+++ b/qdp/qdp-python/qumat_qdp/torch_ref.py
@@ -1,0 +1,359 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Pure-PyTorch reference implementations of QDP quantum encoding methods.
+
+Serves two purposes:
+1. Speed benchmark reference (compare QDP Rust+CUDA vs PyTorch GPU).
+2. Fallback when the ``_qdp`` Rust extension is unavailable.
+
+All functions are fully vectorized (no Python loops over batch/state dims)
+and return complex tensors of shape ``(batch_size, 2**num_qubits)``.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+__all__ = ["amplitude_encode", "angle_encode", "basis_encode", "encode", "iqp_encode"]
+
+_COMPLEX_DTYPE_MAP = {
+    torch.float32: torch.complex64,
+    torch.float64: torch.complex128,
+}
+
+
+def _complex_dtype(real_dtype: torch.dtype) -> torch.dtype:
+    """Map a real dtype to its complex counterpart."""
+    result = _COMPLEX_DTYPE_MAP.get(real_dtype)
+    if result is None:
+        raise TypeError(
+            f"Unsupported dtype {real_dtype} for complex conversion. "
+            "Use float32 or float64."
+        )
+    return result
+
+
+def _ensure_2d(data: torch.Tensor) -> torch.Tensor:
+    """Promote 1-D input to ``(1, features)``."""
+    if data.ndim == 1:
+        return data.unsqueeze(0)
+    if data.ndim != 2:
+        raise ValueError(f"Expected 1-D or 2-D tensor, got {data.ndim}-D")
+    return data
+
+
+def _check_float_dtype(data: torch.Tensor) -> None:
+    """Check that *data* is floating-point (dtype only, no GPU sync)."""
+    if not data.is_floating_point():
+        raise ValueError(f"Expected floating-point input, got {data.dtype}")
+
+
+# ---------------------------------------------------------------------------
+# Amplitude encoding
+# ---------------------------------------------------------------------------
+
+
+def amplitude_encode(
+    data: torch.Tensor,
+    num_qubits: int,
+    *,
+    device: torch.device | str | None = None,
+) -> torch.Tensor:
+    """Amplitude encoding: L2-normalize and zero-pad to ``2**num_qubits``.
+
+    Args:
+        data: Real tensor of shape ``(batch, features)`` or ``(features,)``.
+        num_qubits: Number of qubits; state dimension is ``2**num_qubits``.
+        device: Target device. Defaults to the device of *data*.
+
+    Returns:
+        Complex tensor of shape ``(batch, 2**num_qubits)``.
+    """
+    data = _ensure_2d(data)
+    if device is not None:
+        data = data.to(device=torch.device(device))
+
+    _check_float_dtype(data)
+
+    state_dim = 1 << num_qubits
+    features = data.shape[1]
+    if features > state_dim:
+        raise ValueError(
+            f"Input features ({features}) exceed state dimension ({state_dim})"
+        )
+
+    # Zero-pad to state_dim if needed.
+    if features < state_dim:
+        data = F.pad(data, (0, state_dim - features))
+
+    # L2-normalize per row.  Clamp avoids GPU→CPU sync from checking for
+    # zero norms; a zero-norm row produces near-zero output instead of
+    # crashing (NaN/Inf propagate naturally through downstream ops).
+    norms = torch.linalg.vector_norm(data, dim=1, keepdim=True)
+    data = data / norms.clamp(min=1e-10)
+
+    # Cast to complex (real-to-complex sets imaginary part to zero).
+    return data.to(_complex_dtype(data.dtype))
+
+
+# ---------------------------------------------------------------------------
+# Angle encoding
+# ---------------------------------------------------------------------------
+
+
+def angle_encode(
+    data: torch.Tensor,
+    num_qubits: int,
+    *,
+    device: torch.device | str | None = None,
+) -> torch.Tensor:
+    """Angle encoding: tensor product of per-qubit Ry rotations.
+
+    For state index *i* with binary representation b_{n-1}...b_0::
+
+        amplitude_i = prod_k (sin(θ_k) if b_k == 1 else cos(θ_k))
+
+    Args:
+        data: Real tensor of shape ``(batch, num_qubits)`` or ``(num_qubits,)``
+              containing rotation angles.
+        num_qubits: Number of qubits.
+        device: Target device.
+
+    Returns:
+        Complex tensor of shape ``(batch, 2**num_qubits)``.
+    """
+    data = _ensure_2d(data)
+    if device is not None:
+        data = data.to(device=torch.device(device))
+
+    _check_float_dtype(data)
+
+    if data.shape[1] != num_qubits:
+        raise RuntimeError(
+            f"Angle encoding expects {num_qubits} values per sample, got {data.shape[1]}"
+        )
+
+    state_dim = 1 << num_qubits
+
+    # Trigonometric values: (batch, num_qubits)
+    cos_vals = torch.cos(data)
+    sin_vals = torch.sin(data)
+
+    # Bit-pattern matrix: (state_dim, num_qubits)
+    # bits[i, k] = (i >> k) & 1
+    indices = torch.arange(state_dim, device=data.device, dtype=torch.long)
+    bits = (
+        (indices.unsqueeze(1) >> torch.arange(num_qubits, device=data.device)) & 1
+    ).to(data.dtype)
+
+    # For each state index: amplitude = prod_k (sin if bit else cos)
+    # Shape: (batch, state_dim, num_qubits) via broadcasting
+    trig = bits.unsqueeze(0) * sin_vals.unsqueeze(1) + (
+        1 - bits.unsqueeze(0)
+    ) * cos_vals.unsqueeze(1)
+
+    # Product over qubits → (batch, state_dim)
+    amplitudes = trig.prod(dim=2)
+
+    return amplitudes.to(_complex_dtype(data.dtype))
+
+
+# ---------------------------------------------------------------------------
+# Basis encoding
+# ---------------------------------------------------------------------------
+
+
+def basis_encode(
+    data: torch.Tensor,
+    num_qubits: int,
+    *,
+    device: torch.device | str | None = None,
+) -> torch.Tensor:
+    """Basis encoding: one-hot computational basis state.
+
+    Args:
+        data: Tensor of integer indices (as float) with shape ``(batch,)``
+              or ``(batch, 1)``.
+        num_qubits: Number of qubits; state dimension is ``2**num_qubits``.
+        device: Target device.
+
+    Returns:
+        Complex tensor of shape ``(batch, 2**num_qubits)``.
+    """
+    if device is not None:
+        data = data.to(device=torch.device(device))
+
+    if data.ndim > 2 or (data.ndim == 2 and data.shape[1] != 1):
+        raise ValueError(
+            f"Basis encoding expects shape (batch,) or (batch, 1), got {data.shape}"
+        )
+
+    data = data.flatten()
+    batch = data.shape[0]
+    state_dim = 1 << num_qubits
+
+    # Validate: finite and integer-valued.
+    if data.is_floating_point():
+        if torch.any(~torch.isfinite(data)):
+            raise RuntimeError("Basis encoding indices must be finite")
+        if torch.any(data != data.floor()):
+            raise RuntimeError("Basis encoding requires integer-valued indices")
+    indices = data.long()
+
+    # Validate range.
+    if torch.any(indices < 0):
+        raise RuntimeError("Basis encoding indices must be non-negative")
+    if torch.any(indices >= state_dim):
+        raise RuntimeError(
+            f"Basis index exceeds state vector size (2**{num_qubits} = {state_dim})"
+        )
+
+    cdtype = (
+        _complex_dtype(data.dtype) if data.is_floating_point() else torch.complex128
+    )
+    result = torch.zeros(batch, state_dim, dtype=cdtype, device=data.device)
+    result.scatter_(1, indices.unsqueeze(1), 1.0)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# IQP encoding
+# ---------------------------------------------------------------------------
+
+
+def iqp_encode(
+    data: torch.Tensor,
+    num_qubits: int,
+    *,
+    device: torch.device | str | None = None,
+    enable_zz: bool = True,
+) -> torch.Tensor:
+    """IQP (Instantaneous Quantum Polynomial) encoding.
+
+    Implements ``|ψ⟩ = H^⊗n · U_phase(data) · H^⊗n |0⟩^⊗n`` using the
+    Fast Walsh-Hadamard Transform.
+
+    Args:
+        data: Real tensor of shape ``(batch, params)`` or ``(params,)``.
+              For *enable_zz=True*: params = n + n*(n-1)/2.
+              For *enable_zz=False*: params = n.
+        num_qubits: Number of qubits.
+        device: Target device.
+        enable_zz: If True, include two-qubit ZZ interaction terms.
+
+    Returns:
+        Complex tensor of shape ``(batch, 2**num_qubits)``.
+    """
+    data = _ensure_2d(data)
+    if device is not None:
+        data = data.to(device=torch.device(device))
+
+    _check_float_dtype(data)
+
+    n = num_qubits
+    expected_params = n + n * (n - 1) // 2 if enable_zz else n
+    if data.shape[1] != expected_params:
+        raise RuntimeError(
+            f"IQP encoding ({'ZZ' if enable_zz else 'Z-only'}) expects {expected_params} "
+            f"parameters for {n} qubits, got {data.shape[1]}"
+        )
+
+    state_dim = 1 << n
+    batch = data.shape[0]
+
+    # Build bit patterns for all basis states: (state_dim, n)
+    x_indices = torch.arange(state_dim, device=data.device, dtype=torch.long)
+    x_bits = ((x_indices.unsqueeze(1) >> torch.arange(n, device=data.device)) & 1).to(
+        data.dtype
+    )
+
+    # Phase computation for each basis state x:
+    # θ(x) = Σ_i x_i * data[i]  (+ ZZ terms if enabled)
+    z_params = data[:, :n]  # (batch, n)
+    phase = torch.matmul(z_params, x_bits.T)  # (batch, state_dim)
+
+    if enable_zz and n >= 2:
+        # Two-qubit ZZ terms: Σ_{i<j} x_i * x_j * data[n + pair_index]
+        zz_params = data[:, n:]  # (batch, n*(n-1)//2)
+        # Vectorized pair product via torch.combinations
+        pairs = torch.combinations(torch.arange(n, device=data.device), r=2)
+        pair_matrix = (
+            x_bits[:, pairs[:, 0]] * x_bits[:, pairs[:, 1]]
+        )  # (state_dim, n_pairs)
+        phase = phase + torch.matmul(zz_params, pair_matrix.T)
+
+    # f[x] = exp(i * θ(x))  — use complex tensor for WHT
+    f = torch.complex(torch.cos(phase), torch.sin(phase))
+
+    # Fast Walsh-Hadamard Transform: n sequential butterfly stages
+    for s in range(n):
+        stride = 1 << s
+        block = 1 << (s + 1)
+        f = f.view(batch, state_dim // block, block)
+        lo = f[:, :, :stride]
+        hi = f[:, :, stride:]
+        f = torch.cat([lo + hi, lo - hi], dim=2)
+    f = f.view(batch, state_dim)
+
+    # Normalize by 1/2^n
+    f = f * (1.0 / state_dim)
+
+    cdtype = _complex_dtype(data.dtype)
+    return f.to(cdtype)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+_ENCODERS = {
+    "amplitude": amplitude_encode,
+    "angle": angle_encode,
+    "basis": basis_encode,
+    "iqp": iqp_encode,
+}
+
+
+def encode(
+    data: torch.Tensor,
+    num_qubits: int,
+    encoding_method: str = "amplitude",
+    *,
+    device: torch.device | str | None = None,
+    **kwargs: object,
+) -> torch.Tensor:
+    """Dispatch to the appropriate encoding function by method name.
+
+    Args:
+        data: Input tensor.
+        num_qubits: Number of qubits.
+        encoding_method: One of ``"amplitude"``, ``"angle"``, ``"basis"``, ``"iqp"``.
+        device: Target device.
+        **kwargs: Extra arguments forwarded to the encoder (e.g. *enable_zz* for IQP).
+
+    Returns:
+        Complex tensor of shape ``(batch, 2**num_qubits)``.
+    """
+    fn = _ENCODERS.get(encoding_method)
+    if fn is None:
+        raise ValueError(
+            f"Unknown encoding method {encoding_method!r}. "
+            f"Supported: {', '.join(sorted(_ENCODERS))}"
+        )
+    return fn(data, num_qubits, device=device, **kwargs)

--- a/qdp/qdp-python/qumat_qdp/torch_ref.py
+++ b/qdp/qdp-python/qumat_qdp/torch_ref.py
@@ -155,18 +155,19 @@ def angle_encode(
     cos_vals = torch.cos(data)
     sin_vals = torch.sin(data)
 
-    # Bit-pattern matrix: (state_dim, num_qubits)
-    # bits[i, k] = (i >> k) & 1
+    # Bit-pattern mask: (state_dim, num_qubits), bits[i, k] = bool((i >> k) & 1)
     indices = torch.arange(state_dim, device=data.device, dtype=torch.long)
     bits = (
         (indices.unsqueeze(1) >> torch.arange(num_qubits, device=data.device)) & 1
-    ).to(data.dtype)
+    ).bool()
 
     # For each state index: amplitude = prod_k (sin if bit else cos)
     # Shape: (batch, state_dim, num_qubits) via broadcasting
-    trig = bits.unsqueeze(0) * sin_vals.unsqueeze(1) + (
-        1 - bits.unsqueeze(0)
-    ) * cos_vals.unsqueeze(1)
+    trig = torch.where(
+        bits.unsqueeze(0),
+        sin_vals.unsqueeze(1),
+        cos_vals.unsqueeze(1),
+    )
 
     # Product over qubits → (batch, state_dim)
     amplitudes = trig.prod(dim=2)

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -58,7 +58,7 @@ def pytest_collection_modifyitems(config, items):
         "Build with: cd qdp/qdp-python && maturin develop"
     )
 
-    # Tests that work without _qdp (PyTorch fallback / reference tests).
+    # Tests that work without _qdp (PyTorch reference backend tests).
     _NO_QDP_OK = {"test_torch_ref.py", "test_fallback.py"}
 
     for item in items:

--- a/testing/conftest.py
+++ b/testing/conftest.py
@@ -58,15 +58,20 @@ def pytest_collection_modifyitems(config, items):
         "Build with: cd qdp/qdp-python && maturin develop"
     )
 
+    # Tests that work without _qdp (PyTorch fallback / reference tests).
+    _NO_QDP_OK = {"test_torch_ref.py", "test_fallback.py"}
+
     for item in items:
         # Skip tests explicitly marked with @pytest.mark.gpu
         if "gpu" in item.keywords:
             item.add_marker(skip_marker)
 
-        # Skip all tests in testing/qdp/ directory
+        # Skip all tests in testing/qdp/ directory, except those that
+        # explicitly do not require the Rust extension.
         fspath_str = str(item.fspath)
         if "testing/qdp" in fspath_str or "testing\\qdp" in fspath_str:
-            item.add_marker(skip_marker)
+            if not any(name in fspath_str for name in _NO_QDP_OK):
+                item.add_marker(skip_marker)
 
 
 @pytest.fixture

--- a/testing/qdp_python/test_fallback.py
+++ b/testing/qdp_python/test_fallback.py
@@ -15,7 +15,10 @@
 # limitations under the License.
 
 """
-Tests for the fallback mechanism when _qdp is unavailable.
+Tests for backend selection when _qdp is unavailable.
+
+The PyTorch reference backend must be explicitly selected via
+``.backend("pytorch")``; it is NOT used as an automatic fallback.
 """
 
 from __future__ import annotations
@@ -67,6 +70,15 @@ class TestBackendDetection:
         finally:
             force_backend(None)
 
+    def test_auto_detection_skips_pytorch(self):
+        """Without _qdp, auto-detection returns NONE, not PYTORCH."""
+        from qumat_qdp._backend import Backend, get_backend
+
+        # If _qdp is not installed, get_backend() should be NONE.
+        # If _qdp IS installed, it will be RUST_CUDA.  Either way, not PYTORCH.
+        b = get_backend()
+        assert b is not Backend.PYTORCH
+
     def test_get_torch(self):
         from qumat_qdp._backend import get_torch
 
@@ -75,73 +87,77 @@ class TestBackendDetection:
 
 
 # ---------------------------------------------------------------------------
-# Loader fallback (simulate _qdp unavailable)
+# Loader with explicit PyTorch backend
 # ---------------------------------------------------------------------------
 
 
-def _patch_qdp_unavailable(monkeypatch):
-    """Make _get_qdp() return None to simulate missing _qdp extension."""
-    from qumat_qdp import loader
+class TestLoaderPytorchBackend:
+    def test_no_qdp_without_explicit_backend_raises(self, monkeypatch):
+        """Without _qdp and without .backend('pytorch'), iteration raises."""
+        from qumat_qdp import loader as loader_mod
+        from qumat_qdp.loader import QuantumDataLoader
 
-    # Clear lru_cache and replace with a function returning None.
-    monkeypatch.setattr(loader, "_get_qdp", lambda: None)
+        monkeypatch.setattr(loader_mod, "_get_qdp", lambda: None)
+        ld = (
+            QuantumDataLoader(device_id=0)
+            .qubits(2)
+            .encoding("amplitude")
+            .batches(1, size=1)
+            .source_synthetic()
+        )
+        with pytest.raises(RuntimeError, match="Rust extension"):
+            list(ld)
 
-
-class TestLoaderFallback:
-    def test_synthetic_fallback_yields_tensors(self, monkeypatch):
-        _patch_qdp_unavailable(monkeypatch)
+    def test_synthetic_pytorch_yields_tensors(self):
         from qumat_qdp.loader import QuantumDataLoader
 
         loader = (
             QuantumDataLoader(device_id=0)
+            .backend("pytorch")
             .qubits(2)
             .encoding("amplitude")
             .batches(3, size=2)
             .source_synthetic()
         )
-        with pytest.warns(UserWarning, match="PyTorch fallback"):
-            batches = list(loader)
+        batches = list(loader)
         assert len(batches) == 3
         for b in batches:
             assert isinstance(b, torch.Tensor)
             assert b.shape == (2, 4)  # batch_size=2, 2^2=4
             assert b.is_complex()
 
-    def test_synthetic_fallback_angle(self, monkeypatch):
-        _patch_qdp_unavailable(monkeypatch)
+    def test_synthetic_pytorch_angle(self):
         from qumat_qdp.loader import QuantumDataLoader
 
         loader = (
             QuantumDataLoader(device_id=0)
+            .backend("pytorch")
             .qubits(3)
             .encoding("angle")
             .batches(2, size=4)
             .source_synthetic()
         )
-        with pytest.warns(UserWarning, match="PyTorch fallback"):
-            batches = list(loader)
+        batches = list(loader)
         assert len(batches) == 2
         assert batches[0].shape == (4, 8)
 
-    def test_synthetic_fallback_basis(self, monkeypatch):
-        _patch_qdp_unavailable(monkeypatch)
+    def test_synthetic_pytorch_basis(self):
         from qumat_qdp.loader import QuantumDataLoader
 
         loader = (
             QuantumDataLoader(device_id=0)
+            .backend("pytorch")
             .qubits(2)
             .encoding("basis")
             .batches(2, size=3)
             .source_synthetic()
         )
-        with pytest.warns(UserWarning, match="PyTorch fallback"):
-            batches = list(loader)
+        batches = list(loader)
         assert len(batches) == 2
         for b in batches:
             assert b.shape == (3, 4)
 
-    def test_file_npy_fallback(self, monkeypatch, tmp_path):
-        _patch_qdp_unavailable(monkeypatch)
+    def test_file_npy_pytorch(self, tmp_path):
         import numpy as np
         from qumat_qdp.loader import QuantumDataLoader
 
@@ -152,51 +168,48 @@ class TestLoaderFallback:
 
         loader = (
             QuantumDataLoader(device_id=0)
+            .backend("pytorch")
             .qubits(2)
             .encoding("amplitude")
             .batches(5, size=2)
             .source_file(npy_path)
         )
-        with pytest.warns(UserWarning, match="PyTorch fallback"):
-            batches = list(loader)
+        batches = list(loader)
         assert len(batches) == 5
         for b in batches:
             assert isinstance(b, torch.Tensor)
             assert b.shape == (2, 4)
 
-    def test_file_parquet_raises(self, monkeypatch):
-        _patch_qdp_unavailable(monkeypatch)
+    def test_file_parquet_raises(self):
         from qumat_qdp.loader import QuantumDataLoader
 
         loader = (
             QuantumDataLoader(device_id=0)
+            .backend("pytorch")
             .qubits(2)
             .encoding("amplitude")
             .batches(1, size=1)
             .source_file("data.parquet")
         )
-        with pytest.warns(UserWarning, match="PyTorch fallback"):
-            with pytest.raises(RuntimeError, match="only supports"):
-                list(loader)
+        with pytest.raises(RuntimeError, match="only supports"):
+            list(loader)
 
-    def test_synthetic_fallback_iqp(self, monkeypatch):
-        _patch_qdp_unavailable(monkeypatch)
+    def test_synthetic_pytorch_iqp(self):
         from qumat_qdp.loader import QuantumDataLoader
 
         loader = (
             QuantumDataLoader(device_id=0)
+            .backend("pytorch")
             .qubits(3)
             .encoding("iqp")
             .batches(2, size=4)
             .source_synthetic()
         )
-        with pytest.warns(UserWarning, match="PyTorch fallback"):
-            batches = list(loader)
+        batches = list(loader)
         assert len(batches) == 2
         assert batches[0].shape == (4, 8)
 
-    def test_file_pt_fallback(self, monkeypatch, tmp_path):
-        _patch_qdp_unavailable(monkeypatch)
+    def test_file_pt_pytorch(self, tmp_path):
         from qumat_qdp.loader import QuantumDataLoader
 
         data = torch.randn(10, 4, dtype=torch.float64)
@@ -205,32 +218,37 @@ class TestLoaderFallback:
 
         loader = (
             QuantumDataLoader(device_id=0)
+            .backend("pytorch")
             .qubits(2)
             .encoding("amplitude")
             .batches(5, size=2)
             .source_file(pt_path)
         )
-        with pytest.warns(UserWarning, match="PyTorch fallback"):
-            batches = list(loader)
+        batches = list(loader)
         assert len(batches) == 5
         for b in batches:
             assert isinstance(b, torch.Tensor)
             assert b.shape == (2, 4)
 
-    def test_streaming_raises(self, monkeypatch):
-        _patch_qdp_unavailable(monkeypatch)
+    def test_streaming_raises(self):
         from qumat_qdp.loader import QuantumDataLoader
 
         loader = (
             QuantumDataLoader(device_id=0)
+            .backend("pytorch")
             .qubits(2)
             .encoding("amplitude")
             .batches(1, size=1)
             .source_file("data.parquet", streaming=True)
         )
-        with pytest.warns(UserWarning, match="PyTorch fallback"):
-            with pytest.raises(RuntimeError, match="Streaming"):
-                list(loader)
+        with pytest.raises(RuntimeError, match="Streaming"):
+            list(loader)
+
+    def test_invalid_backend_raises(self):
+        from qumat_qdp.loader import QuantumDataLoader
+
+        with pytest.raises(ValueError, match="'rust' or 'pytorch'"):
+            QuantumDataLoader(device_id=0).backend("auto")
 
 
 # ---------------------------------------------------------------------------
@@ -267,8 +285,14 @@ class TestBenchmarkFallback:
     def test_invalid_backend_raises(self):
         from qumat_qdp.api import QdpBenchmark
 
-        with pytest.raises(ValueError, match="'auto', 'rust', or 'pytorch'"):
+        with pytest.raises(ValueError, match="'rust' or 'pytorch'"):
             QdpBenchmark().backend("invalid")
+
+    def test_auto_backend_raises(self):
+        from qumat_qdp.api import QdpBenchmark
+
+        with pytest.raises(ValueError, match="'rust' or 'pytorch'"):
+            QdpBenchmark().backend("auto")
 
     def test_pytorch_throughput(self):
         from qumat_qdp.api import QdpBenchmark

--- a/testing/qdp_python/test_fallback.py
+++ b/testing/qdp_python/test_fallback.py
@@ -1,0 +1,300 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for the fallback mechanism when _qdp is unavailable.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+
+# ---------------------------------------------------------------------------
+# Backend detection
+# ---------------------------------------------------------------------------
+
+
+class TestBackendDetection:
+    def test_enum_values(self):
+        from qumat_qdp._backend import Backend
+
+        assert Backend.RUST_CUDA.value == "rust_cuda"
+        assert Backend.PYTORCH.value == "pytorch"
+        assert Backend.NONE.value == "none"
+
+    def test_get_backend_returns_valid(self):
+        from qumat_qdp._backend import Backend, get_backend
+
+        b = get_backend()
+        assert isinstance(b, Backend)
+
+    def test_force_backend(self):
+        from qumat_qdp._backend import Backend, force_backend, get_backend
+
+        original = get_backend()
+        try:
+            force_backend(Backend.PYTORCH)
+            assert get_backend() is Backend.PYTORCH
+            force_backend(Backend.NONE)
+            assert get_backend() is Backend.NONE
+        finally:
+            force_backend(None)
+            assert get_backend() == original
+
+    def test_require_backend_none_raises(self):
+        from qumat_qdp._backend import Backend, force_backend, require_backend
+
+        try:
+            force_backend(Backend.NONE)
+            with pytest.raises(RuntimeError, match="No QDP encoding backend"):
+                require_backend()
+        finally:
+            force_backend(None)
+
+    def test_get_torch(self):
+        from qumat_qdp._backend import get_torch
+
+        t = get_torch()
+        assert t is not None  # torch is available in test env
+
+
+# ---------------------------------------------------------------------------
+# Loader fallback (simulate _qdp unavailable)
+# ---------------------------------------------------------------------------
+
+
+def _patch_qdp_unavailable(monkeypatch):
+    """Make _get_qdp() return None to simulate missing _qdp extension."""
+    from qumat_qdp import loader
+
+    # Clear lru_cache and replace with a function returning None.
+    monkeypatch.setattr(loader, "_get_qdp", lambda: None)
+
+
+class TestLoaderFallback:
+    def test_synthetic_fallback_yields_tensors(self, monkeypatch):
+        _patch_qdp_unavailable(monkeypatch)
+        from qumat_qdp.loader import QuantumDataLoader
+
+        loader = (
+            QuantumDataLoader(device_id=0)
+            .qubits(2)
+            .encoding("amplitude")
+            .batches(3, size=2)
+            .source_synthetic()
+        )
+        with pytest.warns(UserWarning, match="PyTorch fallback"):
+            batches = list(loader)
+        assert len(batches) == 3
+        for b in batches:
+            assert isinstance(b, torch.Tensor)
+            assert b.shape == (2, 4)  # batch_size=2, 2^2=4
+            assert b.is_complex()
+
+    def test_synthetic_fallback_angle(self, monkeypatch):
+        _patch_qdp_unavailable(monkeypatch)
+        from qumat_qdp.loader import QuantumDataLoader
+
+        loader = (
+            QuantumDataLoader(device_id=0)
+            .qubits(3)
+            .encoding("angle")
+            .batches(2, size=4)
+            .source_synthetic()
+        )
+        with pytest.warns(UserWarning, match="PyTorch fallback"):
+            batches = list(loader)
+        assert len(batches) == 2
+        assert batches[0].shape == (4, 8)
+
+    def test_synthetic_fallback_basis(self, monkeypatch):
+        _patch_qdp_unavailable(monkeypatch)
+        from qumat_qdp.loader import QuantumDataLoader
+
+        loader = (
+            QuantumDataLoader(device_id=0)
+            .qubits(2)
+            .encoding("basis")
+            .batches(2, size=3)
+            .source_synthetic()
+        )
+        with pytest.warns(UserWarning, match="PyTorch fallback"):
+            batches = list(loader)
+        assert len(batches) == 2
+        for b in batches:
+            assert b.shape == (3, 4)
+
+    def test_file_npy_fallback(self, monkeypatch, tmp_path):
+        _patch_qdp_unavailable(monkeypatch)
+        import numpy as np
+        from qumat_qdp.loader import QuantumDataLoader
+
+        # Create a small .npy file.
+        data = np.random.rand(10, 4).astype(np.float64)
+        npy_path = str(tmp_path / "test_data.npy")
+        np.save(npy_path, data)
+
+        loader = (
+            QuantumDataLoader(device_id=0)
+            .qubits(2)
+            .encoding("amplitude")
+            .batches(5, size=2)
+            .source_file(npy_path)
+        )
+        with pytest.warns(UserWarning, match="PyTorch fallback"):
+            batches = list(loader)
+        assert len(batches) == 5
+        for b in batches:
+            assert isinstance(b, torch.Tensor)
+            assert b.shape == (2, 4)
+
+    def test_file_parquet_raises(self, monkeypatch):
+        _patch_qdp_unavailable(monkeypatch)
+        from qumat_qdp.loader import QuantumDataLoader
+
+        loader = (
+            QuantumDataLoader(device_id=0)
+            .qubits(2)
+            .encoding("amplitude")
+            .batches(1, size=1)
+            .source_file("data.parquet")
+        )
+        with pytest.warns(UserWarning, match="PyTorch fallback"):
+            with pytest.raises(RuntimeError, match="only supports"):
+                list(loader)
+
+    def test_synthetic_fallback_iqp(self, monkeypatch):
+        _patch_qdp_unavailable(monkeypatch)
+        from qumat_qdp.loader import QuantumDataLoader
+
+        loader = (
+            QuantumDataLoader(device_id=0)
+            .qubits(3)
+            .encoding("iqp")
+            .batches(2, size=4)
+            .source_synthetic()
+        )
+        with pytest.warns(UserWarning, match="PyTorch fallback"):
+            batches = list(loader)
+        assert len(batches) == 2
+        assert batches[0].shape == (4, 8)
+
+    def test_file_pt_fallback(self, monkeypatch, tmp_path):
+        _patch_qdp_unavailable(monkeypatch)
+        from qumat_qdp.loader import QuantumDataLoader
+
+        data = torch.randn(10, 4, dtype=torch.float64)
+        pt_path = str(tmp_path / "test_data.pt")
+        torch.save(data, pt_path)
+
+        loader = (
+            QuantumDataLoader(device_id=0)
+            .qubits(2)
+            .encoding("amplitude")
+            .batches(5, size=2)
+            .source_file(pt_path)
+        )
+        with pytest.warns(UserWarning, match="PyTorch fallback"):
+            batches = list(loader)
+        assert len(batches) == 5
+        for b in batches:
+            assert isinstance(b, torch.Tensor)
+            assert b.shape == (2, 4)
+
+    def test_streaming_raises(self, monkeypatch):
+        _patch_qdp_unavailable(monkeypatch)
+        from qumat_qdp.loader import QuantumDataLoader
+
+        loader = (
+            QuantumDataLoader(device_id=0)
+            .qubits(2)
+            .encoding("amplitude")
+            .batches(1, size=1)
+            .source_file("data.parquet", streaming=True)
+        )
+        with pytest.warns(UserWarning, match="PyTorch fallback"):
+            with pytest.raises(RuntimeError, match="Streaming"):
+                list(loader)
+
+
+# ---------------------------------------------------------------------------
+# Import-level fallback
+# ---------------------------------------------------------------------------
+
+
+class TestImportFallback:
+    def test_backend_exported(self):
+        from qumat_qdp import BACKEND, Backend
+
+        assert isinstance(BACKEND, Backend)
+
+    def test_backend_enum_importable(self):
+        from qumat_qdp import Backend
+
+        assert hasattr(Backend, "RUST_CUDA")
+        assert hasattr(Backend, "PYTORCH")
+        assert hasattr(Backend, "NONE")
+
+
+# ---------------------------------------------------------------------------
+# Benchmark API fallback
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkFallback:
+    def test_backend_builder(self):
+        from qumat_qdp.api import QdpBenchmark
+
+        b = QdpBenchmark().backend("pytorch")
+        assert b._backend_name == "pytorch"
+
+    def test_invalid_backend_raises(self):
+        from qumat_qdp.api import QdpBenchmark
+
+        with pytest.raises(ValueError, match="'auto', 'rust', or 'pytorch'"):
+            QdpBenchmark().backend("invalid")
+
+    def test_pytorch_throughput(self):
+        from qumat_qdp.api import QdpBenchmark
+
+        result = (
+            QdpBenchmark()
+            .backend("pytorch")
+            .qubits(2)
+            .encoding("amplitude")
+            .batches(5, size=4)
+            .warmup(1)
+            .run_throughput()
+        )
+        assert result.duration_sec > 0
+        assert result.vectors_per_sec > 0
+
+    def test_pytorch_latency(self):
+        from qumat_qdp.api import QdpBenchmark
+
+        result = (
+            QdpBenchmark()
+            .backend("pytorch")
+            .qubits(2)
+            .encoding("amplitude")
+            .batches(5, size=4)
+            .run_latency()
+        )
+        assert result.duration_sec > 0
+        assert result.latency_ms_per_vector > 0

--- a/testing/qdp_python/test_torch_ref.py
+++ b/testing/qdp_python/test_torch_ref.py
@@ -1,0 +1,403 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Tests for pure-PyTorch reference encoding implementations.
+
+These tests run on CPU and do NOT require the _qdp Rust extension.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from qumat_qdp.torch_ref import (
+    amplitude_encode,
+    angle_encode,
+    basis_encode,
+    encode,
+    iqp_encode,
+)
+
+# ---------------------------------------------------------------------------
+# Amplitude encoding
+# ---------------------------------------------------------------------------
+
+
+class TestAmplitudeEncode:
+    def test_normalization(self):
+        data = torch.tensor([[3.0, 4.0, 0.0, 0.0]], dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=2)
+        expected = torch.tensor(
+            [[0.6 + 0j, 0.8 + 0j, 0.0 + 0j, 0.0 + 0j]], dtype=torch.complex128
+        )
+        assert torch.allclose(result, expected, atol=1e-10)
+
+    def test_padding(self):
+        data = torch.tensor([[1.0, 0.0]], dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=2)
+        assert result.shape == (1, 4)
+        # After padding [1, 0, 0, 0] and normalizing: [1, 0, 0, 0]
+        assert torch.allclose(
+            result[0, 0], torch.tensor(1.0 + 0j, dtype=torch.complex128)
+        )
+        assert torch.allclose(result[0, 1:], torch.zeros(3, dtype=torch.complex128))
+
+    def test_batch(self):
+        data = torch.randn(5, 8, dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=3)
+        assert result.shape == (5, 8)
+
+    def test_1d_input(self):
+        data = torch.tensor([3.0, 4.0, 0.0, 0.0], dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=2)
+        assert result.shape == (1, 4)
+
+    def test_zero_vector_near_zero(self):
+        """Zero-norm row produces near-zero output (no GPU sync error)."""
+        data = torch.zeros(1, 4, dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=2)
+        assert torch.allclose(result.abs(), torch.zeros_like(result.abs()), atol=1e-5)
+
+    def test_nan_propagates(self):
+        """NaN input propagates through output (no GPU sync validation)."""
+        data = torch.tensor([[float("nan"), 1.0, 0.0, 0.0]], dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=2)
+        assert torch.any(torch.isnan(result.real))
+
+    def test_features_exceed_state_dim_raises(self):
+        data = torch.randn(1, 16, dtype=torch.float64)
+        with pytest.raises(ValueError, match="exceed state dimension"):
+            amplitude_encode(data, num_qubits=2)  # state_dim=4
+
+    def test_unit_norm(self):
+        data = torch.randn(10, 8, dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=3)
+        norms = torch.abs(result).norm(dim=1)
+        assert torch.allclose(norms, torch.ones(10, dtype=torch.float64), atol=1e-10)
+
+    def test_dtype_float32(self):
+        data = torch.randn(2, 4, dtype=torch.float32)
+        result = amplitude_encode(data, num_qubits=2)
+        assert result.dtype == torch.complex64
+
+    def test_dtype_float64(self):
+        data = torch.randn(2, 4, dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=2)
+        assert result.dtype == torch.complex128
+
+
+# ---------------------------------------------------------------------------
+# Angle encoding
+# ---------------------------------------------------------------------------
+
+
+class TestAngleEncode:
+    def test_zero_angles(self):
+        """[0, 0] -> |00> = [1, 0, 0, 0]."""
+        data = torch.tensor([[0.0, 0.0]], dtype=torch.float64)
+        result = angle_encode(data, num_qubits=2)
+        expected = torch.tensor(
+            [[1.0 + 0j, 0.0 + 0j, 0.0 + 0j, 0.0 + 0j]], dtype=torch.complex128
+        )
+        assert torch.allclose(result, expected, atol=1e-10)
+
+    def test_pi_half_first_qubit(self):
+        """[pi/2, 0] -> cos(pi/2)*cos(0)=0, sin(pi/2)*cos(0)=1, ..."""
+        data = torch.tensor([[math.pi / 2, 0.0]], dtype=torch.float64)
+        result = angle_encode(data, num_qubits=2)
+        # State |01>: bit0=1 -> sin(pi/2)=1, bit1=0 -> cos(0)=1 => amplitude=1
+        assert abs(result[0, 0].real) < 1e-10  # |00>
+        assert abs(result[0, 1].real - 1.0) < 1e-10  # |01>
+        assert abs(result[0, 2].real) < 1e-10  # |10>
+        assert abs(result[0, 3].real) < 1e-10  # |11>
+
+    def test_wrong_length_raises(self):
+        data = torch.tensor([[1.0, 2.0, 3.0]], dtype=torch.float64)
+        with pytest.raises(RuntimeError, match="expects 2 values"):
+            angle_encode(data, num_qubits=2)
+
+    def test_unit_norm(self):
+        data = torch.randn(10, 4, dtype=torch.float64)
+        result = angle_encode(data, num_qubits=4)
+        norms = torch.abs(result).norm(dim=1)
+        assert torch.allclose(norms, torch.ones(10, dtype=torch.float64), atol=1e-10)
+
+    def test_batch_shape(self):
+        data = torch.randn(7, 3, dtype=torch.float64)
+        result = angle_encode(data, num_qubits=3)
+        assert result.shape == (7, 8)
+
+    def test_1d_input(self):
+        data = torch.tensor([0.5, 1.0], dtype=torch.float64)
+        result = angle_encode(data, num_qubits=2)
+        assert result.shape == (1, 4)
+
+
+# ---------------------------------------------------------------------------
+# Basis encoding
+# ---------------------------------------------------------------------------
+
+
+class TestBasisEncode:
+    def test_index_zero(self):
+        data = torch.tensor([0.0], dtype=torch.float64)
+        result = basis_encode(data, num_qubits=2)
+        expected = torch.tensor([[1.0 + 0j, 0, 0, 0]], dtype=torch.complex128)
+        assert torch.allclose(result, expected)
+
+    def test_index_three(self):
+        data = torch.tensor([3.0], dtype=torch.float64)
+        result = basis_encode(data, num_qubits=2)
+        assert result[0, 3].real == 1.0
+        assert result[0, :3].abs().sum() == 0.0
+
+    def test_batch(self):
+        data = torch.tensor([0.0, 1.0, 2.0, 3.0], dtype=torch.float64)
+        result = basis_encode(data, num_qubits=2)
+        assert result.shape == (4, 4)
+        for i in range(4):
+            assert result[i, i].real == 1.0
+
+    def test_2d_input(self):
+        data = torch.tensor([[2.0]])
+        result = basis_encode(data, num_qubits=2)
+        assert result.shape == (1, 4)
+        assert result[0, 2].real == 1.0
+
+    def test_out_of_range_raises(self):
+        data = torch.tensor([4.0])
+        with pytest.raises(RuntimeError, match="exceeds state vector size"):
+            basis_encode(data, num_qubits=2)
+
+    def test_negative_raises(self):
+        data = torch.tensor([-1.0])
+        with pytest.raises(RuntimeError, match="non-negative"):
+            basis_encode(data, num_qubits=2)
+
+    def test_non_integer_raises(self):
+        data = torch.tensor([1.5])
+        with pytest.raises(RuntimeError, match="integer-valued"):
+            basis_encode(data, num_qubits=2)
+
+
+# ---------------------------------------------------------------------------
+# IQP encoding
+# ---------------------------------------------------------------------------
+
+
+class TestIqpEncode:
+    def test_zero_params_gives_zero_state(self):
+        """All-zero params → H^n I H^n |0⟩ = |0⟩ = [1, 0, ..., 0]."""
+        n = 3
+        data = torch.zeros(1, n, dtype=torch.float64)
+        result = iqp_encode(data, num_qubits=n, enable_zz=False)
+        expected = torch.zeros(1, 1 << n, dtype=torch.complex128)
+        expected[0, 0] = 1.0 + 0j
+        assert torch.allclose(result, expected, atol=1e-10)
+
+    def test_z_only_mode(self):
+        n = 3
+        data = torch.randn(2, n, dtype=torch.float64)
+        result = iqp_encode(data, num_qubits=n, enable_zz=False)
+        assert result.shape == (2, 1 << n)
+
+    def test_zz_mode(self):
+        n = 3
+        n_params = n + n * (n - 1) // 2  # 3 + 3 = 6
+        data = torch.randn(2, n_params, dtype=torch.float64)
+        result = iqp_encode(data, num_qubits=n, enable_zz=True)
+        assert result.shape == (2, 1 << n)
+
+    def test_unit_norm(self):
+        n = 4
+        n_params = n + n * (n - 1) // 2
+        data = torch.randn(5, n_params, dtype=torch.float64)
+        result = iqp_encode(data, num_qubits=n, enable_zz=True)
+        norms = torch.abs(result).norm(dim=1)
+        assert torch.allclose(norms, torch.ones(5, dtype=torch.float64), atol=1e-10)
+
+    def test_wrong_param_count_raises(self):
+        with pytest.raises(RuntimeError, match="expects"):
+            iqp_encode(
+                torch.randn(1, 5, dtype=torch.float64), num_qubits=3, enable_zz=False
+            )
+
+    def test_1d_input(self):
+        data = torch.zeros(3, dtype=torch.float64)
+        result = iqp_encode(data, num_qubits=3, enable_zz=False)
+        assert result.shape == (1, 8)
+
+    def test_default_enable_zz(self):
+        """Default enable_zz=True."""
+        n = 2
+        n_params = n + n * (n - 1) // 2  # 2 + 1 = 3
+        data = torch.randn(1, n_params, dtype=torch.float64)
+        result = iqp_encode(data, num_qubits=n)
+        assert result.shape == (1, 4)
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher
+# ---------------------------------------------------------------------------
+
+
+class TestDispatcher:
+    def test_amplitude(self):
+        data = torch.randn(2, 4, dtype=torch.float64)
+        result = encode(data, num_qubits=2, encoding_method="amplitude")
+        assert result.shape == (2, 4)
+
+    def test_angle(self):
+        data = torch.randn(2, 3, dtype=torch.float64)
+        result = encode(data, num_qubits=3, encoding_method="angle")
+        assert result.shape == (2, 8)
+
+    def test_basis(self):
+        data = torch.tensor([0.0, 1.0])
+        result = encode(data, num_qubits=2, encoding_method="basis")
+        assert result.shape == (2, 4)
+
+    def test_iqp(self):
+        data = torch.randn(1, 3, dtype=torch.float64)
+        result = encode(data, num_qubits=3, encoding_method="iqp", enable_zz=False)
+        assert result.shape == (1, 8)
+
+    def test_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown encoding method"):
+            encode(torch.randn(1, 4), num_qubits=2, encoding_method="invalid")
+
+
+# ---------------------------------------------------------------------------
+# Device placement (CPU always; GPU if available)
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_integer_dtype_raises(self):
+        data = torch.tensor([[1, 2, 3, 4]])
+        with pytest.raises(ValueError, match="floating-point"):
+            amplitude_encode(data, num_qubits=2)
+
+    def test_3d_tensor_raises(self):
+        data = torch.randn(2, 3, 4, dtype=torch.float64)
+        with pytest.raises(ValueError, match="2-D"):
+            amplitude_encode(data, num_qubits=2)
+
+    def test_angle_nan_propagates(self):
+        """NaN propagates through angle encoding."""
+        data = torch.tensor([[float("nan"), 0.0]], dtype=torch.float64)
+        result = angle_encode(data, num_qubits=2)
+        assert torch.any(torch.isnan(result.real))
+
+    def test_iqp_inf_propagates(self):
+        """Inf propagates through IQP encoding."""
+        data = torch.tensor([[float("inf"), 0.0, 0.0]], dtype=torch.float64)
+        result = iqp_encode(data, num_qubits=3, enable_zz=False)
+        # Inf in phase → cos/sin produce NaN
+        assert torch.any(torch.isnan(result.real))
+
+    def test_basis_multi_column_raises(self):
+        data = torch.tensor([[0.0, 1.0], [2.0, 3.0]])
+        with pytest.raises(ValueError, match="\\(batch,\\) or \\(batch, 1\\)"):
+            basis_encode(data, num_qubits=2)
+
+    def test_iqp_zz_wrong_param_count_raises(self):
+        with pytest.raises(RuntimeError, match="expects"):
+            iqp_encode(
+                torch.randn(1, 3, dtype=torch.float64), num_qubits=3, enable_zz=True
+            )
+
+    def test_basis_integer_tensor(self):
+        """basis_encode accepts integer tensors directly."""
+        data = torch.tensor([0, 3], dtype=torch.long)
+        result = basis_encode(data, num_qubits=2)
+        assert result.dtype == torch.complex128
+        assert result[0, 0].real == 1.0
+        assert result[1, 3].real == 1.0
+
+    def test_unsupported_dtype_raises(self):
+        data = torch.randn(2, 4).half()  # float16
+        with pytest.raises(TypeError, match="Unsupported dtype"):
+            amplitude_encode(data, num_qubits=2)
+
+
+class TestDevicePlacement:
+    def test_cpu_output(self):
+        data = torch.randn(2, 4, dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=2, device="cpu")
+        assert result.device.type == "cpu"
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_gpu_output(self):
+        data = torch.randn(2, 4, dtype=torch.float64)
+        result = amplitude_encode(data, num_qubits=2, device="cuda:0")
+        assert result.device.type == "cuda"
+
+
+# ---------------------------------------------------------------------------
+# Cross-validation: torch_ref vs _qdp (only runs when Rust extension is available)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossValidation:
+    """Compare torch_ref output against _qdp output for the same inputs."""
+
+    @pytest.fixture(autouse=True)
+    def _require_qdp(self):
+        pytest.importorskip("_qdp")
+
+    @pytest.mark.gpu
+    @pytest.mark.parametrize("encoding", ["amplitude", "angle", "basis", "iqp"])
+    def test_encoding_matches_rust(self, encoding):
+        import _qdp
+        import numpy as np
+
+        engine = _qdp.QdpEngine(0)
+        num_qubits = 3
+        state_dim = 1 << num_qubits
+
+        if encoding == "basis":
+            np_data = np.array([[0.0], [3.0], [7.0]])
+        elif encoding == "angle":
+            np_data = np.random.rand(4, num_qubits).astype(np.float64) * 2 * 3.14159
+        elif encoding == "iqp":
+            n_params = num_qubits + num_qubits * (num_qubits - 1) // 2
+            np_data = np.random.rand(4, n_params).astype(np.float64)
+        else:
+            np_data = np.random.rand(4, state_dim).astype(np.float64)
+
+        # Rust path
+        rust_qt = engine.encode(
+            np_data, num_qubits=num_qubits, encoding_method=encoding
+        )
+        rust_tensor = torch.from_dlpack(rust_qt)
+
+        # PyTorch reference path
+        pt_data = torch.tensor(np_data, dtype=torch.float64, device="cuda:0")
+        if encoding == "basis":
+            pt_data = pt_data.flatten()
+        ref_tensor = encode(pt_data, num_qubits, encoding, device="cuda:0")
+
+        assert torch.allclose(
+            rust_tensor.to(torch.complex128),
+            ref_tensor.to(torch.complex128),
+            atol=1e-10,
+        ), f"Mismatch for {encoding} encoding"

--- a/testing/qdp_python/test_torch_ref.py
+++ b/testing/qdp_python/test_torch_ref.py
@@ -370,7 +370,7 @@ class TestCrossValidation:
         import _qdp
         import numpy as np
 
-        engine = _qdp.QdpEngine(0)
+        engine = _qdp.QdpEngine(0)  # type: ignore[unresolved-attribute]
         num_qubits = 3
         state_dim = 1 << num_qubits
 

--- a/testing/qdp_python/test_torch_ref.py
+++ b/testing/qdp_python/test_torch_ref.py
@@ -365,6 +365,7 @@ class TestCrossValidation:
         pytest.importorskip("_qdp")
 
     @pytest.mark.gpu
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
     @pytest.mark.parametrize("encoding", ["amplitude", "angle", "basis", "iqp"])
     def test_encoding_matches_rust(self, encoding):
         import _qdp


### PR DESCRIPTION
Closes #1177 
Related to #1227 

## Summary

This PR adds a pure-PyTorch reference backend to the QDP Python package to compare with our implementation of GPU kernel~

## Benchmark Results

All runs: 100 batches x 64 vectors (except 18-qubit: 50 batches x 64), median of 3 trials.

### Amplitude Encoding

| Qubits | Mode | PyTorch CPU | PyTorch GPU | Mahout | Mahout vs GPU |
|---|---|---|---|---|---|
| 10 | encode-only | 462,882 | 1,390,998 | 567,499 | 0.4x |
| 10 | end-to-end | 73,699 | 86,939 | 234,170 | **2.7x** |
| 14 | encode-only | 118,620 | 789,862 | 151,713 | 0.2x |
| 14 | end-to-end | 5,514 | 6,356 | 25,603 | **4.0x** |
| 16 | encode-only | 5,458 | 228,525 | 65,358 | 0.3x |
| 16 | end-to-end | 721 | 964 | 6,336 | **6.6x** |
| 18 | encode-only | 1,313 | 58,761 | 15,876 | 0.3x |
| 18 | end-to-end | 194 | 237 | 1,529 | **6.5x** |

### Angle Encoding

| Qubits | Mode | PyTorch CPU | PyTorch GPU | Mahout | Mahout vs GPU |
|---|---|---|---|---|---|
| 14 | encode-only | 1,086 | 59,864 | 45,332 | 0.8x |
| 14 | end-to-end | 1,114 | 56,456 | 50,919 | 0.9x |
| 16 | encode-only | 262 | 10,254 | 8,032 | 0.8x |
| 16 | end-to-end | 252 | 10,093 | 11,496 | **1.1x** |

### IQP Encoding

| Qubits | Mode | PyTorch CPU | PyTorch GPU | Mahout | Mahout vs GPU |
|---|---|---|---|---|---|
| 10 | encode-only | 15,381 | 74,239 | 484,071 | **6.5x** |
| 14 | encode-only | 1,258 | 25,597 | 55,304 | **2.2x** |

### Analysis

- **Amplitude encode-only**: PyTorch GPU wins 2-4x because its vectorized L2-norm + pad is very efficient, while Mahout's `encode` path still pays per-batch GPU output allocation + D2H norm validation sync overhead.
- **Amplitude end-to-end**: Mahout wins 2.7-6.6x, with the advantage growing at higher qubit counts. Rust data generation + integrated pipeline dominates Python `generate_batch_data` + `torch.tensor` + H2D transfer.
- **Angle**: Near-parity in both modes (0.8-1.1x). The tensor-product encoding is compute-bound and both implementations are similarly efficient.
- **IQP encode-only**: Mahout wins decisively (2.2-6.5x). Mahout's CUDA kernel for IQP (Walsh-Hadamard + phase computation) is significantly faster than PyTorch's Python-level loop over butterfly stages.

### Known Limitations

- **Basis encode-only**: Rust `engine.encode` expects per-sample basis indices; batch input format differs from PyTorch. Requires Rust API change to support.
- **IQP end-to-end**: Rust pipeline uses `1 << num_qubits` as sample_size regardless of encoding method, causing a mismatch for IQP (which expects `n + n*(n-1)/2`). Pre-existing Rust pipeline bug.
