### PR TITLE
docs(qdp): sync getting-started guide with current engine and encoding behavior

### DIFF
--- a/docs/qdp/getting-started.md
+++ b/docs/qdp/getting-started.md
@@ -54,7 +54,8 @@ data = [0.5, 0.5, 0.5, 0.5]
 qtensor = engine.encode(data, num_qubits=2, encoding_method="amplitude")
 
 # Zero-copy hand-off to PyTorch via DLPack.
-# A QuantumTensor can be consumed only once — pass it to a single consumer.
+# On CUDA the result is a native QuantumTensor whose DLPack export is
+# single-use, so pass it to only one consumer.
 tensor = torch.from_dlpack(qtensor)
 ```
 
@@ -70,7 +71,7 @@ tensor = torch.from_dlpack(qtensor)
 
 | Method | Constraint | Example |
 |--------|-----------|---------|
-| `amplitude` | up to `2^num_qubits` values per sample | `engine.encode([0.5, 0.5, 0.5, 0.5], num_qubits=2, encoding_method="amplitude")` |
+| `amplitude` | CUDA: up to `2^num_qubits` values per sample (zero-padded). AMD: exactly `2^num_qubits` values per sample | `engine.encode([0.5, 0.5, 0.5, 0.5], num_qubits=2, encoding_method="amplitude")` |
 | `angle` | one angle per qubit (`num_qubits` values per sample) | `engine.encode([0.1, 0.2, 0.3, 0.4], num_qubits=4, encoding_method="angle")` |
 | `basis` | one integer index per sample, `0 ≤ index < 2^num_qubits` | `engine.encode([13], num_qubits=4, encoding_method="basis")` (encodes basis state 13) |
 | `iqp`, `iqp-z` | data length matches the IQP parameter shape for `num_qubits` | `engine.encode([0.1, 0.2, 0.3], num_qubits=2, encoding_method="iqp")` |
@@ -79,11 +80,13 @@ tensor = torch.from_dlpack(qtensor)
 
 ## File Inputs
 
-`engine.encode(...)` accepts a path or `pathlib.Path` for supported file formats:
+File and remote-URL inputs are handled by the CUDA route. The AMD route's `encode()` accepts only array-like data (`list`, `numpy.ndarray`, `torch.Tensor`); load files into memory first, or use the CUDA route for the loader/streaming features.
+
+On CUDA, `engine.encode(...)` accepts a path or `pathlib.Path` for supported file formats:
 
 ```python
 engine.encode("data.parquet", num_qubits=10, encoding_method="amplitude")
-# Other supported formats: .arrow, .npy, .pt, .pb
+# Other supported formats: .arrow, .feather, .npy, .pt, .pth, .pb
 ```
 
 Remote object storage URLs are accepted when QDP is built with the `remote-io` feature:

--- a/docs/qdp/getting-started.md
+++ b/docs/qdp/getting-started.md
@@ -4,14 +4,14 @@ title: Getting Started with QDP
 
 # Getting Started with QDP
 
-QDP (Quantum Data Plane) is a GPU-accelerated library for encoding classical data into quantum states.
+QDP (Quantum Data Plane) is a GPU-accelerated library for encoding classical data into quantum states. It ships as part of the Apache Mahout `qumat` package and exposes a single `QdpEngine` facade with explicit backend selection for NVIDIA CUDA and AMD ROCm.
 
 ## Prerequisites
 
 - Python 3.10+
 - One of:
-  - NVIDIA GPU with CUDA toolkit installed (`nvcc --version` to verify)
-  - AMD GPU with ROCm and PyTorch ROCm installed (`python -c "import torch; print(torch.version.hip)"`)
+  - NVIDIA GPU with a CUDA-compatible PyTorch build (verify with `python -c "import torch; print(torch.cuda.is_available())"`)
+  - AMD GPU with a ROCm-compatible PyTorch build (verify with `python -c "import torch; print(torch.version.hip)"`) plus Triton with HIP support
 
 ## Installation
 
@@ -19,21 +19,27 @@ QDP (Quantum Data Plane) is a GPU-accelerated library for encoding classical dat
 pip install qumat[qdp]
 ```
 
-For development (from source):
+For development from source:
 
 ```bash
 git clone https://github.com/apache/mahout.git
 cd mahout
-uv sync --group dev --extra qdp
+uv sync --active --project qdp/qdp-python --group dev
 source .venv/bin/activate
 uv run --active maturin develop --manifest-path qdp/qdp-python/Cargo.toml
 ```
 
