### PR TITLE
fix: remove hardcoded IQP qubit limit and reuse shared validation

### DIFF
--- a/qdp/docs/test/README.md
+++ b/qdp/docs/test/README.md
@@ -7,7 +7,7 @@ Unit tests for QDP core library covering input validation, API workflows, and me
 ### `validation.rs` - Input Validation
 
 - Invalid encoder strategy rejection
-- Qubit size validation (mismatch, zero, max limit 30)
+- Qubit size validation (mismatch, zero, configured max limit)
 - Empty and zero-norm data rejection
 - Error type formatting
 - Non-Linux platform graceful failure

--- a/qdp/qdp-core/src/gpu/encodings/iqp.rs
+++ b/qdp/qdp-core/src/gpu/encodings/iqp.rs
@@ -16,7 +16,7 @@
 
 // IQP (Instantaneous Quantum Polynomial) encoding: entangled quantum states via diagonal phases.
 
-use super::QuantumEncoder;
+use super::{QuantumEncoder, validate_qubit_count};
 #[cfg(target_os = "linux")]
 use crate::error::cuda_error_to_string;
 use crate::error::{MahoutError, Result};
@@ -149,12 +149,7 @@ impl QuantumEncoder for IqpEncoder {
     ) -> Result<GpuStateVector> {
         crate::profile_scope!("IqpEncoder::encode_batch");
 
-        if num_qubits == 0 || num_qubits > 30 {
-            return Err(MahoutError::InvalidInput(format!(
-                "Number of qubits {} must be between 1 and 30",
-                num_qubits
-            )));
-        }
+        validate_qubit_count(num_qubits)?;
 
         let expected_len = self.expected_data_len(num_qubits);
         if sample_size != expected_len {
@@ -251,12 +246,7 @@ impl QuantumEncoder for IqpEncoder {
         num_qubits: usize,
         stream: *mut c_void,
     ) -> Result<GpuStateVector> {
-        if num_qubits == 0 || num_qubits > 30 {
-            return Err(MahoutError::InvalidInput(format!(
-                "Number of qubits {} must be between 1 and 30",
-                num_qubits
-            )));
-        }
+        validate_qubit_count(num_qubits)?;
 
         let expected_len = self.expected_data_len(num_qubits);
         if input_len != expected_len {
@@ -321,12 +311,7 @@ impl QuantumEncoder for IqpEncoder {
         num_qubits: usize,
         stream: *mut c_void,
     ) -> Result<GpuStateVector> {
-        if num_qubits == 0 || num_qubits > 30 {
-            return Err(MahoutError::InvalidInput(format!(
-                "Number of qubits {} must be between 1 and 30",
-                num_qubits
-            )));
-        }
+        validate_qubit_count(num_qubits)?;
 
         let expected_len = self.expected_data_len(num_qubits);
         if sample_size != expected_len {
@@ -384,17 +369,7 @@ impl QuantumEncoder for IqpEncoder {
     }
 
     fn validate_input(&self, data: &[f64], num_qubits: usize) -> Result<()> {
-        if num_qubits == 0 {
-            return Err(MahoutError::InvalidInput(
-                "Number of qubits must be at least 1".to_string(),
-            ));
-        }
-        if num_qubits > 30 {
-            return Err(MahoutError::InvalidInput(format!(
-                "Number of qubits {} exceeds practical limit of 30",
-                num_qubits
-            )));
-        }
+        validate_qubit_count(num_qubits)?;
 
         let expected_len = self.expected_data_len(num_qubits);
         if data.len() != expected_len {

--- a/qdp/qdp-core/tests/gpu_iqp_encoding.rs
+++ b/qdp/qdp-core/tests/gpu_iqp_encoding.rs
@@ -16,8 +16,8 @@
 
 // Unit tests for IQP (Instantaneous Quantum Polynomial) encoding
 
-use qdp_core::gpu::encodings::MAX_QUBITS;
 use qdp_core::MahoutError;
+use qdp_core::gpu::encodings::MAX_QUBITS;
 
 mod common;
 

--- a/qdp/qdp-core/tests/gpu_iqp_encoding.rs
+++ b/qdp/qdp-core/tests/gpu_iqp_encoding.rs
@@ -16,6 +16,7 @@
 
 // Unit tests for IQP (Instantaneous Quantum Polynomial) encoding
 
+use qdp_core::gpu::encodings::MAX_QUBITS;
 use qdp_core::MahoutError;
 
 mod common;
@@ -62,19 +63,23 @@ fn test_iqp_zero_qubits_rejected() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_iqp_max_qubits_exceeded() {
-    println!("Testing IQP max qubits (>30) rejection...");
+    println!("Testing IQP max qubits (>{MAX_QUBITS}) rejection...");
 
     let Some(engine) = common::qdp_engine() else {
         return;
     };
 
-    let data = vec![0.5; iqp_full_data_len(31)];
-    let result = engine.encode(&data, 31, "iqp");
-    assert!(result.is_err(), "Should reject qubits > 30");
+    let requested_qubits = MAX_QUBITS + 1;
+    let data = vec![0.5; iqp_full_data_len(requested_qubits)];
+    let result = engine.encode(&data, requested_qubits, "iqp");
+    assert!(result.is_err(), "Should reject qubits above MAX_QUBITS");
 
     match result {
         Err(MahoutError::InvalidInput(msg)) => {
-            assert!(msg.contains("30"), "Error should mention 30 qubit limit");
+            assert!(
+                msg.contains(&MAX_QUBITS.to_string()),
+                "Error should mention configured qubit limit"
+            );
             println!("PASS: Correctly rejected excessive qubits: {}", msg);
         }
         _ => panic!("Expected InvalidInput error for max qubits"),

--- a/qdp/qdp-core/tests/gpu_validation.rs
+++ b/qdp/qdp-core/tests/gpu_validation.rs
@@ -16,8 +16,8 @@
 
 // Input validation and error handling tests
 
-use qdp_core::gpu::encodings::MAX_QUBITS;
 use qdp_core::MahoutError;
+use qdp_core::gpu::encodings::MAX_QUBITS;
 
 mod common;
 

--- a/qdp/qdp-core/tests/gpu_validation.rs
+++ b/qdp/qdp-core/tests/gpu_validation.rs
@@ -16,6 +16,7 @@
 
 // Input validation and error handling tests
 
+use qdp_core::gpu::encodings::MAX_QUBITS;
 use qdp_core::MahoutError;
 
 mod common;
@@ -105,7 +106,7 @@ fn test_input_validation_zero_qubits() {
 #[test]
 #[cfg(target_os = "linux")]
 fn test_input_validation_max_qubits() {
-    println!("Testing maximum qubit limit (30)...");
+    println!("Testing maximum qubit limit ({MAX_QUBITS})...");
 
     let Some(engine) = common::qdp_engine() else {
         return;
@@ -113,14 +114,14 @@ fn test_input_validation_max_qubits() {
 
     let data = common::create_test_data(100);
 
-    let result = engine.encode(&data, 35, "amplitude");
+    let result = engine.encode(&data, MAX_QUBITS + 5, "amplitude");
     assert!(result.is_err(), "Should reject excessive qubits");
 
     match result {
         Err(MahoutError::InvalidInput(msg)) => {
             assert!(
-                msg.contains("exceeds") && msg.contains("30"),
-                "Error should mention 30 qubit limit"
+                msg.contains("exceeds") && msg.contains(&MAX_QUBITS.to_string()),
+                "Error should mention configured qubit limit"
             );
             println!("PASS: Correctly rejected excessive qubits: {}", msg);
         }

--- a/qdp/qdp-core/tests/preprocessing.rs
+++ b/qdp/qdp-core/tests/preprocessing.rs
@@ -16,6 +16,7 @@
 
 use approx::assert_relative_eq;
 use qdp_core::MahoutError;
+use qdp_core::gpu::encodings::MAX_QUBITS;
 use qdp_core::preprocessing::Preprocessor;
 
 #[test]
@@ -37,7 +38,7 @@ fn test_validate_input_zero_qubits() {
 #[test]
 fn test_validate_input_too_many_qubits() {
     let data = vec![1.0];
-    let result = Preprocessor::validate_input(&data, 31);
+    let result = Preprocessor::validate_input(&data, MAX_QUBITS + 1);
     assert!(
         matches!(result, Err(MahoutError::InvalidInput(msg)) if msg.contains("exceeds practical limit"))
     );
@@ -70,7 +71,7 @@ fn test_validate_input_allows_partial_state() {
 #[test]
 fn test_validate_input_max_qubits_boundary() {
     let data = vec![1.0];
-    assert!(Preprocessor::validate_input(&data, 30).is_ok());
+    assert!(Preprocessor::validate_input(&data, MAX_QUBITS).is_ok());
 }
 
 #[test]


### PR DESCRIPTION
### Related Issues

closes #1260

### Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

`IqpEncoder` still maintained its own hardcoded `30`-qubit limit even though QDP already has a shared qubit-count validation path.

That duplicated policy in multiple IQP code paths and made future qubit-limit changes error-prone, because IQP could silently drift from the shared encoder behavior.

### How

- replaced IQP-local qubit-limit checks with the shared `validate_qubit_count(...)` path
- updated the following IQP paths to reuse shared validation:
  - `validate_input(...)`
  - `encode_batch(...)`
  - `encode_from_gpu_ptr(...)`
  - `encode_batch_from_gpu_ptr(...)`
- removed hardcoded `30` usage from related tests
- updated tests to use shared `MAX_QUBITS` instead of a magic number
- updated `qdp/docs/test/README.md` to stop documenting a hardcoded `30` limit

## Tests

Ran:

```bash
cargo test -p qdp-core max_qubits --manifest-path qdp/Cargo.toml
make pre-commit
```

## Checklist

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
