### PR TITLE
docs(qdp): document phase and iqp-family encodings

### DIFF
--- a/docs/qdp/api.md
+++ b/docs/qdp/api.md
@@ -19,13 +19,14 @@ import qumat.qdp as qdp
 
 ## Class: `QdpEngine`
 
-### `QdpEngine(device_id=0, precision="float32")`
+### `QdpEngine(device_id=0, precision="float32", backend="cuda")`
 
 Create a GPU encoder instance.
 
 **Parameters**
 - `device_id` (int): CUDA device ID, default `0`.
 - `precision` (str): `"float32"` or `"float64"`.
+- `backend` (str): Public Python route selector. `qumat.qdp` uses `"cuda"` for the Rust/CUDA path and `"amd"` for the Triton AMD route.
 
 **Raises**
 - `RuntimeError`: Initialization failure or unsupported precision.
@@ -43,7 +44,7 @@ Encode classical input into a quantum state and return a DLPack tensor on GPU.
     - `.parquet`, `.arrow` / `.feather`, `.npy`, `.pt` / `.pth`, `.pb`
     - remote URL (`s3://bucket/key`, `gs://bucket/key`) when built with `remote-io`
 - `num_qubits` (int): Number of qubits, range 1–30.
-- `encoding_method` (str): `"amplitude" | "angle" | "basis" | "iqp" | "iqp-z"` (lowercase).
+- `encoding_method` (str): `"amplitude" | "angle" | "basis" | "phase" | "iqp" | "iqp-z"` (lowercase).
 
 **Returns**
 - `QuantumTensor` with 2D shape:
@@ -55,6 +56,20 @@ Encode classical input into a quantum state and return a DLPack tensor on GPU.
 - Parquet streaming currently supports `"amplitude"` and `"basis"`.
 - PyTorch file inputs (`.pt`, `.pth`) require building with the `pytorch` feature.
 - Remote URL query/fragment is not supported (`?versionId=...`, `#...`).
+
+### Advanced Encoding Support Matrix
+
+For the advanced methods documented below, support currently differs by route:
+
+| Surface | `phase` | `iqp` | `iqp-z` |
+|---------|---------|-------|---------|
+| `qumat.qdp.QdpEngine(..., backend="cuda").encode(...)` | ✅ | ✅ | ✅ |
+| CUDA tensor direct-input fast path | ❌ | ✅ | ✅ |
+| `qumat.qdp.QdpEngine(..., backend="amd")` | ❌ | ❌ | ❌ |
+
+Notes:
+- `phase` is implemented and tested on the CUDA encode path, but it is not part of the CUDA tensor direct-input fast path today.
+- The AMD Triton route currently supports `amplitude`, `angle`, and `basis` only.
 
 **Raises**
 - `RuntimeError`: Invalid inputs, shapes, dtypes, or unsupported formats.
@@ -96,6 +111,13 @@ Return `(device_type, device_id)`; CUDA devices report `(2, gpu_id)`.
 
 - Each sample provides one integer index in `[0, 2^num_qubits)`.
 
+### `phase`
+
+- Expects `n` phase angles for `n = num_qubits`.
+- Produces a product state of the form `(1/sqrt(2^n)) * sum_b exp(i * phase(b)) |b>`.
+- All phase angles must be finite (no NaN/Inf).
+- Available on the CUDA encode path; not currently exposed through the AMD route.
+
 ### `iqp`
 
 - Expects `n + n*(n-1)/2` parameters for `n = num_qubits` (Z + ZZ terms).
@@ -120,6 +142,7 @@ Return `(device_type, device_id)`; CUDA devices report `(2, gpu_id)`.
 - Input length exceeds `2^num_qubits`.
 - Non-`float64` NumPy/Torch inputs.
 - Torch tensors not on CPU or not contiguous.
+- `phase` used through a CUDA tensor direct-input path.
 - DLPack capsule consumed more than once.
 
 ## Requirements & Deprecation

--- a/docs/qdp/concepts.md
+++ b/docs/qdp/concepts.md
@@ -61,7 +61,7 @@ Note: $n=30$ is already very large—just the output state for a single sample i
 
 ---
 
-## 4. Encoding methods (amplitude, basis, angle)
+## 4. Encoding methods (amplitude, basis, angle, phase, IQP)
 
 ### 4.1 Amplitude encoding
 
@@ -131,6 +131,49 @@ When to use it:
 Trade-offs:
 
 - Only $n$ real numbers per sample, so input is compact. Output is still $2^n$ complex amplitudes. Does not by itself create entanglement (product state).