-For AMD ROCm with the Triton backend:
+For AMD ROCm with the Triton backend, install a ROCm-compatible PyTorch first, then sync the benchmark group (which includes `triton`):
 
 ```bash
-uv sync --group dev --extra qdp
-pip install triton
+uv sync --active --project qdp/qdp-python --group benchmark
+```
+
+You can confirm the AMD route is usable at runtime:
+
+```python
+from qumat_qdp import is_triton_amd_available
+print(is_triton_amd_available())
 ```
 
 ## Quick Start
@@ -42,18 +48,20 @@ pip install triton
 import torch
 from qumat.qdp import QdpEngine
 
-engine = QdpEngine(device_id=0, backend="cuda")
+# CUDA is the default backend.
+engine = QdpEngine(device_id=0)
 data = [0.5, 0.5, 0.5, 0.5]
 qtensor = engine.encode(data, num_qubits=2, encoding_method="amplitude")
 
-# Convert to PyTorch (zero-copy)
-tensor = torch.from_dlpack(qtensor)  # Note: can only be consumed once
+# Zero-copy hand-off to PyTorch via DLPack.
+# A QuantumTensor can be consumed only once — pass it to a single consumer.
+tensor = torch.from_dlpack(qtensor)
 ```
 
-AMD ROCm uses the same API with a different backend selector:
+To run on AMD ROCm, pass `backend="amd"`:
 
 ```python
-engine = QdpEngine(device_id=0, backend="amd", precision="float32")
+engine = QdpEngine(device_id=0, backend="amd")
 qtensor = engine.encode(data, num_qubits=2, encoding_method="amplitude")
 tensor = torch.from_dlpack(qtensor)
 ```
@@ -62,17 +70,23 @@ tensor = torch.from_dlpack(qtensor)
 
 | Method | Constraint | Example |
 |--------|-----------|---------|
-| `amplitude` | data length ≤ 2^num_qubits | `encode([0.5, 0.5, 0.5, 0.5], num_qubits=2, encoding_method="amplitude")` |
-| `angle` | data length = num_qubits | `encode([0.1, 0.2, 0.3, 0.4], num_qubits=4, encoding_method="angle")` |
-| `basis` | data length = num_qubits | `encode([1, 0, 1, 1], num_qubits=4, encoding_method="basis")` |
+| `amplitude` | up to `2^num_qubits` values per sample | `engine.encode([0.5, 0.5, 0.5, 0.5], num_qubits=2, encoding_method="amplitude")` |
+| `angle` | one angle per qubit (`num_qubits` values per sample) | `engine.encode([0.1, 0.2, 0.3, 0.4], num_qubits=4, encoding_method="angle")` |
+| `basis` | one integer index per sample, `0 ≤ index < 2^num_qubits` | `engine.encode([13], num_qubits=4, encoding_method="basis")` (encodes basis state 13) |
+| `iqp`, `iqp-z` | data length matches the IQP parameter shape for `num_qubits` | `engine.encode([0.1, 0.2, 0.3], num_qubits=2, encoding_method="iqp")` |
+
+> Backend support: `amplitude`, `angle`, and `basis` work on both CUDA and AMD. `iqp` and `iqp-z` are CUDA-only today. See [Concepts](./concepts/) for the IQP parameter layout and method semantics.
 
 ## File Inputs
 
+`engine.encode(...)` accepts a path or `pathlib.Path` for supported file formats:
+
 ```python
-engine.encode("data.parquet", num_qubits=10, encoding_method="amplitude")  # also: .arrow, .npy, .pt, .pb
+engine.encode("data.parquet", num_qubits=10, encoding_method="amplitude")
+# Other supported formats: .arrow, .npy, .pt, .pb
 ```
 
-Remote object storage URLs are supported when QDP is built with `remote-io`:
+Remote object storage URLs are accepted when QDP is built with the `remote-io` feature:
 
 ```python
 engine.encode("s3://my-bucket/path/data.parquet", num_qubits=10, encoding_method="amplitude")
