### PR TITLE
[QDP] Improve PyTorch reader coverage (#1183)

### DIFF
--- a/qdp/qdp-core/tests/torch_io.rs
+++ b/qdp/qdp-core/tests/torch_io.rs
@@ -14,11 +14,60 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use qdp_core::reader::DataReader;
+use qdp_core::readers::TorchReader;
+
+/// Test that TorchReader::new() fails for a missing file.
+/// This test runs regardless of whether the pytorch feature is enabled.
+#[test]
+fn test_torch_reader_missing_file() {
+    let missing_path = "/tmp/nonexistent_torch_file_12345.pt";
+    let result = TorchReader::new(missing_path);
+    assert!(result.is_err());
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("not found") || err_msg.contains("NotImplemented"),
+        "Expected 'not found' or 'NotImplemented' error, got: {}",
+        err_msg
+    );
+}
+
+/// Test reader state getters before and after reading.
+/// This test runs regardless of whether the pytorch feature is enabled.
+#[test]
+fn test_torch_reader_getters() {
+    // For non-pytorch feature, we can only test the initial state
+    // since we can't create a valid .pt file without PyTorch
+    #[cfg(not(feature = "pytorch"))]
+    {
+        // Test with a path that exists (any file will do for new())
+        let temp_path = "/tmp/test_torch_getters_dummy.txt";
+        std::fs::write(temp_path, "dummy").unwrap();
+
+        let reader = TorchReader::new(temp_path).unwrap();
+
+        // Before read_batch(), getters should return None
+        assert_eq!(reader.get_sample_size(), None);
+        assert_eq!(reader.get_num_samples(), None);
+
+        // read_batch() should fail with NotImplemented when pytorch feature is disabled
+        let result = reader.read_batch();
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("NotImplemented") || err_msg.contains("pytorch"),
+            "Expected NotImplemented error, got: {}",
+            err_msg
+        );
+
+        std::fs::remove_file(temp_path).unwrap();
+    }
+}
+
 #[cfg(feature = "pytorch")]
 mod pytorch_tests {
+    use super::*;
     use qdp_core::io::read_torch_batch;
-    use qdp_core::reader::DataReader;
-    use qdp_core::readers::TorchReader;
     use std::fs;
     use tch::Tensor;
 
@@ -32,11 +81,20 @@ mod pytorch_tests {
         tensor.save(temp_path).unwrap();
 
         let mut reader = TorchReader::new(temp_path).unwrap();
+
+        // Test getters before read
+        assert_eq!(reader.get_sample_size(), None);
+        assert_eq!(reader.get_num_samples(), None);
+
         let (read_data, read_samples, read_size) = reader.read_batch().unwrap();
 
         assert_eq!(read_samples, 1);
         assert_eq!(read_size, sample_size);
         assert_eq!(read_data, data);
+
+        // Test getters after read
+        assert_eq!(reader.get_sample_size(), Some(sample_size));
+        assert_eq!(reader.get_num_samples(), Some(1));
 
         fs::remove_file(temp_path).unwrap();
     }
@@ -58,5 +116,80 @@ mod pytorch_tests {
         assert_eq!(read_data, data);
 
         fs::remove_file(temp_path).unwrap();
+    }
+
+    /// Test that read_batch() rejects a second read with "Reader already consumed".
+    #[test]
+    fn test_torch_reader_double_read_fails() {
+        let temp_path = "/tmp/test_torch_double_read.pt";
+        let sample_size = 8;
+        let data: Vec<f64> = (0..sample_size).map(|i| i as f64).collect();
+
+        let tensor = Tensor::from_slice(&data);
+        tensor.save(temp_path).unwrap();
+
+        let mut reader = TorchReader::new(temp_path).unwrap();
+
+        // First read should succeed
+        let result = reader.read_batch();
+        assert!(result.is_ok());
+
+        // Second read should fail with "Reader already consumed"
+        let result = reader.read_batch();
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("already consumed"),
+            "Expected 'Reader already consumed' error, got: {}",
+            err_msg
+        );
+
+        fs::remove_file(temp_path).unwrap();
+    }
+
+    /// Test TorchReader with 2D tensor and verify all getters.
+    #[test]
+    fn test_torch_reader_2d_getters() {
+        let temp_path = "/tmp/test_torch_2d_getters.pt";
+        let num_samples = 5;
+        let sample_size = 10;
+        let data: Vec<f64> = (0..num_samples * sample_size).map(|i| i as f64).collect();
+
+        let tensor = Tensor::from_slice(&data).reshape([num_samples as i64, sample_size as i64]);
+        tensor.save(temp_path).unwrap();
+
+        let mut reader = TorchReader::new(temp_path).unwrap();
+
+        // Before read: getters return None
+        assert_eq!(reader.get_sample_size(), None);
+        assert_eq!(reader.get_num_samples(), None);
+
+        // Read the data
+        let (read_data, read_samples, read_size) = reader.read_batch().unwrap();
+
+        // Verify data integrity
+        assert_eq!(read_samples, num_samples);
+        assert_eq!(read_size, sample_size);
+        assert_eq!(read_data, data);
+
+        // After read: getters return the actual values
+        assert_eq!(reader.get_sample_size(), Some(sample_size));
+        assert_eq!(reader.get_num_samples(), Some(num_samples));
+
+        fs::remove_file(temp_path).unwrap();
+    }
+
+    /// Test TorchReader::new() error for missing file (with pytorch feature).
+    #[test]
+    fn test_torch_reader_new_missing_file_with_pytorch() {
+        let missing_path = "/tmp/nonexistent_file_abcdef.pt";
+        let result = TorchReader::new(missing_path);
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("not found"),
+            "Expected 'not found' error, got: {}",
+            err_msg
+        );
     }
 }


### PR DESCRIPTION
## Summary

Improves test coverage for `qdp/qdp-core/src/readers/torch.rs` as requested in #1183.

## Changes

Added comprehensive tests to `qdp/qdp-core/tests/torch_io.rs`:

1. **test_torch_reader_missing_file** - Verifies that `TorchReader::new()` returns an error when the file does not exist (runs with or without pytorch feature)

2. **test_torch_reader_getters** - Tests `get_sample_size()` and `get_num_samples()` behavior before and after reading, and verifies the `NotImplemented` error path when pytorch feature is disabled

3. **test_torch_reader_double_read_fails** (pytorch feature only) - Verifies that calling `read_batch()` twice returns an error with "Reader already consumed"

4. **test_torch_reader_2d_getters** (pytorch feature only) - Validates 2D tensor handling with getter assertions before and after read

5. **test_torch_reader_new_missing_file_with_pytorch** (pytorch feature only) - Explicit test for missing file error with pytorch feature enabled

## Coverage Improvements

The new tests exercise:
- `TorchReader::new()` success and error paths
- `read_batch()` with 1D and 2D tensors
- Reader consumption guard (prevents double-read)
- `get_sample_size()` and `get_num_samples()` behavior
- Non-feature `NotImplemented` error path

## Testing Notes

Tests are gated by the `pytorch` feature flag where appropriate. Tests that don't require PyTorch (e.g., missing file handling) run regardless of feature flags.

Fixes #1183

---
*This PR was created with assistance from an AI agent (ClawOSS).*