### PR TITLE
[QDP] fix: Enhance TorchReader tests for file handling and error cases

### DIFF
--- a/qdp/qdp-core/tests/torch_io.rs
+++ b/qdp/qdp-core/tests/torch_io.rs
@@ -71,6 +71,7 @@ fn test_torch_reader_new_rejects_missing_file() {
     }
 }
 
+#[cfg(not(feature = "pytorch"))]
 #[test]
 fn test_torch_reader_default_build_tracks_consumed_state() {
     let path = create_temp_file("pt");


### PR DESCRIPTION
### Related Issues
#1183 
<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why
We already have qdp/qdp-core/tests/torch_io.rs, but the current coverage still suggests that constructor and reader state transitions in readers/torch.rs are not being exercised in the main coverage workflow.

This leaves basic reader behavior under-tested.
<!-- Why is this change needed? -->

### How
Split `tests/torch_io.rs` into two layers:
- **Unconditional tests** — cover `TorchReader::new()` (success + missing-file error), the `NotImplemented` branch on default builds, the `InvalidInput("Reader already consumed")` state, and `get_sample_size()`/`get_num_samples()` returning `None` after a failed read.
- **`#[cfg(feature = "pytorch")]` tests** — kept for real `.pt` tensor reads; tightened to also assert metadata population and second-call rejection after a successful read.
<!-- What was done? -->

### Test Result
From
```
qdp-core/src/readers/torch.rs                    29                29     0.00%           4                 4     0.00%          41                41     0.00%           0                 0         -
```
to
```
qdp-core/src/readers/torch.rs                    29                 4    86.21%           4                 0   100.00%          41                 9    78.05%           0                 0         -
```
## Checklist

- [x]  Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
