### PR TITLE
Hoist loop-invariant norm computation in iqp_encode_batch_kernel_naive

### DIFF
--- a/qdp/qdp-kernels/src/iqp.cu
+++ b/qdp/qdp-kernels/src/iqp.cu
@@ -251,6 +251,8 @@ __global__ void iqp_encode_batch_kernel_naive(
     const size_t total_elements = num_samples * state_len;
     const size_t stride = gridDim.x * blockDim.x;
     const size_t state_mask = state_len - 1;
+    // Normalize by 1/2^n (state_len = 2^n) - hoisted outside the loop
+    const double norm = 1.0 / (double)state_len;
 
     for (size_t global_idx = blockIdx.x * blockDim.x + threadIdx.x;
          global_idx < total_elements;
@@ -261,7 +263,6 @@ __global__ void iqp_encode_batch_kernel_naive(
 
         cuDoubleComplex amp = compute_amplitude_naive(data, z, state_len, num_qubits, enable_zz);
 
-        double norm = 1.0 / (double)state_len;
         state_batch[global_idx] = make_cuDoubleComplex(cuCreal(amp) * norm, cuCimag(amp) * norm);
     }
 }


### PR DESCRIPTION
## Description

This PR fixes issue #1187 by hoisting the loop-invariant `norm` computation outside the grid-stride loop in `iqp_encode_batch_kernel_naive`.

## Problem

In `qdp/qdp-kernels/src/iqp.cu`, the batch naive kernel recomputes `norm` on every iteration of the grid-stride loop, even though `state_len` is constant:

```cuda
for (size_t global_idx = blockIdx.x * blockDim.x + threadIdx.x;
     global_idx < total_elements;
     global_idx += stride) {
    ...
    double norm = 1.0 / (double)state_len;  // loop-invariant
    state_batch[global_idx] = make_cuDoubleComplex(cuCreal(amp) * norm, cuCimag(amp) * norm);
}
```

## Solution

Hoist `norm` before the loop to match the pattern used in `iqp_encode_kernel_naive`:

```cuda
const double norm = 1.0 / (double)state_len;

for (size_t global_idx = blockIdx.x * blockDim.x + threadIdx.x;
     global_idx < total_elements;
     global_idx += stride) {
    ...
    state_batch[global_idx] = make_cuDoubleComplex(cuCreal(amp) * norm, cuCimag(amp) * norm);
}
```

## Impact

- **Severity**: Low. NVCC almost certainly hoists this via loop-invariant code motion at `-O2`. The fix is primarily for readability and consistency with `iqp_encode_kernel_naive`, which already computes `norm` outside any loop.
- **Location**: `qdp/qdp-kernels/src/iqp.cu`, line 262, inside `iqp_encode_batch_kernel_naive`.

## Related Issue

Fixes #1187