@@ -80,29 +94,31 @@ engine.encode("gs://my-bucket/path/data.parquet", num_qubits=10, encoding_method
 ```
 
 Notes:
-- Remote URL query/fragment is not supported (`?versionId=...`, `#...`).
-- Streaming still requires `.parquet`.
+- Query strings and fragments in remote URLs (e.g. `?versionId=...`, `#...`) are not supported.
+- Streaming sources are limited to `.parquet`; see the [Python API](./python-api/) page for the loader/streaming surface.
 
 ## Tips
 
-- Use `precision="float64"` for higher precision: `QdpEngine(0, precision="float64")`
-- NumPy inputs must be `float64` dtype
-- Streaming only works with Parquet files
+- Default `precision` is `"float32"`; pass `precision="float64"` for higher precision: `QdpEngine(device_id=0, precision="float64")`.
+- NumPy inputs must be `float64` dtype. CUDA `torch.Tensor` inputs accept `float32` or `float64` for amplitude; angle and IQP methods require `float64` for batched inputs.
+- Backend selection is explicit; valid values are `"cuda"` and `"amd"` (with `"triton_amd"` accepted as an alias for `"amd"`).
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| Import fails | Activate root venv: `source mahout/.venv/bin/activate` (or `cd mahout && source .venv/bin/activate`) |
-| CUDA errors | Run `cargo clean` in `qdp/` and rebuild |
-| AMD backend unavailable | Verify ROCm PyTorch reports `torch.version.hip` and install `triton` |
+| Problem | Resolution |
+|---------|-----------|
+| `ImportError` on `qumat.qdp` | Activate the project venv: `source mahout/.venv/bin/activate` |
+| `ValueError: Unsupported backend` | Use `backend="cuda"` or `backend="amd"` |
+| AMD route unavailable | Confirm `torch.version.hip` is set, then check `qumat_qdp.is_triton_amd_available()` and install the benchmark group if `triton` is missing |
+| CUDA build failures (from source) | Run `cargo clean` in `qdp/` and rebuild with `maturin develop` |
 | Out of memory | Reduce `num_qubits` or use `precision="float32"` |
 
 ## Next Steps
 
-- [Concepts](./concepts/) - Learn about quantum encoding concepts
-- [API Reference](./api/) - Detailed API documentation
-- [Examples](./examples/) - More usage examples
+- [Concepts](./concepts/) - Quantum encoding concepts and architecture
+- [API Reference](./api/) - Public `qumat.qdp` API
+- [Python API](./python-api/) - `qumat_qdp` package surface, loaders, and benchmarks
+- [Examples](./examples/) - Usage examples
 
 ## Help
 


### PR DESCRIPTION
## Summary

PR 1 of the QDP documentation gap backlog (`QDP_DOCS_GAP_BACKLOG.md`). Refreshes `docs/qdp/getting-started.md` so it reflects the current `QdpEngine` facade (`qdp/qdp-python/qumat_qdp/backend.py`), the package README, `TRITON_AMD_BACKEND.md`, and the QDP test suite.

- Drop redundant `backend="cuda"` (it is the default); clarify AMD route via `backend="amd"` and note `"triton_amd"` as an accepted alias.
- Replace the `pip install triton` shortcut with the recommended `uv sync --group benchmark` flow and surface `qumat_qdp.is_triton_amd_available()` as the runtime capability check.
- Fix the **basis** encoding example: the kernel requires `sample_size=1` (one integer index per sample, see `qdp/qdp-core/src/encoding/basis.rs`), not a `num_qubits`-length bitstring. Updated example uses `[13]` for `num_qubits=4`.
- Add `iqp` / `iqp-z` to the methods table with a CUDA-only support note (per `qdp/qdp-python/src/constants.rs`).
- Tighten file-input and remote-URL guidance; move the streaming note out of Tips and point at the Python API page for the loader/streaming surface.
- Expand troubleshooting with `ValueError: Unsupported backend`, a more specific AMD-route diagnosis, and scope the `cargo clean` advice to from-source builds.

Out of scope (per backlog): full API details for loaders/benchmarks, internal Rust extension behavior, reader architecture, test-suite documentation. Those are covered by later PRs in the backlog.

## Test plan

- [ ] Render `docs/qdp/getting-started.md` locally and verify the methods table and notes display correctly.
- [ ] Confirm the runnable snippets (Quick Start, AMD route, file inputs, basis example) execute on a machine with the appropriate backend installed.
- [ ] Verify all internal links in Next Steps still resolve (`./concepts/`, `./api/`, `./python-api/`, `./examples/`).