+
+### 4.4 Phase encoding
+
+**Goal**: map one phase angle per qubit to a product state with uniform magnitudes and basis-dependent phases.
+
+For phase angles $x_0, \ldots, x_{n-1}$:
+
+$$
+\vert\psi(x)\rangle = \bigotimes_{k=0}^{n-1} \frac{1}{\sqrt{2}}\left(\vert 0\rangle + e^{i x_k}\vert 1\rangle\right)
+$$
+
+Key properties in QDP:
+
+- **Input shape**: exactly one phase angle per qubit.
+- **Validation**: all phase angles must be finite.
+- **State structure**: all computational-basis amplitudes have equal magnitude $1/\sqrt{2^n}$; the data changes the phases, not the magnitudes.
+- **Route support**: phase encoding is available on the CUDA encode path. It is not currently part of the AMD route or the CUDA tensor direct-input fast path.
+
+When to use it:
+
+- You want a product-state embedding where classical information is carried in phases instead of amplitude magnitudes.
+
+### 4.5 IQP and IQP-Z encoding
+
+**Goal**: build diagonal-phase embeddings in the IQP family.
+
+QDP supports two related methods:
+
+- **`iqp-z`**: Z-only diagonal phases with `n` parameters for `n` qubits.
+- **`iqp`**: Z + ZZ diagonal phases with `n + n(n-1)/2` parameters.
+
+Key properties in QDP:
+
+- **Input shape**:
+  - `iqp-z`: exactly `n` parameters
+  - `iqp`: exactly `n + n(n-1)/2` parameters
+- **Validation**: all parameters must be finite.
+- **State structure**: unlike `angle` and `phase`, these methods can encode entangling structure through the diagonal phase construction.
+- **Route support**: `iqp` and `iqp-z` are supported on the CUDA encode path. The AMD route does not currently implement them.
+
+When to use them:
+
+- You want an IQP-style feature map and need either the full Z+ZZ form (`iqp`) or the Z-only variant (`iqp-z`).
 
 ---
 

--- a/docs/qdp/examples.md
+++ b/docs/qdp/examples.md
@@ -5,11 +5,10 @@ title: Examples - QDP
 # Examples
 
 :::info Prerequisites
-These examples use the CUDA route for the advanced methods below.
+These examples require Linux with an NVIDIA GPU and CUDA.
 
 - Install QDP support: `pip install qumat[qdp]`
 - Optional deps used below: `torch`, `numpy`
-- The AMD route currently supports `amplitude`, `angle`, and `basis`, but not `phase`, `iqp`, or `iqp-z`.
 :::
 
 ## Example 1: Basic Encode + DLPack to PyTorch
@@ -18,7 +17,7 @@ These examples use the CUDA route for the advanced methods below.
 import torch
 import qumat.qdp as qdp
 
