### PR TITLE
[Feature][QDP] IQP kernel fusion and persistent kernel / grid-stride optimizations

### DIFF
--- a/qdp/qdp-kernels/src/iqp.cu
+++ b/qdp/qdp-kernels/src/iqp.cu
@@ -117,8 +117,8 @@ __global__ void iqp_encode_kernel_naive(
 // FWT O(n * 2^n) Implementation
 // ============================================================================
 
-// Step 1: Compute f[x] = exp(i*theta(x)) for all x
-// One thread per state, reuses existing compute_phase()
+// Step 1: Compute f[x] = exp(i*theta(x)) for all x.
+// Uses a grid-stride loop so large state vectors can reuse a fixed launch size.
 __global__ void iqp_phase_kernel(
     const double* __restrict__ data,
     cuDoubleComplex* __restrict__ state,
@@ -126,14 +126,17 @@ __global__ void iqp_phase_kernel(
     unsigned int num_qubits,
     int enable_zz
 ) {
-    size_t x = blockIdx.x * blockDim.x + threadIdx.x;
-    if (x >= state_len) return;
+    const size_t stride = gridDim.x * blockDim.x;
 
-    double phase = compute_phase(data, x, num_qubits, enable_zz);
+    for (size_t x = blockIdx.x * blockDim.x + threadIdx.x;
+         x < state_len;
+         x += stride) {
+        double phase = compute_phase(data, x, num_qubits, enable_zz);
 
-    double cos_phase, sin_phase;
-    sincos(phase, &sin_phase, &cos_phase);
-    state[x] = make_cuDoubleComplex(cos_phase, sin_phase);
+        double cos_phase, sin_phase;
+        sincos(phase, &sin_phase, &cos_phase);
+        state[x] = make_cuDoubleComplex(cos_phase, sin_phase);
+    }
 }
 
 // Step 2a: FWT butterfly stage for global memory (n > threshold)
@@ -142,39 +145,53 @@ __global__ void iqp_phase_kernel(
 __global__ void fwt_butterfly_stage_kernel(
     cuDoubleComplex* __restrict__ state,
     size_t state_len,
-    unsigned int stage  // 0 to n-1
+    unsigned int stage,  // 0 to n-1
+    double norm_factor
 ) {
-    size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t grid_stride = gridDim.x * blockDim.x;
 
     // Each thread processes one butterfly pair
     // For stage s, butterflies are separated by 2^s
-    size_t stride = 1ULL << stage;
-    size_t block_size = stride << 1;  // 2^(s+1)
-    size_t num_pairs = state_len >> 1;  // state_len / 2 total pairs
+    const size_t stride = 1ULL << stage;
+    const size_t block_size = stride << 1;  // 2^(s+1)
+    const size_t num_pairs = state_len >> 1;  // state_len / 2 total pairs
+    const bool apply_normalization = (norm_factor != 1.0);
 
-    if (idx >= num_pairs) return;
+    for (size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+         idx < num_pairs;
+         idx += grid_stride) {
+        // Compute which butterfly pair this thread handles
+        const size_t block_idx = idx / stride;
+        const size_t pair_offset = idx % stride;
+        const size_t i = block_idx * block_size + pair_offset;
+        const size_t j = i + stride;
 
-    // Compute which butterfly pair this thread handles
-    size_t block_idx = idx / stride;
-    size_t pair_offset = idx % stride;
-    size_t i = block_idx * block_size + pair_offset;
-    size_t j = i + stride;
+        // Load values
+        cuDoubleComplex a = state[i];
+        cuDoubleComplex b = state[j];
+        cuDoubleComplex sum = cuCadd(a, b);
+        cuDoubleComplex diff = cuCsub(a, b);
 
-    // Load values
-    cuDoubleComplex a = state[i];
-    cuDoubleComplex b = state[j];
+        if (apply_normalization) {
+            sum = make_cuDoubleComplex(cuCreal(sum) * norm_factor, cuCimag(sum) * norm_factor);
+            diff = make_cuDoubleComplex(cuCreal(diff) * norm_factor, cuCimag(diff) * norm_factor);
+        }
 
-    // Butterfly: (a, b) -> (a + b, a - b)
-    state[i] = cuCadd(a, b);
-    state[j] = cuCsub(a, b);
+        // Butterfly: (a, b) -> (a + b, a - b)
+        state[i] = sum;
+        state[j] = diff;
+    }
 }
 
-// Step 2b: FWT using shared memory (n <= threshold)
-// All stages in single kernel launch
-__global__ void fwt_shared_memory_kernel(
+// Step 1 + 2 + 3 fused: phase computation, full shared-memory FWT, normalization
+// Used when the entire state fits in shared memory.
+__global__ void iqp_phase_fwt_shared_normalize_kernel(
+    const double* __restrict__ data,
     cuDoubleComplex* __restrict__ state,
     size_t state_len,
-    unsigned int num_qubits
+    unsigned int num_qubits,
+    int enable_zz,
+    double norm_factor
 ) {
     extern __shared__ cuDoubleComplex shared_state[];
 
@@ -185,9 +202,13 @@ __global__ void fwt_shared_memory_kernel(
     // Block 0 handles the full transform
     if (bid > 0) return;
 
-    // Load state into shared memory
+    // Materialize the phase vector directly in shared memory to avoid an
+    // intermediate global-memory write before the FWT.
     for (size_t i = tid; i < state_len; i += blockDim.x) {
-        shared_state[i] = state[i];
+        double phase = compute_phase(data, i, num_qubits, enable_zz);
+        double cos_phase, sin_phase;
+        sincos(phase, &sin_phase, &cos_phase);
+        shared_state[i] = make_cuDoubleComplex(cos_phase, sin_phase);
     }
     __syncthreads();
 
@@ -213,9 +234,13 @@ __global__ void fwt_shared_memory_kernel(
         __syncthreads();
     }
 
-    // Write back to global memory
+    // Write back once, after applying the global 1/2^n normalization.
     for (size_t i = tid; i < state_len; i += blockDim.x) {
-        state[i] = shared_state[i];
+        cuDoubleComplex val = shared_state[i];
+        state[i] = make_cuDoubleComplex(
+            cuCreal(val) * norm_factor,
+            cuCimag(val) * norm_factor
+        );
     }
 }
 
@@ -225,14 +250,17 @@ __global__ void normalize_state_kernel(
     size_t state_len,
     double norm_factor
 ) {
-    size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
-    if (idx >= state_len) return;
+    const size_t stride = gridDim.x * blockDim.x;
 
-    cuDoubleComplex val = state[idx];
-    state[idx] = make_cuDoubleComplex(
-        cuCreal(val) * norm_factor,
-        cuCimag(val) * norm_factor
-    );
+    for (size_t idx = blockIdx.x * blockDim.x + threadIdx.x;
+         idx < state_len;
+         idx += stride) {
+        cuDoubleComplex val = state[idx];
+        state[idx] = make_cuDoubleComplex(
+            cuCreal(val) * norm_factor,
+            cuCimag(val) * norm_factor
+        );
+    }
 }
 
 // ============================================================================
@@ -272,7 +300,7 @@ __global__ void iqp_encode_batch_kernel_naive(
 // FWT O(n * 2^n) Batch Implementation
 // ============================================================================
 
-// Step 1: Compute f[x] = exp(i*theta(x)) for all x, for all samples in batch
+// Step 1: Compute the normalized phase vector for all samples in batch.
 __global__ void iqp_phase_batch_kernel(
     const double* __restrict__ data_batch,
     cuDoubleComplex* __restrict__ state_batch,
@@ -280,7 +308,8 @@ __global__ void iqp_phase_batch_kernel(
     size_t state_len,
     unsigned int num_qubits,
     unsigned int data_len,
-    int enable_zz
+    int enable_zz,
+    double norm_factor
 ) {
     const size_t total_elements = num_samples * state_len;
     const size_t stride = gridDim.x * blockDim.x;
@@ -297,7 +326,10 @@ __global__ void iqp_phase_batch_kernel(
 
         double cos_phase, sin_phase;
         sincos(phase, &sin_phase, &cos_phase);
-        state_batch[global_idx] = make_cuDoubleComplex(cos_phase, sin_phase);
+        state_batch[global_idx] = make_cuDoubleComplex(
+            cos_phase * norm_factor,
+            sin_phase * norm_factor
+        );
     }
 }
 
@@ -385,7 +417,7 @@ extern "C" {
 /// For num_qubits >= FWT_MIN_QUBITS, uses Fast Walsh-Hadamard Transform:
 ///   1. Phase computation: f[x] = exp(i*theta(x)) - O(2^n)
 ///   2. FWT transform: WHT of phase array - O(n * 2^n)
-///   3. Normalization: divide by 2^n - O(2^n)
+///   3. Normalization: fused into the shared-memory path or the final FWT stage
 /// Total: O(n * 2^n) vs naive O(4^n)
 int launch_iqp_encode(
     const double* data_d,
@@ -401,6 +433,7 @@ int launch_iqp_encode(
 
     cuDoubleComplex* state_complex_d = static_cast<cuDoubleComplex*>(state_d);
     const int blockSize = DEFAULT_BLOCK_SIZE;
+    const double norm_factor = 1.0 / (double)state_len;
 
     // Use naive kernel for small n (FWT overhead not worth it)
     if (num_qubits < FWT_MIN_QUBITS) {
@@ -416,47 +449,45 @@ int launch_iqp_encode(
     }
 
     // FWT-based implementation for larger n
-    const int gridSize = (state_len + blockSize - 1) / blockSize;
+    const size_t blocks_needed = (state_len + blockSize - 1) / blockSize;
+    const int gridSize = (int)((blocks_needed < MAX_GRID_BLOCKS) ? blocks_needed : MAX_GRID_BLOCKS);
 
-    // Step 1: Compute phase array f[x] = exp(i*theta(x))
-    iqp_phase_kernel<<<gridSize, blockSize, 0, stream>>>(
-        data_d,
-        state_complex_d,
-        state_len,
-        num_qubits,
-        enable_zz
-    );
-
-    // Step 2: Apply FWT
     if (num_qubits <= FWT_SHARED_MEM_THRESHOLD) {
-        // Shared memory FWT - all stages in one kernel
+        // Shared-memory fast path: phase generation, full FWT, and normalization
+        // happen in a single launch and touch global memory only once.
         size_t shared_mem_size = state_len * sizeof(cuDoubleComplex);
-        fwt_shared_memory_kernel<<<1, blockSize, shared_mem_size, stream>>>(
+        iqp_phase_fwt_shared_normalize_kernel<<<1, blockSize, shared_mem_size, stream>>>(
+            data_d,
             state_complex_d,
             state_len,
-            num_qubits
+            num_qubits,
+            enable_zz,
+            norm_factor
         );
     } else {
+        // Step 1: Compute phase array f[x] = exp(i*theta(x))
+        iqp_phase_kernel<<<gridSize, blockSize, 0, stream>>>(
+            data_d,
+            state_complex_d,
+            state_len,
+            num_qubits,
+            enable_zz
+        );
+
         // Global memory FWT - one kernel launch per stage
         const size_t num_pairs = state_len >> 1;
-        const int fwt_grid_size = (num_pairs + blockSize - 1) / blockSize;
+        const size_t fwt_blocks_needed = (num_pairs + blockSize - 1) / blockSize;
+        const int fwt_grid_size = (int)((fwt_blocks_needed < MAX_GRID_BLOCKS) ? fwt_blocks_needed : MAX_GRID_BLOCKS);
 
         for (unsigned int stage = 0; stage < num_qubits; ++stage) {
             fwt_butterfly_stage_kernel<<<fwt_grid_size, blockSize, 0, stream>>>(
                 state_complex_d,
                 state_len,
-                stage
+                stage,
+                (stage + 1 == num_qubits) ? norm_factor : 1.0
             );
         }
     }
-
-    // Step 3: Normalize by 1/2^n
-    double norm_factor = 1.0 / (double)state_len;
-    normalize_state_kernel<<<gridSize, blockSize, 0, stream>>>(
-        state_complex_d,
-        state_len,
-        norm_factor
-    );
 
     return (int)cudaGetLastError();
 }
@@ -478,9 +509,9 @@ int launch_iqp_encode(
 ///
 /// # Algorithm
 /// For num_qubits >= FWT_MIN_QUBITS, uses Fast Walsh-Hadamard Transform:
-///   1. Phase computation for all samples - O(batch * 2^n)
+///   1. Normalized phase computation for all samples - O(batch * 2^n)
 ///   2. FWT transform for all samples - O(batch * n * 2^n)
-///   3. Normalization - O(batch * 2^n)
+///   3. No standalone normalization kernel; the scale factor is fused into phase
 /// Total: O(batch * n * 2^n) vs naive O(batch * 4^n)
 int launch_iqp_encode_batch(
     const double* data_batch_d,
@@ -501,6 +532,7 @@ int launch_iqp_encode_batch(
     const size_t total_elements = num_samples * state_len;
     const size_t blocks_needed = (total_elements + blockSize - 1) / blockSize;
     const size_t gridSize = (blocks_needed < MAX_GRID_BLOCKS) ? blocks_needed : MAX_GRID_BLOCKS;
+    const double norm_factor = 1.0 / (double)state_len;
 
     // Use naive kernel for small n (FWT overhead not worth it)
     if (num_qubits < FWT_MIN_QUBITS) {
@@ -526,7 +558,8 @@ int launch_iqp_encode_batch(
         state_len,
         num_qubits,
         data_len,
-        enable_zz
+        enable_zz,
+        norm_factor
     );
 
     // Step 2: Apply FWT to all samples (global memory version for batch)
@@ -545,14 +578,6 @@ int launch_iqp_encode_batch(
             stage
         );
     }
-
-    // Step 3: Normalize by 1/2^n
-    double norm_factor = 1.0 / (double)state_len;
-    normalize_batch_kernel<<<gridSize, blockSize, 0, stream>>>(
-        state_complex_d,
-        total_elements,
-        norm_factor
-    );
 
     return (int)cudaGetLastError();
 }

--- a/testing/qdp/test_bindings.py
+++ b/testing/qdp/test_bindings.py
@@ -16,6 +16,8 @@
 
 """Simple tests for PyO3 bindings."""
 
+import math
+
 import pytest
 import torch
 
@@ -28,6 +30,58 @@ def _has_multi_gpu():
         return torch.cuda.is_available() and torch.cuda.device_count() >= 2
     except ImportError:
         return False
+
+
+def _iqp_data_len(num_qubits: int, enable_zz: bool) -> int:
+    """Return the expected IQP parameter count for a given qubit count."""
+    if enable_zz:
+        return num_qubits + num_qubits * (num_qubits - 1) // 2
+    return num_qubits
+
+
+def _build_iqp_params(num_qubits: int, enable_zz: bool, offset: float = 0.0):
+    """Build deterministic IQP parameters for tests."""
+    data_len = _iqp_data_len(num_qubits, enable_zz)
+    return [0.03125 * (i + 1) + offset for i in range(data_len)]
+
+
+def _compute_iqp_phase(data, x: int, num_qubits: int, enable_zz: bool) -> float:
+    """Reference CPU phase computation matching the CUDA kernel."""
+    phase = 0.0
+
+    for i in range(num_qubits):
+        if (x >> i) & 1:
+            phase += data[i]
+
+    if enable_zz:
+        pair_idx = num_qubits
+        for i in range(num_qubits):
+            for j in range(i + 1, num_qubits):
+                if ((x >> i) & 1) and ((x >> j) & 1):
+                    phase += data[pair_idx]
+                pair_idx += 1
+
+    return phase
+
+
+def _cpu_iqp_state(data, num_qubits: int, enable_zz: bool) -> torch.Tensor:
+    """Compute a small IQP reference state on CPU using the naive definition."""
+    state_len = 1 << num_qubits
+    amplitudes = []
+
+    for z in range(state_len):
+        real_sum = 0.0
+        imag_sum = 0.0
+
+        for x in range(state_len):
+            phase = _compute_iqp_phase(data, x, num_qubits, enable_zz)
+            sign = 1.0 if ((x & z).bit_count() & 1) == 0 else -1.0
+            real_sum += sign * math.cos(phase)
+            imag_sum += sign * math.sin(phase)
+
+        amplitudes.append(complex(real_sum / state_len, imag_sum / state_len))
+
+    return torch.tensor([amplitudes], dtype=torch.complex128, device="cuda:0")
 
 
 @requires_qdp
@@ -1299,6 +1353,92 @@ def test_iqp_fwt_shared_vs_global_memory_threshold():
         assert torch.isclose(norm, torch.tensor(1.0, device="cuda:0"), atol=1e-6), (
             f"IQP {num_qubits} qubits not normalized at threshold: got {norm.item()}"
         )
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_iqp_fwt_matches_naive_reference():
+    """Test FWT/fused IQP kernels against a small CPU reference."""
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+
+    for encoding_method, enable_zz in [("iqp-z", False), ("iqp", True)]:
+        for num_qubits in [4, 5]:
+            data = _build_iqp_params(num_qubits, enable_zz)
+            expected = _cpu_iqp_state(data, num_qubits, enable_zz)
+            actual = torch.from_dlpack(engine.encode(data, num_qubits, encoding_method))
+
+            assert torch.allclose(actual, expected, atol=1e-10, rtol=1e-10), (
+                f"{encoding_method} {num_qubits} qubits does not match naive reference"
+            )
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_iqp_batch_matches_single_encode():
+    """Test that batch IQP encoding matches per-sample single encode results."""
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+
+    for encoding_method, enable_zz in [("iqp-z", False), ("iqp", True)]:
+        num_qubits = 6
+        batch_size = 4
+        batch = torch.tensor(
+            [
+                _build_iqp_params(num_qubits, enable_zz, offset=0.01 * sample_idx)
+                for sample_idx in range(batch_size)
+            ],
+            dtype=torch.float64,
+        )
+
+        batch_state = torch.from_dlpack(engine.encode(batch, num_qubits, encoding_method))
+
+        for sample_idx in range(batch_size):
+            single_state = torch.from_dlpack(
+                engine.encode(batch[sample_idx].tolist(), num_qubits, encoding_method)
+            )
+            assert torch.allclose(batch_state[sample_idx], single_state[0], atol=1e-10), (
+                f"{encoding_method} batch sample {sample_idx} diverges from single encode"
+            )
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_iqp_grid_stride_large_state_zero_params():
+    """Test a large IQP-Z state that requires the capped grid-size path."""
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+
+    # For DEFAULT_BLOCK_SIZE=256 and MAX_GRID_BLOCKS=2048, 20 qubits requires
+    # 4096 blocks without the grid cap, so this exercises the grid-stride path.
+    num_qubits = 20
+    data = [0.0] * num_qubits
+
+    state = torch.from_dlpack(engine.encode(data, num_qubits, "iqp-z"))
+    magnitudes = torch.abs(state[0])
+    norm = torch.sum(magnitudes**2)
+
+    assert state.shape == (1, 1 << num_qubits)
+    assert torch.isclose(norm, torch.tensor(1.0, device="cuda:0"), atol=1e-6)
+    assert torch.isclose(
+        state[0, 0], torch.tensor(1.0 + 0.0j, dtype=state.dtype, device="cuda:0"), atol=1e-6
+    )
+    assert torch.max(magnitudes[1:]) < 1e-6
 
 
 @requires_qdp

--- a/testing/qdp/test_bindings.py
+++ b/testing/qdp/test_bindings.py
@@ -1401,13 +1401,17 @@ def test_iqp_batch_matches_single_encode():
             dtype=torch.float64,
         )
 
-        batch_state = torch.from_dlpack(engine.encode(batch, num_qubits, encoding_method))
+        batch_state = torch.from_dlpack(
+            engine.encode(batch, num_qubits, encoding_method)
+        )
 
         for sample_idx in range(batch_size):
             single_state = torch.from_dlpack(
                 engine.encode(batch[sample_idx].tolist(), num_qubits, encoding_method)
             )
-            assert torch.allclose(batch_state[sample_idx], single_state[0], atol=1e-10), (
+            assert torch.allclose(
+                batch_state[sample_idx], single_state[0], atol=1e-10
+            ), (
                 f"{encoding_method} batch sample {sample_idx} diverges from single encode"
             )
 
@@ -1436,7 +1440,9 @@ def test_iqp_grid_stride_large_state_zero_params():
     assert state.shape == (1, 1 << num_qubits)
     assert torch.isclose(norm, torch.tensor(1.0, device="cuda:0"), atol=1e-6)
     assert torch.isclose(
-        state[0, 0], torch.tensor(1.0 + 0.0j, dtype=state.dtype, device="cuda:0"), atol=1e-6
+        state[0, 0],
+        torch.tensor(1.0 + 0.0j, dtype=state.dtype, device="cuda:0"),
+        atol=1e-6,
     )
     assert torch.max(magnitudes[1:]) < 1e-6
 


### PR DESCRIPTION
### Related Issues

Closes #1015

### Changes

- [ ] Bug fix
- [x] New feature
- [x] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

Optimize the QDP IQP CUDA path by reducing kernel-launch overhead and global-memory traffic, and by making large single-sample launches scale with a capped grid + grid-stride loop pattern.

### How

### CUDA kernel changes

- Added grid-stride looping to the single-sample IQP phase kernel
- Added capped-grid launch sizing using `MAX_GRID_BLOCKS`
- Added a shared-memory fused path for `n <= FWT_SHARED_MEM_THRESHOLD`
  - phase generation in shared memory
  - full FWT in shared memory
  - normalization on final write-back
- Fused the final global-memory FWT stage with normalization for `n > threshold`
- Fused batch IQP phase + normalization so batch IQP no longer needs a standalone normalize kernel launch

### Tests

Added GPU tests covering:

- FWT/fused IQP vs naive CPU reference for small qubit counts
- batch IQP encode vs repeated single-sample encode
- large-state capped-grid / grid-stride regression (`num_qubits = 20`)

## Checklist

- [x] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
