### PR TITLE
[QDP] Add unit tests for Parquet readers

### DIFF
--- a/qdp/qdp-core/src/readers/parquet.rs
+++ b/qdp/qdp-core/src/readers/parquet.rs
@@ -632,9 +632,7 @@ mod tests {
 
     #[test]
     fn test_parquet_reader_missing_file() {
-        let file = TempTestFile::new();
-        let path = file.path().to_path_buf();
-        drop(file); // ensure file does not exist
+        let path = std::env::temp_dir().join(format!("missing_{}.parquet", std::process::id()));
         let result = ParquetReader::new(&path, None, NullHandling::FillZero);
         assert!(matches!(result, Err(MahoutError::Io(_))));
     }


### PR DESCRIPTION
### Related Issues

<!-- Closes #123 -->
Closes #1184 
### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

<!-- Why is this change needed? -->
`qdp/qdp-core/src/readers/parquet.rs` had less code coverage. This means there was no regression protection for sample size validation, state initialization, or the streaming encoding path.

### How

<!-- What was done? -->

Added 10 unit tests in `qdp/qdp-core/src/readers/parquet.rs` :

1. test_parquet_reader_missing_file — validates missing file returns MahoutError::Io
2. test_parquet_reader_bad_schema — rejects non-list schema (Int32 column)
3. test_parquet_reader_too_many_columns — rejects files with more than one column
4. test_parquet_reader_bad_list_type — rejects List<Int32> (must be List<Float64>)
5. test_parquet_reader_list_f64 — roundtrip List<Float64> with value and metadata assertions
6. test_parquet_reader_fixed_size_list_f64 — roundtrip FixedSizeList<Float64> with value and metadata assertions
7. test_parquet_reader_inconsistent_sample_sizes — verifies error when list lengths differ across rows
8. test_parquet_streaming_reader_scalar_f64 — validates scalar Float64 basis encoding path with chunked read_chunk() calls
9. test_parquet_streaming_reader_list_f64_chunked — streaming read_batch() over List<Float64> with small batch size
10. test_parquet_streaming_reader_empty_data — explicit assertion on empty Parquet file error

## Checklist

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
<img width="1916" height="104" alt="image" src="https://github.com/user-attachments/assets/1fb0ef22-dc0a-40ac-a579-9ff42ff0587e" />
