### PR TITLE
Add phase encoding

### DIFF
--- a/qdp/qdp-core/src/gpu/encodings/mod.rs
+++ b/qdp/qdp-core/src/gpu/encodings/mod.rs
@@ -141,11 +141,13 @@ pub mod amplitude;
 pub mod angle;
 pub mod basis;
 pub mod iqp;
+pub mod phase;
 
 pub use amplitude::AmplitudeEncoder;
 pub use angle::AngleEncoder;
 pub use basis::BasisEncoder;
 pub use iqp::IqpEncoder;
+pub use phase::PhaseEncoder;
 
 /// Create encoder by name: "amplitude", "angle", "basis", "iqp", or "iqp-z"
 pub fn get_encoder(name: &str) -> Result<Box<dyn QuantumEncoder>> {
@@ -155,8 +157,9 @@ pub fn get_encoder(name: &str) -> Result<Box<dyn QuantumEncoder>> {
         "basis" => Ok(Box::new(BasisEncoder)),
         "iqp" => Ok(Box::new(IqpEncoder::full())),
         "iqp-z" => Ok(Box::new(IqpEncoder::z_only())),
+        "phase" => Ok(Box::new(PhaseEncoder)),
         _ => Err(crate::error::MahoutError::InvalidInput(format!(
-            "Unknown encoder: {}. Available: amplitude, angle, basis, iqp, iqp-z",
+            "Unknown encoder: {}. Available: amplitude, angle, basis, iqp, iqp-z, phase",
             name
         ))),
     }

--- a/qdp/qdp-core/src/gpu/encodings/phase.rs
+++ b/qdp/qdp-core/src/gpu/encodings/phase.rs
@@ -1,0 +1,503 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Phase encoding: map per-qubit phase angles to a product state.
+//
+// Each qubit k is initialized via H|0⟩ = |+⟩ = (1/√2)(|0⟩ + |1⟩), then
+// a phase gate P(φ = x_k) is applied, giving:
+//
+//   |x̄_k⟩ = P(φ = x_k)|+⟩ = (1/√2)(|0⟩ + e^{i x_k}|1⟩)
+//
+// The full N-qubit state is the tensor product of these single-qubit states:
+//
+//   |x̄⟩ = ⊗_{k=1}^{N} (1/√2)(|0⟩ + e^{i x_k}|1⟩)
+//         = (1/√2^N) Σ_{b=0}^{2^N-1}  e^{i Σ_k x_k · b_k}  |b⟩
+//
+// where b_k is the k-th bit of basis index b.  Input x_k ∈ (0, 2π] is
+// recommended to avoid information loss due to 2π periodicity of e^{iφ}.
+//
+// Circuit depth: 2 (one Hadamard layer + one phase-gate layer).
+
+#![allow(unused_unsafe)]
+
+use super::{QuantumEncoder, validate_qubit_count};
+#[cfg(target_os = "linux")]
+use crate::error::cuda_error_to_string;
+use crate::error::{MahoutError, Result};
+use crate::gpu::memory::{GpuStateVector, Precision};
+#[cfg(target_os = "linux")]
+use crate::gpu::pipeline::run_dual_stream_pipeline_aligned;
+use cudarc::driver::CudaDevice;
+use std::sync::Arc;
+
+#[cfg(target_os = "linux")]
+use crate::gpu::memory::map_allocation_error;
+#[cfg(target_os = "linux")]
+use cudarc::driver::DevicePtr;
+#[cfg(target_os = "linux")]
+use std::ffi::c_void;
+
+/// Phase encoding: per-qubit P(φ = x_k) gates applied to |+⟩^⊗N.
+///
+/// Input:  `data` — n f64 values x_k ∈ (0, 2π], one phase angle per qubit.
+///         Values outside (0, 2π] are accepted but may cause information loss
+///         due to 2π periodicity of e^{iφ}.
+/// Output: `GpuStateVector` of length 2^n encoding the product state
+///         (1/√2^n) Σ_b e^{i Σ_k x_k · b_k} |b⟩.
+///
+/// Kernel contract: `launch_phase_encode(phases, state, state_len, num_qubits, stream)`
+/// must write amplitude[b] = (1/√2^n) · e^{i Σ_k phases[k] · ((b >> k) & 1)}
+/// as an interleaved (re, im) f64 pair for each basis index b.
+pub struct PhaseEncoder;
+
+impl QuantumEncoder for PhaseEncoder {
+    fn encode(
+        &self,
+        #[cfg(target_os = "linux")] device: &Arc<CudaDevice>,
+        #[cfg(not(target_os = "linux"))] _device: &Arc<CudaDevice>,
+        data: &[f64],
+        num_qubits: usize,
+    ) -> Result<GpuStateVector> {
+        self.validate_input(data, num_qubits)?;
+        let state_len = 1 << num_qubits;
+
+        #[cfg(target_os = "linux")]
+        {
+            let input_bytes = std::mem::size_of_val(data);
+            let phases_gpu = {
+                crate::profile_scope!("GPU::H2D_Phases");
+                device.htod_sync_copy(data).map_err(|e| {
+                    map_allocation_error(input_bytes, "phase input upload", Some(num_qubits), e)
+                })?
+            };
+
+            let state_vector = {
+                crate::profile_scope!("GPU::Alloc");
+                GpuStateVector::new(device, num_qubits, Precision::Float64)?
+            };
+
+            let state_ptr = state_vector.ptr_f64().ok_or_else(|| {
+                MahoutError::InvalidInput(
+                    "State vector precision mismatch (expected float64 buffer)".to_string(),
+                )
+            })?;
+
+            let ret = {
+                crate::profile_scope!("GPU::KernelLaunch");
+                unsafe {
+                    qdp_kernels::launch_phase_encode(
+                        *phases_gpu.device_ptr() as *const f64,
+                        state_ptr as *mut c_void,
+                        state_len,
+                        num_qubits as u32,
+                        std::ptr::null_mut(),
+                    )
+                }
+            };
+
+            if ret != 0 {
+                return Err(MahoutError::KernelLaunch(format!(
+                    "Phase encoding kernel failed with CUDA error code: {} ({})",
+                    ret,
+                    cuda_error_to_string(ret)
+                )));
+            }
+
+            {
+                crate::profile_scope!("GPU::Synchronize");
+                device.synchronize().map_err(|e| {
+                    MahoutError::Cuda(format!("CUDA device synchronize failed: {:?}", e))
+                })?;
+            }
+
+            Ok(state_vector)
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            Err(MahoutError::Cuda(
+                "CUDA unavailable (non-Linux stub)".to_string(),
+            ))
+        }
+    }
+
+    /// Encode multiple phase samples in a single GPU allocation and kernel launch.
+    #[cfg(target_os = "linux")]
+    fn encode_batch(
+        &self,
+        device: &Arc<CudaDevice>,
+        batch_data: &[f64],
+        num_samples: usize,
+        sample_size: usize,
+        num_qubits: usize,
+    ) -> Result<GpuStateVector> {
+        crate::profile_scope!("PhaseEncoder::encode_batch");
+
+        // Each sample provides exactly one phase angle per qubit.
+        if sample_size != num_qubits {
+            return Err(MahoutError::InvalidInput(format!(
+                "Phase encoding expects sample_size={} (one angle per qubit), got {}",
+                num_qubits, sample_size
+            )));
+        }
+
+        if batch_data.len() != num_samples * sample_size {
+            return Err(MahoutError::InvalidInput(format!(
+                "Batch data length {} doesn't match num_samples {} * sample_size {}",
+                batch_data.len(),
+                num_samples,
+                sample_size
+            )));
+        }
+
+        validate_qubit_count(num_qubits)?;
+
+        for (i, &val) in batch_data.iter().enumerate() {
+            if !val.is_finite() {
+                let sample_idx = i / sample_size;
+                let angle_idx = i % sample_size;
+                return Err(MahoutError::InvalidInput(format!(
+                    "Sample {} phase angle {} must be finite, got {}",
+                    sample_idx, angle_idx, val
+                )));
+            }
+        }
+
+        let state_len = 1 << num_qubits;
+
+        const ASYNC_THRESHOLD_ELEMENTS: usize = 1024 * 1024 / std::mem::size_of::<f64>(); // 1 MB
+        if batch_data.len() >= ASYNC_THRESHOLD_ELEMENTS {
+            return Self::encode_batch_async_pipeline(
+                device,
+                batch_data,
+                num_samples,
+                sample_size,
+                num_qubits,
+                state_len,
+            );
+        }
+
+        let batch_state_vector = {
+            crate::profile_scope!("GPU::AllocBatch");
+            GpuStateVector::new_batch(device, num_samples, num_qubits, Precision::Float64)?
+        };
+
+        let input_bytes = std::mem::size_of_val(batch_data);
+        let phases_gpu = {
+            crate::profile_scope!("GPU::H2D_BatchPhases");
+            device.htod_sync_copy(batch_data).map_err(|e| {
+                map_allocation_error(input_bytes, "phase batch upload", Some(num_qubits), e)
+            })?
+        };
+
+        let state_ptr = batch_state_vector.ptr_f64().ok_or_else(|| {
+            MahoutError::InvalidInput(
+                "Batch state vector precision mismatch (expected float64 buffer)".to_string(),
+            )
+        })?;
+
+        {
+            crate::profile_scope!("GPU::BatchKernelLaunch");
+            let ret = unsafe {
+                qdp_kernels::launch_phase_encode_batch(
+                    *phases_gpu.device_ptr() as *const f64,
+                    state_ptr as *mut c_void,
+                    num_samples,
+                    state_len,
+                    num_qubits as u32,
+                    std::ptr::null_mut(),
+                )
+            };
+
+            if ret != 0 {
+                return Err(MahoutError::KernelLaunch(format!(
+                    "Batch phase encoding kernel failed: {} ({})",
+                    ret,
+                    cuda_error_to_string(ret)
+                )));
+            }
+        }
+
+        {
+            crate::profile_scope!("GPU::Synchronize");
+            device
+                .synchronize()
+                .map_err(|e| MahoutError::Cuda(format!("Sync failed: {:?}", e)))?;
+        }
+
+        Ok(batch_state_vector)
+    }
+
+    #[cfg(target_os = "linux")]
+    unsafe fn encode_from_gpu_ptr(
+        &self,
+        device: &Arc<CudaDevice>,
+        input_d: *const c_void,
+        input_len: usize,
+        num_qubits: usize,
+        stream: *mut c_void,
+    ) -> Result<GpuStateVector> {
+        if input_len != num_qubits {
+            return Err(MahoutError::InvalidInput(format!(
+                "Phase encoding expects {} values (one angle per qubit), got {}",
+                num_qubits, input_len
+            )));
+        }
+        let state_len = 1 << num_qubits;
+        let phases_d = input_d as *const f64;
+
+        let state_vector = {
+            crate::profile_scope!("GPU::Alloc");
+            GpuStateVector::new(device, num_qubits, Precision::Float64)?
+        };
+        let state_ptr = state_vector.ptr_f64().ok_or_else(|| {
+            MahoutError::InvalidInput(
+                "State vector precision mismatch (expected float64 buffer)".to_string(),
+            )
+        })?;
+
+        {
+            crate::profile_scope!("GPU::KernelLaunch");
+            let ret = unsafe {
+                qdp_kernels::launch_phase_encode(
+                    phases_d,
+                    state_ptr as *mut c_void,
+                    state_len,
+                    num_qubits as u32,
+                    stream,
+                )
+            };
+            if ret != 0 {
+                return Err(MahoutError::KernelLaunch(format!(
+                    "Phase encoding kernel failed with CUDA error code: {} ({})",
+                    ret,
+                    cuda_error_to_string(ret)
+                )));
+            }
+        }
+
+        {
+            crate::profile_scope!("GPU::Synchronize");
+            crate::gpu::cuda_sync::sync_cuda_stream(stream, "CUDA stream synchronize failed")?;
+        }
+
+        Ok(state_vector)
+    }
+
+    #[cfg(target_os = "linux")]
+    unsafe fn encode_batch_from_gpu_ptr(
+        &self,
+        device: &Arc<CudaDevice>,
+        input_batch_d: *const c_void,
+        num_samples: usize,
+        sample_size: usize,
+        num_qubits: usize,
+        stream: *mut c_void,
+    ) -> Result<GpuStateVector> {
+        if sample_size == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Sample size cannot be zero".into(),
+            ));
+        }
+        if sample_size != num_qubits {
+            return Err(MahoutError::InvalidInput(format!(
+                "Phase encoding expects sample_size={} (one angle per qubit), got {}",
+                num_qubits, sample_size
+            )));
+        }
+        let state_len = 1 << num_qubits;
+        let input_batch_d = input_batch_d as *const f64;
+
+        // Use the L2-norm kernel as a finiteness probe: NaN/Inf propagates
+        // through the norm and is caught on the host side.
+        let phase_validation_buffer = {
+            crate::profile_scope!("GPU::PhaseFiniteCheckBatch");
+            use cudarc::driver::DevicePtrMut;
+            let mut buffer = device.alloc_zeros::<f64>(num_samples).map_err(|e| {
+                MahoutError::MemoryAllocation(format!(
+                    "Failed to allocate phase validation buffer: {:?}",
+                    e
+                ))
+            })?;
+            let ret = unsafe {
+                qdp_kernels::launch_l2_norm_batch(
+                    input_batch_d,
+                    num_samples,
+                    sample_size,
+                    *buffer.device_ptr_mut() as *mut f64,
+                    stream,
+                )
+            };
+            if ret != 0 {
+                return Err(MahoutError::KernelLaunch(format!(
+                    "Phase validation norm kernel failed with CUDA error code: {} ({})",
+                    ret,
+                    cuda_error_to_string(ret)
+                )));
+            }
+            buffer
+        };
+
+        {
+            crate::profile_scope!("GPU::PhaseFiniteValidationHostCopy");
+            let host_norms = device
+                .dtoh_sync_copy(&phase_validation_buffer)
+                .map_err(|e| {
+                    MahoutError::Cuda(format!(
+                        "Failed to copy phase validation norms to host: {:?}",
+                        e
+                    ))
+                })?;
+            if host_norms.iter().any(|v| !v.is_finite()) {
+                return Err(MahoutError::InvalidInput(
+                    "Phase encoding batch contains non-finite values (NaN or Inf)".to_string(),
+                ));
+            }
+        }
+
+        let batch_state_vector = {
+            crate::profile_scope!("GPU::AllocBatch");
+            GpuStateVector::new_batch(device, num_samples, num_qubits, Precision::Float64)?
+        };
+        let state_ptr = batch_state_vector.ptr_f64().ok_or_else(|| {
+            MahoutError::InvalidInput(
+                "Batch state vector precision mismatch (expected float64 buffer)".to_string(),
+            )
+        })?;
+
+        {
+            crate::profile_scope!("GPU::BatchKernelLaunch");
+            let ret = unsafe {
+                qdp_kernels::launch_phase_encode_batch(
+                    input_batch_d,
+                    state_ptr as *mut c_void,
+                    num_samples,
+                    state_len,
+                    num_qubits as u32,
+                    stream,
+                )
+            };
+            if ret != 0 {
+                return Err(MahoutError::KernelLaunch(format!(
+                    "Batch phase encoding kernel failed: {} ({})",
+                    ret,
+                    cuda_error_to_string(ret)
+                )));
+            }
+        }
+
+        {
+            crate::profile_scope!("GPU::Synchronize");
+            crate::gpu::cuda_sync::sync_cuda_stream(stream, "CUDA stream synchronize failed")?;
+        }
+
+        Ok(batch_state_vector)
+    }
+
+    fn validate_input(&self, data: &[f64], num_qubits: usize) -> Result<()> {
+        validate_qubit_count(num_qubits)?;
+        if data.len() != num_qubits {
+            return Err(MahoutError::InvalidInput(format!(
+                "Phase encoding expects {} values (one angle per qubit), got {}",
+                num_qubits,
+                data.len()
+            )));
+        }
+        for (i, &val) in data.iter().enumerate() {
+            if !val.is_finite() {
+                return Err(MahoutError::InvalidInput(format!(
+                    "Phase angle at index {} must be finite, got {}",
+                    i, val
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn name(&self) -> &'static str {
+        "phase"
+    }
+
+    fn description(&self) -> &'static str {
+        "Phase encoding: per-qubit P(φ=x_k) gates on |+⟩, producing ⊗_k (1/√2)(|0⟩ + e^{ix_k}|1⟩)"
+    }
+}
+
+impl PhaseEncoder {
+    #[cfg(target_os = "linux")]
+    fn encode_batch_async_pipeline(
+        device: &Arc<CudaDevice>,
+        batch_data: &[f64],
+        num_samples: usize,
+        sample_size: usize,
+        num_qubits: usize,
+        state_len: usize,
+    ) -> Result<GpuStateVector> {
+        let batch_state_vector = {
+            crate::profile_scope!("GPU::AllocBatch");
+            GpuStateVector::new_batch(device, num_samples, num_qubits, Precision::Float64)?
+        };
+
+        let state_ptr = batch_state_vector.ptr_f64().ok_or_else(|| {
+            MahoutError::InvalidInput(
+                "Batch state vector precision mismatch (expected float64 buffer)".to_string(),
+            )
+        })?;
+
+        run_dual_stream_pipeline_aligned(
+            device,
+            batch_data,
+            sample_size,
+            |stream, input_ptr, chunk_offset, chunk_len| {
+                if chunk_len % sample_size != 0 || chunk_offset % sample_size != 0 {
+                    return Err(MahoutError::InvalidInput(
+                        "Phase batch chunk is not aligned to sample size".to_string(),
+                    ));
+                }
+
+                let chunk_samples = chunk_len / sample_size;
+                let sample_offset = chunk_offset / sample_size;
+                let offset_elements = sample_offset.checked_mul(state_len).ok_or_else(|| {
+                    MahoutError::InvalidInput("Phase batch output offset overflow".to_string())
+                })?;
+
+                let state_ptr_offset = unsafe { state_ptr.add(offset_elements) as *mut c_void };
+                let ret = unsafe {
+                    qdp_kernels::launch_phase_encode_batch(
+                        input_ptr,
+                        state_ptr_offset,
+                        chunk_samples,
+                        state_len,
+                        num_qubits as u32,
+                        stream.stream as *mut c_void,
+                    )
+                };
+
+                if ret != 0 {
+                    return Err(MahoutError::KernelLaunch(format!(
+                        "Batch phase encoding kernel failed: {} ({})",
+                        ret,
+                        cuda_error_to_string(ret)
+                    )));
+                }
+
+                Ok(())
+            },
+        )?;
+
+        Ok(batch_state_vector)
+    }
+}

--- a/qdp/qdp-kernels/build.rs
+++ b/qdp/qdp-kernels/build.rs
@@ -35,6 +35,7 @@ fn main() {
     println!("cargo:rerun-if-changed=src/basis.cu");
     println!("cargo:rerun-if-changed=src/angle.cu");
     println!("cargo:rerun-if-changed=src/iqp.cu");
+    println!("cargo:rerun-if-changed=src/phase.cu");
     println!("cargo:rerun-if-env-changed=QDP_NO_CUDA");
     println!("cargo:rerun-if-changed=src/kernel_config.h");
 
@@ -100,5 +101,6 @@ fn main() {
         .file("src/basis.cu")
         .file("src/angle.cu")
         .file("src/iqp.cu")
+        .file("src/phase.cu")
         .compile("kernels");
 }

--- a/qdp/qdp-kernels/src/lib.rs
+++ b/qdp/qdp-kernels/src/lib.rs
@@ -270,6 +270,33 @@ unsafe extern "C" {
         enable_zz: i32,
         stream: *mut c_void,
     ) -> i32;
+
+    /// Launch phase encoding kernel
+    /// Returns CUDA error code (0 = success)
+    ///
+    /// # Safety
+    /// Requires valid GPU pointers, must sync before freeing
+    pub fn launch_phase_encode(
+        phases_d: *const f64,
+        state_d: *mut c_void,
+        state_len: usize,
+        num_qubits: u32,
+        stream: *mut c_void,
+    ) -> i32;
+
+    /// Launch batch phase encoding kernel
+    /// Returns CUDA error code (0 = success)
+    ///
+    /// # Safety
+    /// Requires valid GPU pointers, must sync before freeing
+    pub fn launch_phase_encode_batch(
+        phases_batch_d: *const f64,
+        state_batch_d: *mut c_void,
+        num_samples: usize,
+        state_len: usize,
+        num_qubits: u32,
+        stream: *mut c_void,
+    ) -> i32;
 }
 
 // Dummy implementation for non-Linux and Linux builds without CUDA (allows linking)
@@ -467,6 +494,31 @@ pub extern "C" fn launch_iqp_encode_batch(
     _num_qubits: u32,
     _data_len: u32,
     _enable_zz: i32,
+    _stream: *mut c_void,
+) -> i32 {
+    999
+}
+
+#[cfg(any(not(target_os = "linux"), qdp_no_cuda))]
+#[unsafe(no_mangle)]
+pub extern "C" fn launch_phase_encode(
+    _phases_d: *const f64,
+    _state_d: *mut c_void,
+    _state_len: usize,
+    _num_qubits: u32,
+    _stream: *mut c_void,
+) -> i32 {
+    999
+}
+
+#[cfg(any(not(target_os = "linux"), qdp_no_cuda))]
+#[unsafe(no_mangle)]
+pub extern "C" fn launch_phase_encode_batch(
+    _phases_batch_d: *const f64,
+    _state_batch_d: *mut c_void,
+    _num_samples: usize,
+    _state_len: usize,
+    _num_qubits: u32,
     _stream: *mut c_void,
 ) -> i32 {
     999

--- a/qdp/qdp-kernels/src/phase.cu
+++ b/qdp/qdp-kernels/src/phase.cu
@@ -1,0 +1,188 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Phase Encoding CUDA Kernels
+//
+// For each qubit phase x_k, build a product state:
+// |psi(x)> = ⊗_k (1/√2)(|0> + e^{i x_k}|1>)
+//
+// Equivalently, amplitude at basis index b is:
+//   state[b] = (1/√2^n) * exp(i * Σ_k x_k * b_k)
+// where b_k = (b >> k) & 1 is the k-th bit of b.
+//
+// Circuit: H⊗N layer followed by P(x_k) per qubit.
+// Depth: 2.  Input x_k ∈ (0, 2π] recommended to avoid aliasing.
+
+#include <cuda_runtime.h>
+#include <cuComplex.h>
+#include <math.h>
+#include "kernel_config.h"
+
+// Precompute 1/√2^n as a compile-time-friendly inline.
+// For n qubits the norm factor is pow(M_SQRT1_2, n).
+__device__ __forceinline__ double phase_norm(unsigned int num_qubits) {
+    // M_SQRT1_2 = 1/√2 ≈ 0.7071067811865476
+    double factor = 1.0;
+    for (unsigned int k = 0; k < num_qubits; ++k) {
+        factor *= M_SQRT1_2;
+    }
+    return factor;
+}
+
+__global__ void phase_encode_kernel(
+    const double* __restrict__ phases,
+    cuDoubleComplex* __restrict__ state,
+    size_t state_len,
+    unsigned int num_qubits
+) {
+    size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= state_len) return;
+
+    // φ(idx) = Σ_k phases[k] * b_k,  b_k = (idx >> k) & 1
+    double phi = 0.0;
+    for (unsigned int bit = 0; bit < num_qubits; ++bit) {
+        if ((idx >> bit) & 1U) {
+            phi += phases[bit];
+        }
+    }
+
+    double norm = phase_norm(num_qubits);
+    double re, im;
+    sincos(phi, &im, &re);   // re = cos(φ), im = sin(φ)
+
+    state[idx] = make_cuDoubleComplex(norm * re, norm * im);
+}
+
+__global__ void phase_encode_batch_kernel(
+    const double* __restrict__ phases_batch,
+    cuDoubleComplex* __restrict__ state_batch,
+    size_t num_samples,
+    size_t state_len,
+    unsigned int num_qubits
+) {
+    const size_t total_elements = num_samples * state_len;
+    const size_t stride = gridDim.x * blockDim.x;
+    const size_t state_mask = state_len - 1;
+
+    for (size_t global_idx = blockIdx.x * blockDim.x + threadIdx.x;
+         global_idx < total_elements;
+         global_idx += stride) {
+        const size_t sample_idx = global_idx >> num_qubits;
+        const size_t element_idx = global_idx & state_mask;
+        const double* phases = phases_batch + sample_idx * num_qubits;
+
+        double phi = 0.0;
+        for (unsigned int bit = 0; bit < num_qubits; ++bit) {
+            if ((element_idx >> bit) & 1U) {
+                phi += phases[bit];
+            }
+        }
+
+        double norm = phase_norm(num_qubits);
+        double re, im;
+        sincos(phi, &im, &re);
+
+        state_batch[global_idx] = make_cuDoubleComplex(norm * re, norm * im);
+    }
+}
+
+extern "C" {
+
+/// Launch phase encoding kernel
+///
+/// Produces the product state ⊗_k (1/√2)(|0> + e^{i x_k}|1>) in the
+/// computational basis.  Each amplitude state[b] is written as:
+///   (1/√2^n) * (cos(φ(b)) + i*sin(φ(b))),  φ(b) = Σ_k phases[k] * b_k
+///
+/// # Arguments
+/// * phases_d  - Device pointer to per-qubit phase angles (length num_qubits)
+/// * state_d   - Device pointer to output state vector (length state_len)
+/// * state_len - Target state vector size (2^num_qubits)
+/// * num_qubits - Number of qubits (phases length)
+/// * stream    - CUDA stream for async execution (nullptr = default stream)
+///
+/// # Returns
+/// CUDA error code (0 = cudaSuccess)
+int launch_phase_encode(
+    const double* phases_d,
+    void* state_d,
+    size_t state_len,
+    unsigned int num_qubits,
+    cudaStream_t stream
+) {
+    if (state_len == 0 || num_qubits == 0) {
+        return cudaErrorInvalidValue;
+    }
+
+    cuDoubleComplex* state_complex_d = static_cast<cuDoubleComplex*>(state_d);
+
+    const int blockSize = DEFAULT_BLOCK_SIZE;
+    const int gridSize = (state_len + blockSize - 1) / blockSize;
+
+    phase_encode_kernel<<<gridSize, blockSize, 0, stream>>>(
+        phases_d,
+        state_complex_d,
+        state_len,
+        num_qubits
+    );
+
+    return (int)cudaGetLastError();
+}
+
+/// Launch batch phase encoding kernel
+///
+/// # Arguments
+/// * phases_batch_d - Device pointer to batch phases (num_samples * num_qubits)
+/// * state_batch_d  - Device pointer to output batch state vectors
+/// * num_samples    - Number of samples in batch
+/// * state_len      - State vector size per sample (2^num_qubits)
+/// * num_qubits     - Number of qubits (phases length per sample)
+/// * stream         - CUDA stream for async execution
+///
+/// # Returns
+/// CUDA error code (0 = cudaSuccess)
+int launch_phase_encode_batch(
+    const double* phases_batch_d,
+    void* state_batch_d,
+    size_t num_samples,
+    size_t state_len,
+    unsigned int num_qubits,
+    cudaStream_t stream
+) {
+    if (num_samples == 0 || state_len == 0 || num_qubits == 0) {
+        return cudaErrorInvalidValue;
+    }
+
+    cuDoubleComplex* state_complex_d = static_cast<cuDoubleComplex*>(state_batch_d);
+
+    const int blockSize = DEFAULT_BLOCK_SIZE;
+    const size_t total_elements = num_samples * state_len;
+    const size_t blocks_needed = (total_elements + blockSize - 1) / blockSize;
+    const size_t max_blocks = MAX_GRID_BLOCKS;
+    const size_t gridSize = (blocks_needed < max_blocks) ? blocks_needed : max_blocks;
+
+    phase_encode_batch_kernel<<<gridSize, blockSize, 0, stream>>>(
+        phases_batch_d,
+        state_complex_d,
+        num_samples,
+        state_len,
+        num_qubits
+    );
+
+    return (int)cudaGetLastError();
+}
+
+} // extern "C"

--- a/testing/qdp/test_bindings.py
+++ b/testing/qdp/test_bindings.py
@@ -1299,3 +1299,206 @@ def test_iqp_fwt_shared_vs_global_memory_threshold():
         assert torch.isclose(norm, torch.tensor(1.0, device="cuda:0"), atol=1e-6), (
             f"IQP {num_qubits} qubits not normalized at threshold: got {norm.item()}"
         )
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_phase_encode_basic():
+    """Test basic phase encoding with zero phases (requires GPU).
+
+    phases = [0, 0] => each qubit is (1/√2)(|0> + e^{i·0}|1>) = |+>
+    full state = |+>⊗|+> = (1/2)(|00> + |01> + |10> + |11>)
+    all four amplitudes equal 1/2 + 0j.
+    """
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+    qtensor = engine.encode([0.0, 0.0], 2, "phase")
+    torch_tensor = torch.from_dlpack(qtensor)
+
+    assert torch_tensor.is_cuda
+    assert torch_tensor.shape == (1, 4)
+
+    val = 0.5 + 0j  # 1/√2^2 = 1/2
+    expected = torch.tensor([[val, val, val, val]], device="cuda:0")
+    assert torch.allclose(
+        torch_tensor, expected.to(torch_tensor.dtype), atol=1e-6, rtol=1e-6
+    )
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_phase_encode_single_qubit():
+    """Test single-qubit phase encoding against the spec formula.
+
+    For one qubit: |x> = (1/√2)(|0> + e^{i x}|1>)
+    With x = π/2: amplitudes are (1/√2, i/√2).
+    """
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+    qtensor = engine.encode([torch.pi / 2], 1, "phase")
+    torch_tensor = torch.from_dlpack(qtensor)
+
+    assert torch_tensor.shape == (1, 2)
+
+    inv_sqrt2 = 1.0 / (2.0**0.5)
+    expected = torch.tensor(
+        [[inv_sqrt2 + 0j, 0.0 + inv_sqrt2 * 1j]],
+        device="cuda:0",
+        dtype=torch.complex128,
+    )
+    assert torch.allclose(
+        torch_tensor, expected.to(torch_tensor.dtype), atol=1e-6, rtol=1e-6
+    )
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_phase_encode_pi_phase():
+    """Test phase encoding with x_k = π.
+
+    phases = [π, π]:
+      qubit 0: (1/√2)(|0> + e^{iπ}|1>) = (1/√2)(|0> - |1>)  = |->
+      qubit 1: same
+    full state = (1/2)(|00> - |01> - |10> + |11>)
+    amplitudes: [+1/2, -1/2, -1/2, +1/2]  (all real, no imaginary part).
+    """
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+    qtensor = engine.encode([torch.pi, torch.pi], 2, "phase")
+    torch_tensor = torch.from_dlpack(qtensor)
+
+    assert torch_tensor.shape == (1, 4)
+
+    expected = torch.tensor(
+        [[0.5 + 0j, -0.5 + 0j, -0.5 + 0j, 0.5 + 0j]],
+        device="cuda:0",
+        dtype=torch.complex128,
+    )
+    assert torch.allclose(
+        torch_tensor, expected.to(torch_tensor.dtype), atol=1e-6, rtol=1e-6
+    )
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_phase_encode_normalization():
+    """State vector must be unit-norm for arbitrary phases."""
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+    phases = [0.3, 1.1, 2.7, 0.9]  # 4 qubits, arbitrary phases
+    qtensor = engine.encode(phases, 4, "phase")
+    torch_tensor = torch.from_dlpack(qtensor)
+
+    norm_sq = torch.sum(torch.abs(torch_tensor) ** 2).item()
+    assert abs(norm_sq - 1.0) < 1e-10, f"Expected unit norm, got {norm_sq}"
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_phase_encode_batch():
+    """Test batch phase encoding (requires GPU).
+
+    Sample 0: phases = [0, 0]  -> all amplitudes 1/2
+    Sample 1: phases = [π, π]  -> amplitudes [+1/2, -1/2, -1/2, +1/2]
+    """
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+    data = torch.tensor(
+        [[0.0, 0.0], [torch.pi, torch.pi]],
+        dtype=torch.float64,
+    )
+    qtensor = engine.encode(data, 2, "phase")
+    torch_tensor = torch.from_dlpack(qtensor)
+
+    assert torch_tensor.shape == (2, 4)
+
+    expected = torch.tensor(
+        [
+            [0.5 + 0j, 0.5 + 0j, 0.5 + 0j, 0.5 + 0j],
+            [0.5 + 0j, -0.5 + 0j, -0.5 + 0j, 0.5 + 0j],
+        ],
+        device="cuda:0",
+        dtype=torch.complex128,
+    )
+    assert torch.allclose(
+        torch_tensor, expected.to(torch_tensor.dtype), atol=1e-6, rtol=1e-6
+    )
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_phase_encode_errors():
+    """Test error handling for phase encoding (requires GPU)."""
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+
+    # Wrong length (expects one phase per qubit)
+    with pytest.raises(RuntimeError, match="expects 2 values"):
+        engine.encode([0.0], 2, "phase")
+
+    # Non-finite phase
+    with pytest.raises(RuntimeError, match="must be finite"):
+        engine.encode([float("nan"), 0.0], 2, "phase")
+
+    # Inf also rejected
+    with pytest.raises(RuntimeError, match="must be finite"):
+        engine.encode([float("inf"), 0.0], 2, "phase")
+
+
+@requires_qdp
+@pytest.mark.gpu
+@pytest.mark.parametrize(
+    ("data_shape", "expected_shape"),
+    [
+        ([1.0, 2.0, 3.0, 4.0], (1, 16)),  # 1D list -> single sample, 4 qubits
+        (
+            torch.tensor(
+                [[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]], dtype=torch.float64
+            ),
+            (2, 16),
+        ),  # 2D tensor -> batch
+    ],
+)
+def test_phase_encode_shape(data_shape, expected_shape):
+    """Test that output tensor shape matches (num_samples, 2^num_qubits)."""
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+    qtensor = engine.encode(data_shape, 4, "phase")
+    torch_tensor = torch.from_dlpack(qtensor)
+
+    assert torch_tensor.shape == expected_shape


### PR DESCRIPTION
### Related Issues

<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [X] New feature
- [ ] Refactoring
- [ ] Documentation
- [X] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why
Phase encoding is a standard QML data encoding strategy, which is distinct from angle encoding (real-amplitude product state) and IQP encoding (entangled global-phase state).

<!-- Why is this change needed? -->

### How
Add `phase.cu` kernel impl
Add `phase.rs` encoder
### Test done
`uv run pytest testing/qdp/test_bindings.py -k 'test_phase' -rF`
```
============== test session starts ==============
platform linux -- Python 3.10.19, pytest-9.0.2, pluggy-1.6.0 -- /home/vvvdwbvvv/oss/mahout/.venv/bin/python3
cachedir: .pytest_cache
rootdir: /home/vvvdwbvvv/oss/mahout
configfile: pyproject.toml
plugins: cov-7.0.0, xdist-3.8.0
collected 69 items / 61 deselected / 8 selected 

testing/qdp/test_bindings.py::test_phase_encode_basic PASSED [ 12%]
testing/qdp/test_bindings.py::test_phase_encode_single_qubit PASSED [ 25%]
testing/qdp/test_bindings.py::test_phase_encode_pi_phase PASSED [ 37%]
testing/qdp/test_bindings.py::test_phase_encode_normalization PASSED [ 50%]
testing/qdp/test_bindings.py::test_phase_encode_batch PASSED [ 62%]
testing/qdp/test_bindings.py::test_phase_encode_errors PASSED [ 75%]
testing/qdp/test_bindings.py::test_phase_encode_shape[data_shape0-expected_shape0] PASSED [ 87%]
testing/qdp/test_bindings.py::test_phase_encode_shape[data_shape1-expected_shape1] PASSED [100%]

======= 8 passed, 61 deselected in 1.46s ========
```
<!-- What was done? -->

## Checklist

- [X] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
