### PR TITLE
[Feature] Add batch float32 zero-copy angle encoding in qdp-python bindings

### DIFF
--- a/qdp/qdp-python/src/engine.rs
+++ b/qdp/qdp-python/src/engine.rs
@@ -128,7 +128,7 @@ impl QdpEngine {
     ///     encoding_method: Encoding strategy ("amplitude" default, "angle", or "basis")
     ///         CUDA tensor note:
     ///         - amplitude accepts float64 and float32
-    ///         - angle accepts float64 generally, plus float32 for 1D single-sample tensors
+    ///         - angle accepts float64 generally, plus float32 for 1D and 2D CUDA tensors
     ///
     /// Returns:
     ///     QuantumTensor: DLPack-compatible tensor for zero-copy PyTorch integration
@@ -687,20 +687,39 @@ impl QdpEngine {
                     let data_ptr = data_ptr_u64 as *const f32;
 
                     let ptr = unsafe {
-                        self.core_engine()?
-                            .encode_batch_from_gpu_ptr_f32_with_stream(
-                                data_ptr,
-                                num_samples,
-                                sample_size,
-                                num_qubits,
-                                stream_ptr,
-                            )
-                            .map_err(|e| {
-                                PyRuntimeError::new_err(format!(
-                                    "Encoding failed (float32 amplitude batch): {}",
-                                    e
-                                ))
-                            })?
+                        match method.as_str() {
+                            "amplitude" => self
+                                .core_engine()?
+                                .encode_batch_from_gpu_ptr_f32_with_stream(
+                                    data_ptr,
+                                    num_samples,
+                                    sample_size,
+                                    num_qubits,
+                                    stream_ptr,
+                                )
+                                .map_err(|e| {
+                                    PyRuntimeError::new_err(format!(
+                                        "Encoding failed (float32 amplitude batch): {}",
+                                        e
+                                    ))
+                                })?,
+                            "angle" => self
+                                .core_engine()?
+                                .encode_angle_batch_from_gpu_ptr_f32_with_stream(
+                                    data_ptr,
+                                    num_samples,
+                                    sample_size,
+                                    num_qubits,
+                                    stream_ptr,
+                                )
+                                .map_err(|e| {
+                                    PyRuntimeError::new_err(format!(
+                                        "Encoding failed (float32 angle batch): {}",
+                                        e
+                                    ))
+                                })?,
+                            _ => unreachable!("unreachable: unhandled f32 batch encoding method"),
+                        }
                     };
 
                     Ok(QuantumTensor {

--- a/qdp/qdp-python/src/engine.rs
+++ b/qdp/qdp-python/src/engine.rs
@@ -125,8 +125,11 @@ impl QdpEngine {
     ///         - String path: .parquet, .arrow, .feather, .npy, .pt, .pth, .pb file
     ///         - pathlib.Path: Path object (converted via os.fspath())
     ///     num_qubits: Number of qubits for encoding
-    ///     encoding_method: Encoding strategy ("amplitude" default, "angle", or "basis"). CUDA tensor notes:
+    ///     encoding_method: Encoding strategy ("amplitude" default, "angle", "basis",
+    ///         "iqp", or "iqp-z"). CUDA tensor notes:
     ///         - amplitude and angle accept float64 and float32
+    ///         - basis requires int64
+    ///         - iqp and iqp-z require float64
     ///
     /// Returns:
     ///     QuantumTensor: DLPack-compatible tensor for zero-copy PyTorch integration

--- a/qdp/qdp-python/src/engine.rs
+++ b/qdp/qdp-python/src/engine.rs
@@ -125,8 +125,7 @@ impl QdpEngine {
     ///         - String path: .parquet, .arrow, .feather, .npy, .pt, .pth, .pb file
     ///         - pathlib.Path: Path object (converted via os.fspath())
     ///     num_qubits: Number of qubits for encoding
-    ///     encoding_method: Encoding strategy ("amplitude" default, "angle", or "basis")
-    ///         CUDA tensor note:
+    ///     encoding_method: Encoding strategy ("amplitude" default, "angle", or "basis"). CUDA tensor notes:
     ///         - amplitude accepts float64 and float32
     ///         - angle accepts float64 generally, plus float32 for 1D and 2D CUDA tensors
     ///

--- a/qdp/qdp-python/src/engine.rs
+++ b/qdp/qdp-python/src/engine.rs
@@ -126,8 +126,7 @@ impl QdpEngine {
     ///         - pathlib.Path: Path object (converted via os.fspath())
     ///     num_qubits: Number of qubits for encoding
     ///     encoding_method: Encoding strategy ("amplitude" default, "angle", or "basis"). CUDA tensor notes:
-    ///         - amplitude accepts float64 and float32
-    ///         - angle accepts float64 generally, plus float32 for 1D and 2D CUDA tensors
+    ///         - amplitude and angle accept float64 and float32
     ///
     /// Returns:
     ///     QuantumTensor: DLPack-compatible tensor for zero-copy PyTorch integration

--- a/qdp/qdp-python/src/pytorch.rs
+++ b/qdp/qdp-python/src/pytorch.rs
@@ -175,11 +175,17 @@ pub fn validate_cuda_tensor_for_encoding(
                 )));
             }
         }
-        "angle" | "iqp" | "iqp-z" => {
-            if method == "angle" && dtype_str_lower.contains("float32") {
-                // qdp-core provides dedicated float32 angle kernels for both single-sample and
-                // batched CUDA tensors, so keep validation aligned with the available binding path.
-            } else if !dtype_str_lower.contains("float64") {
+        "angle" => {
+            if !(dtype_str_lower.contains("float64") || dtype_str_lower.contains("float32")) {
+                return Err(PyRuntimeError::new_err(format!(
+                    "CUDA tensor must have dtype float64 or float32 for angle encoding, got {}. \
+                     Use tensor.to(torch.float64) or tensor.to(torch.float32)",
+                    dtype_str
+                )));
+            }
+        }
+        "iqp" | "iqp-z" => {
+            if !dtype_str_lower.contains("float64") {
                 return Err(PyRuntimeError::new_err(format!(
                     "CUDA tensor must have dtype float64 for {} encoding, got {}. \
                      Use tensor.to(torch.float64)",

--- a/qdp/qdp-python/src/pytorch.rs
+++ b/qdp/qdp-python/src/pytorch.rs
@@ -151,7 +151,6 @@ pub fn validate_cuda_tensor_for_encoding(
     encoding_method: &str,
 ) -> PyResult<()> {
     let method = encoding_method.to_ascii_lowercase();
-    let ndim: usize = tensor.call_method0("dim")?.extract()?;
 
     if !CUDA_ENCODING_METHODS.contains(&method.as_str()) {
         return Err(PyRuntimeError::new_err(format!(
@@ -178,12 +177,8 @@ pub fn validate_cuda_tensor_for_encoding(
         }
         "angle" | "iqp" | "iqp-z" => {
             if method == "angle" && dtype_str_lower.contains("float32") {
-                if ndim != 1 {
-                    return Err(PyRuntimeError::new_err(
-                        "CUDA tensor float32 angle encoding currently supports only 1D single-sample tensors. \
-                         Use tensor.to(torch.float64) for batch angle encoding.",
-                    ));
-                }
+                // qdp-core provides dedicated float32 angle kernels for both single-sample and
+                // batched CUDA tensors, so keep validation aligned with the available binding path.
             } else if !dtype_str_lower.contains("float64") {
                 return Err(PyRuntimeError::new_err(format!(
                     "CUDA tensor must have dtype float64 for {} encoding, got {}. \

--- a/qdp/qdp-python/src/pytorch.rs
+++ b/qdp/qdp-python/src/pytorch.rs
@@ -166,21 +166,12 @@ pub fn validate_cuda_tensor_for_encoding(
     let dtype_str: String = dtype.str()?.extract()?;
     let dtype_str_lower = dtype_str.to_ascii_lowercase();
     match method.as_str() {
-        "amplitude" => {
+        "amplitude" | "angle" => {
             if !(dtype_str_lower.contains("float64") || dtype_str_lower.contains("float32")) {
                 return Err(PyRuntimeError::new_err(format!(
-                    "CUDA tensor must have dtype float64 or float32 for amplitude encoding, got {}. \
+                    "CUDA tensor must have dtype float64 or float32 for {} encoding, got {}. \
                      Use tensor.to(torch.float64) or tensor.to(torch.float32)",
-                    dtype_str
-                )));
-            }
-        }
-        "angle" => {
-            if !(dtype_str_lower.contains("float64") || dtype_str_lower.contains("float32")) {
-                return Err(PyRuntimeError::new_err(format!(
-                    "CUDA tensor must have dtype float64 or float32 for angle encoding, got {}. \
-                     Use tensor.to(torch.float64) or tensor.to(torch.float32)",
-                    dtype_str
+                    method, dtype_str
                 )));
             }
         }

--- a/testing/qdp/test_bindings.py
+++ b/testing/qdp/test_bindings.py
@@ -694,8 +694,48 @@ def test_angle_encode_cuda_tensor_float32_input_output_dtype(precision, expected
 
 @requires_qdp
 @pytest.mark.gpu
-def test_angle_encode_cuda_tensor_float32_batch_rejected():
-    """Test that float32 CUDA angle encoding stays limited to 1D single-sample tensors."""
+@pytest.mark.parametrize(
+    ("precision", "expected_dtype"),
+    [
+        ("float32", torch.complex64),
+        ("float64", torch.complex128),
+    ],
+)
+def test_angle_encode_cuda_tensor_float32_batch(precision, expected_dtype):
+    """Test batched float32 CUDA angle encoding respects engine precision."""
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0, precision=precision)
+    data = torch.tensor(
+        [[0.0, 0.0], [torch.pi / 2, 0.0]],
+        dtype=torch.float32,
+        device="cuda:0",
+    )
+    result = torch.from_dlpack(engine.encode(data, 2, "angle"))
+
+    assert result.dtype == expected_dtype, (
+        f"Expected {expected_dtype}, got {result.dtype}"
+    )
+    assert result.shape == (2, 4)
+
+    expected = torch.tensor(
+        [
+            [1.0 + 0j, 0.0 + 0j, 0.0 + 0j, 0.0 + 0j],
+            [0.0 + 0j, 1.0 + 0j, 0.0 + 0j, 0.0 + 0j],
+        ],
+        device="cuda:0",
+    )
+    assert torch.allclose(result, expected.to(result.dtype), atol=1e-6, rtol=1e-6)
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_angle_encode_cuda_tensor_float32_batch_wrong_feature_count():
+    """Test batched float32 CUDA angle encoding surfaces per-sample shape validation."""
     pytest.importorskip("torch")
     from _qdp import QdpEngine
 
@@ -704,12 +744,51 @@ def test_angle_encode_cuda_tensor_float32_batch_rejected():
 
     engine = QdpEngine(0)
     data = torch.tensor(
-        [[0.0, 0.0], [torch.pi / 2, 0.0]],
+        [[0.0, 0.0, 0.0], [torch.pi / 2, 0.0, 0.0]],
         dtype=torch.float32,
         device="cuda:0",
     )
 
-    with pytest.raises(RuntimeError, match="supports only 1D single-sample tensors"):
+    with pytest.raises(RuntimeError, match="sample_size=2|one angle per qubit"):
+        engine.encode(data, 2, "angle")
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_angle_encode_cuda_tensor_float32_batch_non_contiguous():
+    """Test batched float32 CUDA angle encoding rejects non-contiguous tensors."""
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+    data = torch.tensor(
+        [[0.0, torch.pi / 2], [0.0, 0.0]],
+        dtype=torch.float32,
+        device="cuda:0",
+    ).t()
+    assert not data.is_contiguous()
+
+    with pytest.raises(RuntimeError, match="CUDA tensor must be contiguous"):
+        engine.encode(data, 2, "angle")
+
+
+@requires_qdp
+@pytest.mark.gpu
+def test_angle_encode_cuda_tensor_float32_batch_empty():
+    """Test batched float32 CUDA angle encoding rejects empty CUDA tensors."""
+    pytest.importorskip("torch")
+    from _qdp import QdpEngine
+
+    if not torch.cuda.is_available():
+        pytest.skip("GPU required for QdpEngine")
+
+    engine = QdpEngine(0)
+    data = torch.empty((0, 2), dtype=torch.float32, device="cuda:0")
+
+    with pytest.raises(RuntimeError, match="CUDA tensor cannot be empty"):
         engine.encode(data, 2, "angle")
 
 

--- a/testing/qdp_python/test_dlpack_validation.py
+++ b/testing/qdp_python/test_dlpack_validation.py
@@ -138,8 +138,8 @@ def test_cuda_float32_angle_supported_single_sample() -> None:
 
 
 @pytest.mark.skipif(not _cuda_available(), reason="CUDA not available")
-def test_cuda_float32_angle_2d_rejected() -> None:
-    """Float32 CUDA angle encoding should remain single-sample only."""
+def test_cuda_float32_angle_2d_supported() -> None:
+    """2D float32 CUDA tensor should use the batch GPU-pointer float32 angle path."""
     engine = _engine()
     t = torch.tensor(
         [[0.0, 0.0], [torch.pi / 2, 0.0]],
@@ -147,8 +147,23 @@ def test_cuda_float32_angle_2d_rejected() -> None:
         device="cuda",
     )
 
-    with pytest.raises(RuntimeError, match="1D single-sample"):
-        engine.encode(t, num_qubits=2, encoding_method="angle")
+    result = engine.encode(t, num_qubits=2, encoding_method="angle")
+    assert result is not None
+
+    qt = torch.from_dlpack(result)
+    assert qt.is_cuda
+    assert qt.shape == (2, 4)
+    assert qt.dtype == torch.complex64
+
+    expected = torch.tensor(
+        [
+            [1.0 + 0j, 0.0 + 0j, 0.0 + 0j, 0.0 + 0j],
+            [0.0 + 0j, 1.0 + 0j, 0.0 + 0j, 0.0 + 0j],
+        ],
+        dtype=torch.complex64,
+        device="cuda",
+    )
+    assert torch.allclose(qt, expected, atol=1e-6, rtol=1e-6)
 
 
 @pytest.mark.skipif(not _cuda_available(), reason="CUDA not available")


### PR DESCRIPTION
### Related Issues

Closes #1277

### Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

qdp-core already supports batch `float32` angle encoding from CUDA pointers, but qdp-python only exposed the single-sample `float32` angle path. That left a mismatch between core capabilities and the Python binding surface, forcing batched CUDA users to upcast to `float64` or give up the zero-copy batch path.

This PR closes that binding gap with a narrowly scoped change in qdp-python only.

### How

- allow CUDA `torch.float32` tensors for `encoding_method="angle"` in the shared Python-side tensor validation path
- dispatch 2D CUDA `float32` angle tensors to `encode_angle_batch_from_gpu_ptr_f32_with_stream(...)`
- keep the existing 1D `float32` angle fast path unchanged
- add targeted GPU binding tests covering:
  - 1D `float32` angle output dtype behavior
  - 2D batch `float32` angle output dtype behavior
  - expected encoded states for a small deterministic batch
  - invalid batch feature-count handling
  - non-contiguous batch rejection
  - empty batch rejection
  - invalid `float16` rejection
  - existing `float64` batch angle regression coverage

## Checklist

- [x] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes
