### PR TITLE
[QDP] Add unit tests for streaming amplitude encoder coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,3 @@ __pycache__/
 
 # coverage
 .coverage
-qdp/.cargo/config.toml


### PR DESCRIPTION
### Related Issues

<!-- Closes #123 -->
Closes #1180 

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->

`encoding/amplitude.rs` had less code coverage. This means there was no regression protection for sample size validation, state initialization, or the streaming encoding path.

### How

<!-- What was done? -->
Added 6 unit tests in  `qdp/qdp-core/src/encoding/amplitude.rs `:

reject_sample_size_zero
 — validates sample_size == 0 returns InvalidInput

reject_sample_size_exceeds_stage
 — validates sample_size > STAGE_SIZE_ELEMENTS returns InvalidInput

accept_valid_sample_size
 — confirms valid size passes

accept_max_valid_sample_size
 — boundary test at STAGE_SIZE_ELEMENTS

needs_staging_copy_returns_true
 — verifies default trait impl

init_state_allocates_norm_buffer
 — confirms GPU norm buffer allocation succeeds


## Checklist

- [x] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
<img width="1310" height="77" alt="image" src="https://github.com/user-attachments/assets/bb846858-4100-41ee-a7a5-02c3b2c15048" />
