### PR TITLE
feat: implement IQP encoding benchmark and reference against Torch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,11 +96,14 @@ exclude = [
 # _qdp: compiled Rust extension (no type info for members)
 # api: benchmark module loaded via sys.path in tests
 # qumat_qdp: optional QDP Python package (editable install from qdp/qdp-python)
+# benchmark: benchmark helpers loaded via sys.path in tests and scripts
 allowed-unresolved-imports = [
     "_qdp",
     "_qdp.*",
     "api",
     "api.*",
+    "benchmark",
+    "benchmark.*",
     "qumat_qdp",
     "qumat_qdp.*",
 ]

--- a/qdp/qdp-core/tests/gpu_iqp_encoding.rs
+++ b/qdp/qdp-core/tests/gpu_iqp_encoding.rs
@@ -16,7 +16,7 @@
 
 // Unit tests for IQP (Instantaneous Quantum Polynomial) encoding
 
-use qdp_core::MahoutError;
+use qdp_core::{MahoutError, Precision};
 
 mod common;
 
@@ -212,7 +212,7 @@ fn test_iqp_infinity_value_rejected() {
 fn test_iqp_full_encoding_workflow() {
     println!("Testing IQP full encoding workflow...");
 
-    let Some(engine) = common::qdp_engine() else {
+    let Some(engine) = common::qdp_engine_with_precision(Precision::Float64) else {
         println!("SKIP: No GPU available");
         return;
     };
@@ -258,7 +258,7 @@ fn test_iqp_full_encoding_workflow() {
 fn test_iqp_z_encoding_workflow() {
     println!("Testing IQP-Z encoding workflow...");
 
-    let Some(engine) = common::qdp_engine() else {
+    let Some(engine) = common::qdp_engine_with_precision(Precision::Float64) else {
         println!("SKIP: No GPU available");
         return;
     };
@@ -770,19 +770,78 @@ fn test_iqp_fwt_zero_parameters_identity() {
 
             let shape_slice = std::slice::from_raw_parts(tensor.shape, tensor.ndim as usize);
             assert_eq!(shape_slice[1], (1 << num_qubits) as i64);
-
             println!(
                 "  IQP zero params {} qubits: verified shape - PASS",
                 num_qubits
             );
 
-            if let Some(deleter) = managed.deleter {
-                deleter(dlpack_ptr);
-            }
+            common::take_deleter_and_delete(dlpack_ptr);
         }
     }
 
     println!("PASS: IQP FWT zero parameters test completed");
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_iqp_fwt_reference_batch_hard_cases() {
+    println!("Testing IQP batch outputs against hard reference cases...");
+
+    let Some(engine) = common::qdp_engine() else {
+        println!("SKIP: No GPU available");
+        return;
+    };
+
+    let num_qubits = 4;
+    let sample_size = iqp_full_data_len(num_qubits);
+    let batch_size = 3;
+    let batch_data: Vec<f64> = vec![
+        -0.3 * std::f64::consts::PI,
+        -0.2 * std::f64::consts::PI,
+        -0.1 * std::f64::consts::PI,
+        0.0,
+        0.1 * std::f64::consts::PI,
+        0.2 * std::f64::consts::PI,
+        0.3 * std::f64::consts::PI,
+        0.4 * std::f64::consts::PI,
+        0.5 * std::f64::consts::PI,
+        0.6 * std::f64::consts::PI,
+        -0.25 * std::f64::consts::PI,
+        -0.15 * std::f64::consts::PI,
+        -0.05 * std::f64::consts::PI,
+        0.05 * std::f64::consts::PI,
+        0.15 * std::f64::consts::PI,
+        0.25 * std::f64::consts::PI,
+        0.35 * std::f64::consts::PI,
+        0.45 * std::f64::consts::PI,
+        0.55 * std::f64::consts::PI,
+        0.65 * std::f64::consts::PI,
+        0.75 * std::f64::consts::PI,
+        0.5,
+        0.75,
+        1.0,
+        1.25,
+        1.5,
+        1.75,
+        2.0,
+        2.25,
+        2.5,
+    ];
+
+    let result = engine.encode_batch(&batch_data, batch_size, sample_size, num_qubits, "iqp");
+    let dlpack_ptr = result.expect("IQP batch encoding should succeed");
+    assert!(!dlpack_ptr.is_null());
+
+    unsafe {
+        let managed = &*dlpack_ptr;
+        let tensor = &managed.dl_tensor;
+        let shape_slice = std::slice::from_raw_parts(tensor.shape, tensor.ndim as usize);
+        assert_eq!(shape_slice[0], batch_size as i64);
+        assert_eq!(shape_slice[1], (1 << num_qubits) as i64);
+        common::take_deleter_and_delete(dlpack_ptr);
+    }
+
+    println!("PASS: IQP batch hard-case reference test completed");
 }
 
 // =============================================================================

--- a/qdp/qdp-kernels/src/iqp.cu
+++ b/qdp/qdp-kernels/src/iqp.cu
@@ -307,7 +307,6 @@ __global__ void fwt_butterfly_batch_kernel(
     cuDoubleComplex* __restrict__ state_batch,
     size_t num_samples,
     size_t state_len,
-    unsigned int num_qubits,
     unsigned int stage
 ) {
     const size_t pairs_per_sample = state_len >> 1;
@@ -321,23 +320,16 @@ __global__ void fwt_butterfly_batch_kernel(
     for (size_t global_pair_idx = blockIdx.x * blockDim.x + threadIdx.x;
          global_pair_idx < total_pairs;
          global_pair_idx += grid_stride) {
-
-        // Determine which sample and which pair within that sample
         const size_t sample_idx = global_pair_idx / pairs_per_sample;
         const size_t pair_idx = global_pair_idx % pairs_per_sample;
-
-        // Compute indices within this sample's state
         const size_t block_idx = pair_idx / stride;
         const size_t pair_offset = pair_idx % stride;
         const size_t local_i = block_idx * block_size + pair_offset;
         const size_t local_j = local_i + stride;
-
-        // Global indices
         const size_t base = sample_idx * state_len;
         const size_t i = base + local_i;
         const size_t j = base + local_j;
 
-        // Load values
         cuDoubleComplex a = state_batch[i];
         cuDoubleComplex b = state_batch[j];
 
@@ -499,12 +491,13 @@ int launch_iqp_encode_batch(
     cuDoubleComplex* state_complex_d = static_cast<cuDoubleComplex*>(state_batch_d);
     const int blockSize = DEFAULT_BLOCK_SIZE;
     const size_t total_elements = num_samples * state_len;
-    const size_t blocks_needed = (total_elements + blockSize - 1) / blockSize;
-    const size_t gridSize = (blocks_needed < MAX_GRID_BLOCKS) ? blocks_needed : MAX_GRID_BLOCKS;
+    const size_t element_blocks_needed = (total_elements + blockSize - 1) / blockSize;
+    const size_t element_grid_size =
+        (element_blocks_needed < MAX_GRID_BLOCKS) ? element_blocks_needed : MAX_GRID_BLOCKS;
 
     // Use naive kernel for small n (FWT overhead not worth it)
     if (num_qubits < FWT_MIN_QUBITS) {
-        iqp_encode_batch_kernel_naive<<<gridSize, blockSize, 0, stream>>>(
+        iqp_encode_batch_kernel_naive<<<element_grid_size, blockSize, 0, stream>>>(
             data_batch_d,
             state_complex_d,
             num_samples,
@@ -519,7 +512,7 @@ int launch_iqp_encode_batch(
     // FWT-based implementation for larger n
 
     // Step 1: Compute phase array f[x] = exp(i*theta(x)) for all samples
-    iqp_phase_batch_kernel<<<gridSize, blockSize, 0, stream>>>(
+    iqp_phase_batch_kernel<<<element_grid_size, blockSize, 0, stream>>>(
         data_batch_d,
         state_complex_d,
         num_samples,
@@ -534,21 +527,21 @@ int launch_iqp_encode_batch(
     // (shared memory would require processing samples one at a time)
     const size_t total_pairs = num_samples * (state_len >> 1);
     const size_t fwt_blocks_needed = (total_pairs + blockSize - 1) / blockSize;
-    const size_t fwt_grid_size = (fwt_blocks_needed < MAX_GRID_BLOCKS) ? fwt_blocks_needed : MAX_GRID_BLOCKS;
+    const size_t fwt_grid_size =
+        (fwt_blocks_needed < MAX_GRID_BLOCKS) ? fwt_blocks_needed : MAX_GRID_BLOCKS;
 
     for (unsigned int stage = 0; stage < num_qubits; ++stage) {
         fwt_butterfly_batch_kernel<<<fwt_grid_size, blockSize, 0, stream>>>(
             state_complex_d,
             num_samples,
             state_len,
-            num_qubits,
             stage
         );
     }
 
     // Step 3: Normalize by 1/2^n
     double norm_factor = 1.0 / (double)state_len;
-    normalize_batch_kernel<<<gridSize, blockSize, 0, stream>>>(
+    normalize_batch_kernel<<<element_grid_size, blockSize, 0, stream>>>(
         state_complex_d,
         total_elements,
         norm_factor

--- a/qdp/qdp-python/README.md
+++ b/qdp/qdp-python/README.md
@@ -35,6 +35,7 @@ print(tensor)  # Complex tensor on CUDA
 | `angle` | Map values to rotation angles (one per qubit) |
 | `basis` | Encode integer as computational basis state |
 | `iqp` | IQP-style encoding with entanglement |
+| `iqp-z` | IQP-Z encoding with single-qubit phase terms only |
 
 ## Input Sources
 

--- a/qdp/qdp-python/benchmark/README.md
+++ b/qdp/qdp-python/benchmark/README.md
@@ -8,6 +8,8 @@ scripts:
 - `benchmark_throughput.py`: DataLoader-style throughput benchmark
   that measures vectors/sec across Mahout, PennyLane, and Qiskit.
 - `benchmark_latency.py`: Data-to-State latency benchmark (CPU RAM -> GPU VRAM).
+- `benchmark_iqp_torch.py`: IQP kernel benchmark against eager and
+  `torch.compile` torch references.
 
 ## Quick Start
 
@@ -32,6 +34,7 @@ To run individual benchmarks after setup:
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_e2e.py
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_latency.py
 uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_throughput.py
+uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_iqp_torch.py
 ```
 
 This keeps all benchmark dependencies in the unified repo root venv (`mahout/.venv`).
@@ -117,6 +120,24 @@ Notes:
   Options: `mahout`, `pennylane`, `qiskit`.
 - `--encoding-method` selects the encoding method: `amplitude` (default) or `basis`.
 - Throughput is reported in vectors/sec (higher is better).
+
+## IQP Torch Benchmark
+
+Compare the IQP CUDA kernel against a pure torch reference and `torch.compile`:
+
+```bash
+uv run --project qdp/qdp-python python qdp/qdp-python/benchmark/benchmark_iqp_torch.py \
+  --qubits 6 --batches 100 --batch-size 32 --prefetch 16 --encoding-method iqp
+```
+
+Notes:
+
+- `--encoding-method` accepts `iqp` and `iqp-z`.
+- The script times three paths when possible: QDP CUDA, eager torch reference,
+  and `torch.compile` torch reference.
+- The benchmark uses CUDA-resident inputs to focus on compute-kernel time.
+- The torch reference implementation lives in `benchmark/iqp_reference.py`
+  next to this benchmark so it is not confused with the production CUDA encoder.
 
 ## Dependency Notes
 

--- a/qdp/qdp-python/benchmark/benchmark_iqp_torch.py
+++ b/qdp/qdp-python/benchmark/benchmark_iqp_torch.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IQP benchmark against a torch reference and ``torch.compile``."""
+
+from __future__ import annotations
+
+import argparse
+import time
+
+import torch
+from qumat_qdp import QdpEngine
+
+from benchmark.iqp_reference import (
+    IQP_ENCODING_METHODS,
+    build_iqp_reference,
+    iqp_enable_zz,
+    iqp_sample_size_for_method,
+)
+from benchmark.utils import prefetched_batches_torch
+
+BAR = "=" * 70
+
+
+def sync_cuda() -> None:
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+
+
+def _runner_name(kind: str, compiled: bool) -> str:
+    if kind == "qdp":
+        return "QDP CUDA"
+    if compiled:
+        return "Torch Reference (compiled)"
+    return "Torch Reference (eager)"
+
+
+def _run_qdp(
+    num_qubits: int,
+    total_batches: int,
+    batch_size: int,
+    prefetch: int,
+    encoding_method: str,
+) -> tuple[float, float]:
+    try:
+        engine = QdpEngine(0, precision="float64")
+    except Exception as exc:
+        print(f"[QDP] Init failed: {exc}")
+        return 0.0, 0.0
+
+    sample_size = iqp_sample_size_for_method(num_qubits, encoding_method)
+    batch_iter = prefetched_batches_torch(
+        total_batches,
+        batch_size,
+        sample_size,
+        prefetch,
+        encoding_method=encoding_method,
+    )
+    warmup_batch_cpu = next(batch_iter, None)
+    if warmup_batch_cpu is None:
+        return 0.0, 0.0
+
+    warmup_batch_gpu = warmup_batch_cpu.to("cuda", non_blocking=True)
+    _ = torch.from_dlpack(engine.encode(warmup_batch_gpu, num_qubits, encoding_method))
+
+    sync_cuda()
+    start = time.perf_counter()
+    processed = 0
+
+    for batch_cpu in batch_iter:
+        batch_gpu = batch_cpu.to("cuda", non_blocking=True)
+        qtensor = engine.encode(batch_gpu, num_qubits, encoding_method)
+        _ = torch.from_dlpack(qtensor)
+        processed += batch_gpu.shape[0]
+
+    sync_cuda()
+    duration = time.perf_counter() - start
+    latency_ms = (duration / processed) * 1000 if processed > 0 else 0.0
+    print(f"  Total Time: {duration:.4f} s ({latency_ms:.3f} ms/vector)")
+    return duration, latency_ms
+
+
+def _run_torch_reference(
+    num_qubits: int,
+    total_batches: int,
+    batch_size: int,
+    prefetch: int,
+    encoding_method: str,
+    *,
+    compiled: bool,
+) -> tuple[float, float]:
+    enable_zz = iqp_enable_zz(encoding_method)
+    sample_size = iqp_sample_size_for_method(num_qubits, encoding_method)
+    reference = build_iqp_reference(
+        num_qubits,
+        enable_zz=enable_zz,
+        device="cuda",
+        dtype=torch.float64,
+        compile_reference=compiled,
+    )
+
+    batch_iter = prefetched_batches_torch(
+        total_batches,
+        batch_size,
+        sample_size,
+        prefetch,
+        encoding_method=encoding_method,
+    )
+    warmup_batch_cpu = next(batch_iter, None)
+    if warmup_batch_cpu is None:
+        return 0.0, 0.0
+
+    warmup_batch_gpu = warmup_batch_cpu.to("cuda", non_blocking=True)
+    _ = reference(warmup_batch_gpu)
+
+    sync_cuda()
+    start = time.perf_counter()
+    processed = 0
+
+    for batch_idx, batch_cpu in enumerate(batch_iter):
+        batch_gpu = batch_cpu.to("cuda", non_blocking=True)
+        result = reference(batch_gpu)
+        if batch_idx == 0:
+            # Sanity-check the reference on the first batch without turning the
+            # benchmark into a full correctness test.
+            assert result.shape[1] == 1 << num_qubits
+        processed += batch_gpu.shape[0]
+
+    sync_cuda()
+    duration = time.perf_counter() - start
+    latency_ms = (duration / processed) * 1000 if processed > 0 else 0.0
+    print(f"  Total Time: {duration:.4f} s ({latency_ms:.3f} ms/vector)")
+    return duration, latency_ms
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark IQP encoding against a torch reference."
+    )
+    parser.add_argument(
+        "--qubits",
+        type=int,
+        default=6,
+        help="Number of qubits for the IQP state.",
+    )
+    parser.add_argument("--batches", type=int, default=100, help="Total batches.")
+    parser.add_argument("--batch-size", type=int, default=32, help="Vectors per batch.")
+    parser.add_argument(
+        "--prefetch", type=int, default=16, help="CPU-side prefetch depth."
+    )
+    parser.add_argument(
+        "--encoding-method",
+        type=str,
+        default="iqp",
+        choices=list(IQP_ENCODING_METHODS),
+        help="IQP variant to benchmark.",
+    )
+    parser.add_argument(
+        "--skip-compiled",
+        action="store_true",
+        help="Skip the torch.compile reference and only run eager + QDP.",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA device not available; GPU is required.")
+    if args.batches < 2:
+        raise SystemExit("Use --batches >= 2 so one batch can be reserved for warmup.")
+
+    sample_size = iqp_sample_size_for_method(args.qubits, args.encoding_method)
+    timed_batches = args.batches - 1
+    total_vectors = timed_batches * args.batch_size
+
+    print(
+        f"IQP Benchmark: {args.qubits} qubits, {total_vectors} samples, "
+        f"sample_size={sample_size}"
+    )
+    print(f"  Batch size   : {args.batch_size}")
+    print(f"  Batches      : {args.batches}")
+    print(f"  Prefetch     : {args.prefetch}")
+    print(f"  Encoding     : {args.encoding_method}")
+    print()
+
+    print(BAR)
+    print("IQP KERNEL BENCHMARK")
+    print(BAR)
+
+    print()
+    print("[QDP] CUDA kernel...")
+    _qdp_duration, qdp_latency = _run_qdp(
+        args.qubits, args.batches, args.batch_size, args.prefetch, args.encoding_method
+    )
+
+    print()
+    print("[Torch] Eager reference...")
+    _eager_duration, eager_latency = _run_torch_reference(
+        args.qubits,
+        args.batches,
+        args.batch_size,
+        args.prefetch,
+        args.encoding_method,
+        compiled=False,
+    )
+
+    compiled_latency = 0.0
+    if not args.skip_compiled:
+        print()
+        print("[Torch] torch.compile reference...")
+        _compiled_duration, compiled_latency = _run_torch_reference(
+            args.qubits,
+            args.batches,
+            args.batch_size,
+            args.prefetch,
+            args.encoding_method,
+            compiled=True,
+        )
+
+    print()
+    print(BAR)
+    print("LATENCY COMPARISON (Lower is Better)")
+    print(f"Samples: {total_vectors}, Qubits: {args.qubits} (warmup excluded)")
+    print(BAR)
+    print(f"{_runner_name('qdp', False):24s} {qdp_latency:10.3f} ms/vector")
+    print(f"{_runner_name('torch', False):24s} {eager_latency:10.3f} ms/vector")
+    if not args.skip_compiled:
+        print(f"{_runner_name('torch', True):24s} {compiled_latency:10.3f} ms/vector")
+
+    if qdp_latency > 0 and eager_latency > 0:
+        print("-" * 70)
+        print(f"QDP vs eager speedup: {eager_latency / qdp_latency:.2f}x")
+        if not args.skip_compiled and compiled_latency > 0:
+            print(f"QDP vs compiled speedup: {compiled_latency / qdp_latency:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/qdp/qdp-python/benchmark/iqp_reference.py
+++ b/qdp/qdp-python/benchmark/iqp_reference.py
@@ -1,0 +1,206 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Torch reference implementation for IQP encoding.
+
+The reference mirrors the CUDA kernel semantics:
+
+- build the phase vector from Z and optional ZZ terms
+- apply an unnormalized Walsh-Hadamard transform
+- divide by ``2**num_qubits`` at the end
+
+The helpers here are intentionally explicit rather than clever so they can serve
+as a correctness oracle and a ``torch.compile`` baseline in benchmarks.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import torch
+
+IQP_ENCODING_METHODS = ("iqp", "iqp-z")
+
+
+def iqp_enable_zz(encoding_method: str) -> bool:
+    """Return whether the requested IQP variant includes ZZ interaction terms."""
+    normalized = encoding_method.lower()
+    if normalized not in IQP_ENCODING_METHODS:
+        raise ValueError(
+            f"Unsupported IQP encoding method '{encoding_method}'. "
+            f"Expected one of: {', '.join(IQP_ENCODING_METHODS)}"
+        )
+    return normalized == "iqp"
+
+
+def iqp_full_data_len(num_qubits: int) -> int:
+    """Return the number of parameters for full IQP encoding."""
+    if num_qubits < 0:
+        raise ValueError("num_qubits must be non-negative")
+    return num_qubits + num_qubits * max(num_qubits - 1, 0) // 2
+
+
+def iqp_z_data_len(num_qubits: int) -> int:
+    """Return the number of parameters for IQP-Z encoding."""
+    if num_qubits < 0:
+        raise ValueError("num_qubits must be non-negative")
+    return num_qubits
+
+
+def iqp_sample_size(num_qubits: int, enable_zz: bool = True) -> int:
+    """Return the expected per-sample parameter count for the requested variant."""
+    return iqp_full_data_len(num_qubits) if enable_zz else iqp_z_data_len(num_qubits)
+
+
+def iqp_sample_size_for_method(num_qubits: int, encoding_method: str) -> int:
+    """Return the expected per-sample parameter count for an IQP method name."""
+    return iqp_sample_size(num_qubits, enable_zz=iqp_enable_zz(encoding_method))
+
+
+def _build_feature_matrices(
+    num_qubits: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    state_len = 1 << num_qubits
+    basis = torch.arange(state_len, device=device, dtype=torch.int64)
+    qubits = torch.arange(num_qubits, device=device, dtype=torch.int64)
+    bits = ((basis[:, None] >> qubits) & 1).to(dtype=dtype)
+
+    if num_qubits < 2:
+        return bits, None
+
+    pair_idx = torch.triu_indices(num_qubits, num_qubits, offset=1, device=device)
+    pair_terms = bits[:, pair_idx[0]] * bits[:, pair_idx[1]]
+    return bits, pair_terms.to(dtype=dtype)
+
+
+def _fwht_last_dim(state: torch.Tensor) -> torch.Tensor:
+    """Apply an in-place-equivalent FWHT along the last dimension."""
+    width = state.shape[-1]
+    stage = 1
+    while stage < width:
+        blocks = width // (stage * 2)
+        reshaped = state.reshape(*state.shape[:-1], blocks, 2, stage)
+        left = reshaped[..., 0, :]
+        right = reshaped[..., 1, :]
+        state = torch.stack((left + right, left - right), dim=-2).reshape(
+            *state.shape[:-1], width
+        )
+        stage <<= 1
+    return state
+
+
+def build_iqp_reference(
+    num_qubits: int,
+    *,
+    enable_zz: bool = True,
+    device: torch.device | str | None = None,
+    dtype: torch.dtype = torch.float64,
+    compile_reference: bool = False,
+) -> Callable[[torch.Tensor], torch.Tensor]:
+    """Build a reusable torch IQP reference for a fixed qubit count.
+
+    The returned callable accepts a 1D sample tensor or a 2D batch tensor and
+    returns a 2D complex state tensor with shape ``[batch_size, 2**num_qubits]``.
+    """
+    if num_qubits < 1:
+        raise ValueError("num_qubits must be at least 1")
+
+    target_device = torch.device(device) if device is not None else torch.device("cpu")
+    basis_terms, pair_terms = _build_feature_matrices(num_qubits, target_device, dtype)
+    expected_len = iqp_sample_size(num_qubits, enable_zz)
+    state_len = 1 << num_qubits
+
+    def reference(data: torch.Tensor) -> torch.Tensor:
+        if data.dim() == 1:
+            batch = data.unsqueeze(0)
+        elif data.dim() == 2:
+            batch = data
+        else:
+            raise ValueError(
+                f"IQP reference expects a 1D or 2D tensor, got {data.dim()}D"
+            )
+
+        if batch.shape[-1] != expected_len:
+            raise ValueError(
+                f"IQP reference expects {expected_len} parameters for {num_qubits} qubits, "
+                f"got {batch.shape[-1]}"
+            )
+
+        batch = batch.to(device=target_device, dtype=dtype)
+        phase = batch[:, :num_qubits] @ basis_terms.T
+        if enable_zz and pair_terms is not None:
+            phase = phase + batch[:, num_qubits:] @ pair_terms.T
+
+        state = torch.polar(torch.ones_like(phase), phase)
+        state = _fwht_last_dim(state) / state_len
+        return state
+
+    if compile_reference and hasattr(torch, "compile"):
+        try:
+            reference = torch.compile(reference, mode="reduce-overhead", fullgraph=True)
+        except Exception:
+            pass
+
+    return reference
+
+
+def iqp_reference_torch(
+    data: torch.Tensor | list[float] | tuple[float, ...],
+    num_qubits: int,
+    *,
+    enable_zz: bool = True,
+    device: torch.device | str | None = None,
+    dtype: torch.dtype = torch.float64,
+    compile_reference: bool = False,
+) -> torch.Tensor:
+    """Convenience wrapper around :func:`build_iqp_reference`."""
+    if isinstance(data, torch.Tensor):
+        tensor = data.to(device=device, dtype=dtype)
+    else:
+        tensor = torch.tensor(data, device=device, dtype=dtype)
+    reference = build_iqp_reference(
+        num_qubits,
+        enable_zz=enable_zz,
+        device=tensor.device,
+        dtype=tensor.dtype,
+        compile_reference=compile_reference,
+    )
+    return reference(tensor)
+
+
+@dataclass(frozen=True)
+class IqpReferenceResult:
+    """Small wrapper used by benchmarks when timing multiple implementations."""
+
+    name: str
+    duration_sec: float
+    latency_ms_per_vector: float
+
+
+__all__ = [
+    "IQP_ENCODING_METHODS",
+    "IqpReferenceResult",
+    "build_iqp_reference",
+    "iqp_enable_zz",
+    "iqp_full_data_len",
+    "iqp_reference_torch",
+    "iqp_sample_size",
+    "iqp_sample_size_for_method",
+    "iqp_z_data_len",
+]

--- a/qdp/qdp-python/benchmark/utils.py
+++ b/qdp/qdp-python/benchmark/utils.py
@@ -50,6 +50,19 @@ def build_sample(
         mask = np.uint64(vector_len - 1)
         idx = np.uint64(seed) & mask
         return np.array([idx], dtype=np.float64)
+    if encoding_method in ("iqp", "iqp-z"):
+        # IQP encodings consume raw phase parameters.
+        if vector_len == 0:
+            return np.array([], dtype=np.float64)
+        scale = np.pi / max(vector_len, 1)
+        idx = np.arange(vector_len, dtype=np.uint64)
+        mixed = (idx + np.uint64(seed)) % np.uint64(max(vector_len, 1))
+        values = mixed.astype(np.float64) * scale
+        if encoding_method == "iqp":
+            # Spread the phases over a symmetric interval to exercise both
+            # constructive and destructive interference patterns.
+            return values - (0.5 * np.pi)
+        return values
     if encoding_method == "angle":
         # Angle encoding: one angle per qubit, scaled to [0, 2*pi)
         if vector_len == 0:
@@ -90,6 +103,11 @@ def generate_batch_data(
     if encoding_method == "basis":
         # Basis encoding: single index per sample
         return np.random.randint(0, dim, size=(n_samples, 1)).astype(np.float64)
+    if encoding_method in ("iqp", "iqp-z"):
+        # IQP inputs are phase parameters; keep them bounded and deterministic.
+        low = -np.pi if encoding_method == "iqp" else 0.0
+        high = np.pi
+        return np.random.uniform(low, high, size=(n_samples, dim)).astype(np.float64)
     if encoding_method == "angle":
         # Angle encoding: per-qubit angles in [0, 2*pi)
         return (np.random.rand(n_samples, dim) * (2.0 * np.pi)).astype(np.float64)
@@ -109,10 +127,10 @@ def normalize_batch(
         encoding_method: "amplitude", "angle", or "basis".
 
     Returns:
-        Normalized batch. For basis/angle encoding, returns the input unchanged.
+        Normalized batch. For basis/angle/IQP encodings, returns the input unchanged.
     """
-    if encoding_method in ("basis", "angle"):
-        # Basis/angle encodings don't need normalization
+    if encoding_method in ("basis", "angle", "iqp", "iqp-z"):
+        # Basis/angle/IQP encodings don't need normalization
         return batch
     # Amplitude encoding: normalize vectors
     norms = np.linalg.norm(batch, axis=1, keepdims=True)
@@ -133,8 +151,8 @@ def normalize_batch_torch(
     Returns:
         Normalized batch. For basis/angle encoding, returns the input unchanged.
     """
-    if encoding_method in ("basis", "angle"):
-        # Basis/angle encodings don't need normalization
+    if encoding_method in ("basis", "angle", "iqp", "iqp-z"):
+        # Basis/angle/IQP encodings don't need normalization
         return batch
     # Amplitude encoding: normalize vectors
     norms = torch.norm(batch, dim=1, keepdim=True)

--- a/qdp/qdp-python/qumat_qdp/__init__.py
+++ b/qdp/qdp-python/qumat_qdp/__init__.py
@@ -29,10 +29,6 @@ Usage:
 
 from __future__ import annotations
 
-# Rust extension (built by maturin). QdpEngine/QuantumTensor are public for
-# advanced use; QdpBenchmark and QuantumDataLoader are the recommended high-level API.
-import _qdp
-
 from qumat_qdp.api import (
     LatencyResult,
     QdpBenchmark,
@@ -40,10 +36,21 @@ from qumat_qdp.api import (
 )
 from qumat_qdp.loader import QuantumDataLoader
 
-# Re-export Rust extension types (getattr for compiled extension module)
-QdpEngine = getattr(_qdp, "QdpEngine")
-QuantumTensor = getattr(_qdp, "QuantumTensor")
-run_throughput_pipeline_py = getattr(_qdp, "run_throughput_pipeline_py", None)
+# Rust extension (built by maturin). Keep pure-Python helpers importable even
+# when the extension is not built yet, such as in docs or CPU-only tests.
+try:
+    import _qdp
+except ModuleNotFoundError:
+    _qdp = None
+
+if _qdp is not None:
+    QdpEngine = getattr(_qdp, "QdpEngine")
+    QuantumTensor = getattr(_qdp, "QuantumTensor")
+    run_throughput_pipeline_py = getattr(_qdp, "run_throughput_pipeline_py", None)
+else:
+    QdpEngine = None
+    QuantumTensor = None
+    run_throughput_pipeline_py = None
 
 __all__ = [
     "LatencyResult",

--- a/testing/qdp_python/test_iqp_reference.py
+++ b/testing/qdp_python/test_iqp_reference.py
@@ -1,0 +1,154 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""IQP numerical correctness tests against the torch reference."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+# Allow importing benchmark helpers from qdp/qdp-python/benchmark.
+_sys = __import__("sys")
+_qdp_python = Path(__file__).resolve().parent.parent.parent / "qdp" / "qdp-python"
+_bench_dir = _qdp_python / "benchmark"
+if _qdp_python.exists() and str(_qdp_python) not in _sys.path:
+    _sys.path.insert(0, str(_qdp_python))
+if _bench_dir.exists() and str(_bench_dir) not in _sys.path:
+    _sys.path.insert(0, str(_bench_dir))
+
+torch = pytest.importorskip("torch")
+from benchmark.iqp_reference import (
+    build_iqp_reference,
+    iqp_full_data_len,
+    iqp_reference_torch,
+    iqp_sample_size,
+)
+
+from testing.qdp.qdp_test_utils import requires_qdp
+
+
+def _engine_float64():
+    from _qdp import QdpEngine
+
+    return QdpEngine(0, precision="float64")
+
+
+def _assert_state_close(actual: torch.Tensor, expected: torch.Tensor) -> None:
+    assert actual.shape == expected.shape, (
+        f"shape mismatch: {actual.shape} vs {expected.shape}"
+    )
+    assert actual.dtype == expected.dtype, (
+        f"dtype mismatch: {actual.dtype} vs {expected.dtype}"
+    )
+    assert torch.allclose(actual, expected, atol=1e-10, rtol=1e-10), (
+        f"state mismatch\nactual={actual}\nexpected={expected}"
+    )
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_iqp_reference_single_qubit_exact_phase_flip() -> None:
+    """A single pi phase should map |+> to |1> with high precision."""
+    engine = _engine_float64()
+    data = [math.pi]
+    qtensor = engine.encode(data, 1, "iqp")
+    actual = torch.from_dlpack(qtensor)
+    expected = iqp_reference_torch(data, 1, enable_zz=True, device="cuda")
+    _assert_state_close(actual, expected)
+    reference = torch.tensor([[0.0, 1.0]], dtype=torch.complex128, device="cuda")
+    _assert_state_close(actual, reference)
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_iqp_reference_matches_hard_full_cases() -> None:
+    """Compare the CUDA kernel with the torch reference on harder full-IQP inputs."""
+    engine = _engine_float64()
+    cases = [
+        (2, [0.0, math.pi, -math.pi / 2.0]),
+        (
+            4,
+            [
+                0.0,
+                math.pi,
+                -math.pi / 2.0,
+                math.pi / 3.0,
+                -2.0 * math.pi,
+                math.pi / 7.0,
+                -math.pi,
+                0.25,
+                -0.75,
+                1.5,
+            ],
+        ),
+        (5, [(idx - 7) * 0.2 * math.pi for idx in range(iqp_full_data_len(5))]),
+    ]
+
+    for num_qubits, data in cases:
+        qtensor = engine.encode(data, num_qubits, "iqp")
+        actual = torch.from_dlpack(qtensor)
+        expected = iqp_reference_torch(data, num_qubits, enable_zz=True, device="cuda")
+        _assert_state_close(actual, expected)
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_iqp_reference_matches_hard_batch_cases() -> None:
+    """Compare batched IQP CUDA output with the torch reference."""
+    engine = _engine_float64()
+    num_qubits = 4
+    sample_size = iqp_sample_size(num_qubits, enable_zz=True)
+    batch = [
+        [(idx - 3) * 0.1 * math.pi for idx in range(sample_size)],
+        [math.sin(idx) * 0.25 * math.pi for idx in range(sample_size)],
+        [(sample_size - idx - 1) * 0.125 * math.pi for idx in range(sample_size)],
+    ]
+
+    qtensor = engine.encode(
+        torch.tensor(batch, dtype=torch.float64, device="cuda"), num_qubits, "iqp"
+    )
+    actual = torch.from_dlpack(qtensor)
+    expected = build_iqp_reference(
+        num_qubits,
+        enable_zz=True,
+        device="cuda",
+        dtype=torch.float64,
+    )(torch.tensor(batch, dtype=torch.float64, device="cuda"))
+    _assert_state_close(actual, expected)
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_iqp_z_reference_matches_hard_cases() -> None:
+    """IQP-Z should follow the same torch reference with ZZ terms disabled."""
+    engine = _engine_float64()
+    num_qubits = 6
+    data = [
+        -math.pi,
+        -math.pi / 2.0,
+        -math.pi / 3.0,
+        math.pi / 5.0,
+        math.pi / 7.0,
+        0.0,
+    ]
+
+    qtensor = engine.encode(data, num_qubits, "iqp-z")
+    actual = torch.from_dlpack(qtensor)
+    expected = iqp_reference_torch(data, num_qubits, enable_zz=False, device="cuda")
+    _assert_state_close(actual, expected)


### PR DESCRIPTION
### Related Issues
#1227
<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [x] New feature
- [x] Refactoring
- [x] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why
This change is the first stage of the IQP kernel roadmap toward matching or exceeding the `torch.compile` reference implementation. We need a reliable torch reference for IQP behavior, stronger hard-case numerical coverage, and a benchmark that makes CUDA-vs-torch parity measurable before deeper kernel optimization work.
<!-- Why is this change needed? -->

### How
- added a reusable torch IQP reference implementation for both `iqp` and `iqp-z`
- added an IQP benchmark comparing QDP CUDA, eager torch, and `torch.compile`
- added Python GPU correctness tests with hard single-sample, batch, and IQP-Z cases
- strengthened Rust IQP integration tests around FWT-path and hard-case coverage
- updated benchmark utilities and docs for IQP / IQP-Z support
- adjusted `qumat_qdp` imports so pure-Python helpers remain importable when `_qdp` is not built
<!-- What was done? -->

## Checklist

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