-engine = qdp.QdpEngine(device_id=0, backend="cuda")
+engine = qdp.QdpEngine(device_id=0)
 qtensor = engine.encode(
     [0.5, 0.5, 0.5, 0.5],
     num_qubits=2,
@@ -29,43 +28,4 @@ qtensor = engine.encode(
 tensor = torch.from_dlpack(qtensor)
 assert tensor.is_cuda
 assert tensor.shape == (1, 4)  # [batch_size, 2^num_qubits]
-```
-
-## Example 2: Phase Encoding
-
-```python
-import torch
-import qumat.qdp as qdp
-
-engine = qdp.QdpEngine(device_id=0, backend="cuda")
-qtensor = engine.encode(
-    [0.0, torch.pi / 2],
-    num_qubits=2,
-    encoding_method="phase",
-)
-
-state = torch.from_dlpack(qtensor)
-assert state.shape == (1, 4)
-```
-
-## Example 3: IQP and IQP-Z
-
-```python
-import torch
-import qumat.qdp as qdp
-
-engine = qdp.QdpEngine(device_id=0, backend="cuda")
-
-# 2 qubits:
-# - iqp-z expects n = 2 parameters
-# - iqp expects n + n*(n-1)/2 = 3 parameters
-state_z = torch.from_dlpack(
-    engine.encode([0.1, -0.2], num_qubits=2, encoding_method="iqp-z")
-)
-state_full = torch.from_dlpack(
-    engine.encode([0.1, -0.2, 0.3], num_qubits=2, encoding_method="iqp")
-)
-
-assert state_z.shape == (1, 4)
-assert state_full.shape == (1, 4)
 ```

--- a/docs/qdp/examples.md
+++ b/docs/qdp/examples.md
@@ -5,10 +5,11 @@ title: Examples - QDP
 # Examples
 
 :::info Prerequisites
-These examples require Linux with an NVIDIA GPU and CUDA.
+These examples use the CUDA route for the advanced methods below.
 
 - Install QDP support: `pip install qumat[qdp]`
 - Optional deps used below: `torch`, `numpy`
+- The AMD route currently supports `amplitude`, `angle`, and `basis`, but not `phase`, `iqp`, or `iqp-z`.
 :::
 
 ## Example 1: Basic Encode + DLPack to PyTorch
@@ -17,7 +18,7 @@ These examples require Linux with an NVIDIA GPU and CUDA.
 import torch
 import qumat.qdp as qdp
 
-engine = qdp.QdpEngine(device_id=0)
+engine = qdp.QdpEngine(device_id=0, backend="cuda")
 qtensor = engine.encode(
     [0.5, 0.5, 0.5, 0.5],
     num_qubits=2,
@@ -28,4 +29,43 @@ qtensor = engine.encode(
 tensor = torch.from_dlpack(qtensor)
 assert tensor.is_cuda
 assert tensor.shape == (1, 4)  # [batch_size, 2^num_qubits]
+```
+
+## Example 2: Phase Encoding
+
+```python
+import torch
+import qumat.qdp as qdp
+
+engine = qdp.QdpEngine(device_id=0, backend="cuda")
+qtensor = engine.encode(
+    [0.0, torch.pi / 2],
+    num_qubits=2,
+    encoding_method="phase",
+)
+
+state = torch.from_dlpack(qtensor)
+assert state.shape == (1, 4)
+```
+
+## Example 3: IQP and IQP-Z
+
+```python
+import torch
+import qumat.qdp as qdp
+
+engine = qdp.QdpEngine(device_id=0, backend="cuda")
+
+# 2 qubits:
+# - iqp-z expects n = 2 parameters
+# - iqp expects n + n*(n-1)/2 = 3 parameters
+state_z = torch.from_dlpack(
+    engine.encode([0.1, -0.2], num_qubits=2, encoding_method="iqp-z")
+)
+state_full = torch.from_dlpack(
+    engine.encode([0.1, -0.2, 0.3], num_qubits=2, encoding_method="iqp")
+)
+
+assert state_z.shape == (1, 4)
+assert state_full.shape == (1, 4)
 ```

--- a/docs/qdp/getting-started.md
+++ b/docs/qdp/getting-started.md
@@ -71,6 +71,7 @@ tensor = torch.from_dlpack(qtensor)
 
 Notes:
 - `phase`, `iqp`, and `iqp-z` are currently CUDA-route features. The AMD Triton route supports `amplitude`, `angle`, and `basis`.
+- On the AMD Triton route, `amplitude` currently requires each sample to have length exactly `2^num_qubits`; the generic `≤ 2^num_qubits` constraint in the table above does not apply there.
 - For detailed input contracts and route-specific support, see the [API Reference](./api/) and [Python API](./python-api/).
 
 ## File Inputs

--- a/docs/qdp/getting-started.md
+++ b/docs/qdp/getting-started.md
@@ -64,7 +64,14 @@ tensor = torch.from_dlpack(qtensor)
 |--------|-----------|---------|
 | `amplitude` | data length ≤ 2^num_qubits | `encode([0.5, 0.5, 0.5, 0.5], num_qubits=2, encoding_method="amplitude")` |
 | `angle` | data length = num_qubits | `encode([0.1, 0.2, 0.3, 0.4], num_qubits=4, encoding_method="angle")` |
-| `basis` | data length = num_qubits | `encode([1, 0, 1, 1], num_qubits=4, encoding_method="basis")` |
+| `basis` | one integer index in `[0, 2^num_qubits)` per sample | `encode([3], num_qubits=2, encoding_method="basis")` |
+| `phase` | data length = num_qubits | `encode([0.0, 1.57], num_qubits=2, encoding_method="phase")` |
+| `iqp-z` | data length = num_qubits | `encode([0.1, -0.2], num_qubits=2, encoding_method="iqp-z")` |
+| `iqp` | data length = num_qubits + num_qubits*(num_qubits-1)/2 | `encode([0.1, -0.2, 0.3], num_qubits=2, encoding_method="iqp")` |
+
+Notes:
+- `phase`, `iqp`, and `iqp-z` are currently CUDA-route features. The AMD Triton route supports `amplitude`, `angle`, and `basis`.
+- For detailed input contracts and route-specific support, see the [API Reference](./api/) and [Python API](./python-api/).
 
 ## File Inputs
 

--- a/docs/qdp/python-api.md
+++ b/docs/qdp/python-api.md
@@ -39,18 +39,35 @@ from qumat_qdp import (
 
 GPU encoder. Constructor and main methods:
 
-**`QdpEngine(device_id=0, precision="float32")`**
+**`QdpEngine(device_id=0, precision="float32", backend="cuda")`**
 
 - `device_id` (int): CUDA device ID.
 - `precision` (str): `"float32"` or `"float64"`.
+- `backend` (str): `"cuda"` for the Rust/CUDA route or `"amd"` for the Triton AMD route.
 - Raises `RuntimeError` on init failure or unsupported precision.
 
 **`encode(data, num_qubits, encoding_method="amplitude") -> QuantumTensor`**
 
 - `data`: list of floats, 1D/2D NumPy array (float64, C-contiguous), PyTorch tensor (CPU/CUDA), or file path (`.parquet`, `.arrow`, `.feather`, `.npy`, `.pt`, `.pth`, `.pb`).
 - `num_qubits` (int): Number of qubits.
-- `encoding_method` (str): `"amplitude"` | `"angle"` | `"basis"` | `"iqp"` | `"iqp-z"`.
+- `encoding_method` (str): `"amplitude"` | `"angle"` | `"basis"` | `"phase"` | `"iqp"` | `"iqp-z"`.
 - Returns a DLPack-compatible tensor; use `torch.from_dlpack(qtensor)`. Shape `[batch_size, 2^num_qubits]`.
+
+### Advanced Encoding Support
+
+The advanced methods `phase`, `iqp`, and `iqp-z` are not currently uniform across every helper surface.
+
+| Surface | `phase` | `iqp` | `iqp-z` |
+|--------|---------|-------|---------|
+| `QdpEngine(..., backend="cuda").encode(...)` | ✅ | ✅ | ✅ |
+| CUDA tensor fast path | ❌ | ✅ | ✅ |
+| `QdpEngine(..., backend="amd")` | ❌ | ❌ | ❌ |
+| `qumat_qdp.torch_ref.encode(..., encoding_method=...)` | ❌ | ✅ | ❌ |
+
+Notes:
+- `phase` is implemented on the CUDA encode path and covered by binding tests, but it is not part of the CUDA tensor direct-input fast path.
+- The AMD Triton route currently implements `amplitude`, `angle`, and `basis` only.
+- The pure-PyTorch reference helper exposes `iqp` directly. For Z-only reference behavior, use `iqp_encode(..., enable_zz=False)`.
 
 **`create_synthetic_loader(total_batches, batch_size=64, num_qubits=16, encoding_method="amplitude", seed=None)`**
 
@@ -86,6 +103,8 @@ Builder; chain methods then call `run_throughput()` or `run_latency()`.
 | `batches(total, size=64)` | Total batches and batch size. |
 | `prefetch(n)` | No-op (API compatibility). |
 | `warmup(n)` | Warmup batch count. |
+
+The benchmark helpers remain primarily amplitude/angle/basis oriented. The PyTorch reference backend also supports `iqp`; `phase` and `iqp-z` should be treated as direct-encode methods rather than benchmark-helper features.
 
 **`run_throughput() -> ThroughputResult`**
 
@@ -151,6 +170,8 @@ Builder for a synthetic-data loader. Calling `iter(loader)` (or `for qt in loade
 | `batches(total, size=64)` | Total batches and batch size. |
 | `source_synthetic(total_batches=None)` | Synthetic data (default); optional override for total batches. |
 | `seed(s)` | RNG seed for reproducibility. |
+
+The documented loader surface is amplitude/angle/basis first. The PyTorch reference backend has explicit `iqp` coverage in tests; `phase` and `iqp-z` are not first-class loader methods today.
 
 **Iteration:** `for qt in loader:` yields `QuantumTensor` of shape `[batch_size, 2^num_qubits]`. Consume once per tensor, e.g. `torch.from_dlpack(qt)`.
 

--- a/docs/qdp/python-api.md
+++ b/docs/qdp/python-api.md
@@ -41,7 +41,7 @@ GPU encoder. Constructor and main methods:
 
 **`QdpEngine(device_id=0, precision="float32", backend="cuda")`**
 
-- `device_id` (int): CUDA device ID.
+- `device_id` (int): GPU device ordinal. Maps to a CUDA device for `backend="cuda"` and to the ROCm/PyTorch device for `backend="amd"`.
 - `precision` (str): `"float32"` or `"float64"`.
 - `backend` (str): `"cuda"` for the Rust/CUDA route or `"amd"` for the Triton AMD route.
 - Raises `RuntimeError` on init failure or unsupported precision.


### PR DESCRIPTION
### Related Issues

Related to #1285 
### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

The QDP docs were missing or under-documenting several existing encoding methods and their support boundaries.

In particular:
- `phase` is implemented and covered by tests, but was not documented in the public QDP docs.
- `iqp` / `iqp-z` were only partially documented and were not described consistently across the getting started, API, Python API, and concepts pages.
- The docs did not clearly explain route-specific support differences between the CUDA path, CUDA tensor fast path, and AMD route.


## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
