### PR TITLE
[Feature][QDP] Add MPI-ready distributed amplitude execution scaffolding

### DIFF
--- a/qdp/qdp-core/examples/distributed_multigpu_q33_probe.rs
+++ b/qdp/qdp-core/examples/distributed_multigpu_q33_probe.rs
@@ -52,7 +52,7 @@ fn main() -> Result<(), MahoutError> {
     let num_qubits = std::env::var("QUBITS")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
-        .unwrap_or(34);
+        .unwrap_or(33);
     let host_len = std::env::var("HOST_LEN")
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
@@ -71,7 +71,7 @@ fn main() -> Result<(), MahoutError> {
     let host_data = vec![1.0f64; host_len];
 
     println!(
-        "Starting distributed amplitude probe: qubits={}, host_len={}, gpus={:?}, precision={:?}, shard_policy={:?}, collectives=in-process",
+        "Starting distributed multi-GPU probe: qubits={}, host_len={}, gpus={:?}, precision={:?}, shard_policy={:?}, collectives=in-process",
         num_qubits, host_len, device_ids, precision, shard_policy
     );
 
@@ -98,7 +98,7 @@ fn main() -> Result<(), MahoutError> {
         prepared.layout.recommended_gather_device_id()
     );
 
-    for shard in &prepared.layout.shards {
+    for shard in prepared.layout.shards() {
         let shard_bytes = match precision {
             Precision::Float32 => shard.local_len * 8,
             Precision::Float64 => shard.local_len * 16,

--- a/qdp/qdp-core/examples/distributed_multigpu_q34_probe.rs
+++ b/qdp/qdp-core/examples/distributed_multigpu_q34_probe.rs
@@ -16,8 +16,11 @@
 
 use std::time::Instant;
 
-use qdp_core::{DistributionMode, MahoutError};
-use qdp_core::{HostCommunicator, PlacementRequest, Precision, QdpEngine, ShardPolicy};
+use qdp_core::gpu::LocalCollectiveCommunicator;
+use qdp_core::{
+    DistributedExecutionContext, DistributionMode, MahoutError, PlacementRequest, Precision,
+    QdpEngine, ShardPolicy,
+};
 
 fn gib(bytes: usize) -> f64 {
     bytes as f64 / (1024.0 * 1024.0 * 1024.0)
@@ -65,22 +68,23 @@ fn main() -> Result<(), MahoutError> {
     let device_ids = parse_device_ids()?;
     let request =
         PlacementRequest::new(num_qubits, DistributionMode::ShardedCapacity, shard_policy);
-    let communicator = HostCommunicator;
     let host_data = vec![1.0f64; host_len];
 
     println!(
-        "Starting MPI-shaped distributed amplitude probe: qubits={}, host_len={}, gpus={:?}, precision={:?}, shard_policy={:?}, communicator=host-loopback",
+        "Starting distributed amplitude probe: qubits={}, host_len={}, gpus={:?}, precision={:?}, shard_policy={:?}, collectives=in-process",
         num_qubits, host_len, device_ids, precision, shard_policy
     );
 
+    let collectives = LocalCollectiveCommunicator;
+    let execution = DistributedExecutionContext::single_process(device_ids.clone(), &collectives)?;
+
     let prepare_start = Instant::now();
-    let prepared = QdpEngine::prepare_distributed_amplitude_with_communicator(
-        device_ids.clone(),
+    let prepared = QdpEngine::prepare_distributed_amplitude_on(
+        &execution,
         &host_data,
         num_qubits,
         precision,
         Some(request.clone()),
-        &communicator,
     )?;
     let prepare_elapsed = prepare_start.elapsed();
 
@@ -111,13 +115,12 @@ fn main() -> Result<(), MahoutError> {
     }
 
     let encode_start = Instant::now();
-    let state = QdpEngine::encode_distributed_amplitude_to_shards_with_communicator(
-        device_ids,
+    let state = QdpEngine::encode_distributed_amplitude_to_shards_on(
+        &execution,
         &host_data,
         num_qubits,
         precision,
         Some(request),
-        &communicator,
     )?;
     let encode_elapsed = encode_start.elapsed();
 

--- a/qdp/qdp-core/examples/mpi_multigpu_q34_probe.rs
+++ b/qdp/qdp-core/examples/mpi_multigpu_q34_probe.rs
@@ -1,0 +1,132 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::time::Instant;
+
+use qdp_core::{DistributionMode, MahoutError};
+use qdp_core::{HostCommunicator, PlacementRequest, Precision, QdpEngine, ShardPolicy};
+
+fn gib(bytes: usize) -> f64 {
+    bytes as f64 / (1024.0 * 1024.0 * 1024.0)
+}
+
+fn parse_device_ids() -> Result<Vec<usize>, MahoutError> {
+    let raw = std::env::var("GPU_IDS").unwrap_or_else(|_| "0,1,2,3,4,5".to_string());
+    let mut ids = Vec::new();
+    for piece in raw.split(',') {
+        let trimmed = piece.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        ids.push(trimmed.parse::<usize>().map_err(|err| {
+            MahoutError::InvalidInput(format!("Invalid GPU ID '{trimmed}': {err}"))
+        })?);
+    }
+
+    if ids.is_empty() {
+        return Err(MahoutError::InvalidInput(
+            "GPU_IDS must contain at least one CUDA device ID".to_string(),
+        ));
+    }
+
+    Ok(ids)
+}
+
+fn main() -> Result<(), MahoutError> {
+    let num_qubits = std::env::var("QUBITS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(34);
+    let host_len = std::env::var("HOST_LEN")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(1);
+    let precision = match std::env::var("PRECISION").ok().as_deref() {
+        Some("f64") | Some("float64") => Precision::Float64,
+        _ => Precision::Float32,
+    };
+    let shard_policy = match std::env::var("SHARD_POLICY").ok().as_deref() {
+        Some("equal") => ShardPolicy::Equal,
+        _ => ShardPolicy::BalancedUneven,
+    };
+    let device_ids = parse_device_ids()?;
+    let request =
+        PlacementRequest::new(num_qubits, DistributionMode::ShardedCapacity, shard_policy);
+    let communicator = HostCommunicator;
+    let host_data = vec![1.0f64; host_len];
+
+    println!(
+        "Starting MPI-shaped distributed amplitude probe: qubits={}, host_len={}, gpus={:?}, precision={:?}, shard_policy={:?}, communicator=host-loopback",
+        num_qubits, host_len, device_ids, precision, shard_policy
+    );
+
+    let prepare_start = Instant::now();
+    let prepared = QdpEngine::prepare_distributed_amplitude_with_communicator(
+        device_ids.clone(),
+        &host_data,
+        num_qubits,
+        precision,
+        Some(request.clone()),
+        &communicator,
+    )?;
+    let prepare_elapsed = prepare_start.elapsed();
+
+    println!(
+        "Prepared in {:.3}s; global_len={}; shards={}; max_local_len={}; estimated_max_shard_gib={:.2}; gather_device={:?}",
+        prepare_elapsed.as_secs_f64(),
+        prepared.plan.global_len,
+        prepared.layout.num_shards(),
+        prepared.plan.max_local_len(),
+        gib(prepared.plan.estimated_max_shard_bytes(precision)?),
+        prepared.layout.recommended_gather_device_id()
+    );
+
+    for shard in &prepared.layout.shards {
+        let shard_bytes = match precision {
+            Precision::Float32 => shard.local_len * 8,
+            Precision::Float64 => shard.local_len * 16,
+        };
+        println!(
+            "  shard {} -> cuda:{} range=[{}, {}) local_len={} (~{:.2} GiB)",
+            shard.shard_id,
+            shard.device_id,
+            shard.start_idx,
+            shard.end_idx,
+            shard.local_len,
+            gib(shard_bytes)
+        );
+    }
+
+    let encode_start = Instant::now();
+    let state = QdpEngine::encode_distributed_amplitude_to_shards_with_communicator(
+        device_ids,
+        &host_data,
+        num_qubits,
+        precision,
+        Some(request),
+        &communicator,
+    )?;
+    let encode_elapsed = encode_start.elapsed();
+
+    println!(
+        "Encoded in {:.3}s; state_shards={}; placement={:?}",
+        encode_elapsed.as_secs_f64(),
+        state.num_shards(),
+        state.recommended_placement_device_ids()
+    );
+
+    Ok(())
+}

--- a/qdp/qdp-core/src/gpu/communicator.rs
+++ b/qdp/qdp-core/src/gpu/communicator.rs
@@ -16,21 +16,25 @@
 
 use crate::error::{MahoutError, Result};
 
-/// Abstracts cross-device coordination. PR1 provides a host-coordinated fallback;
-/// a later PR can add NCCL-backed implementations behind the same trait.
-pub trait Communicator: Send + Sync {
-    fn reduce_sum_f64(&self, values: &[f64]) -> Result<f64>;
+/// Abstracts cross-shard collective operations.
+///
+/// The current implementation executes collectives inside one process. A future
+/// MPI-backed implementation can provide the same interface while mapping the
+/// partial contributions to rank-local shards and performing a real all-reduce.
+pub trait CollectiveCommunicator: Send + Sync {
+    fn all_reduce_sum_f64(&self, values: &[f64]) -> Result<f64>;
 }
 
-/// Host-coordinated reduction placeholder used for early distributed amplitude prototypes.
+/// In-process collective implementation for the current single-process
+/// distributed path.
 #[derive(Default, Debug, Clone, Copy)]
-pub struct HostCommunicator;
+pub struct LocalCollectiveCommunicator;
 
-impl Communicator for HostCommunicator {
-    fn reduce_sum_f64(&self, values: &[f64]) -> Result<f64> {
+impl CollectiveCommunicator for LocalCollectiveCommunicator {
+    fn all_reduce_sum_f64(&self, values: &[f64]) -> Result<f64> {
         if values.is_empty() {
             return Err(MahoutError::InvalidInput(
-                "Host communicator requires at least one value for reduction".to_string(),
+                "Collective reduction requires at least one partial contribution".to_string(),
             ));
         }
 

--- a/qdp/qdp-core/src/gpu/communicator.rs
+++ b/qdp/qdp-core/src/gpu/communicator.rs
@@ -22,6 +22,7 @@ use crate::error::{MahoutError, Result};
 /// MPI-backed implementation can provide the same interface while mapping the
 /// partial contributions to rank-local shards and performing a real all-reduce.
 pub trait CollectiveCommunicator: Send + Sync {
+    /// Sum one set of per-shard partial contributions into one global scalar.
     fn all_reduce_sum_f64(&self, values: &[f64]) -> Result<f64>;
 }
 

--- a/qdp/qdp-core/src/gpu/communicator.rs
+++ b/qdp/qdp-core/src/gpu/communicator.rs
@@ -1,0 +1,39 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::{MahoutError, Result};
+
+/// Abstracts cross-device coordination. PR1 provides a host-coordinated fallback;
+/// a later PR can add NCCL-backed implementations behind the same trait.
+pub trait Communicator: Send + Sync {
+    fn reduce_sum_f64(&self, values: &[f64]) -> Result<f64>;
+}
+
+/// Host-coordinated reduction placeholder used for early distributed amplitude prototypes.
+#[derive(Default, Debug, Clone, Copy)]
+pub struct HostCommunicator;
+
+impl Communicator for HostCommunicator {
+    fn reduce_sum_f64(&self, values: &[f64]) -> Result<f64> {
+        if values.is_empty() {
+            return Err(MahoutError::InvalidInput(
+                "Host communicator requires at least one value for reduction".to_string(),
+            ));
+        }
+
+        Ok(values.iter().copied().sum())
+    }
+}

--- a/qdp/qdp-core/src/gpu/communicator.rs
+++ b/qdp/qdp-core/src/gpu/communicator.rs
@@ -14,31 +14,110 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ffi::c_void;
+
 use crate::error::{MahoutError, Result};
 
 /// Abstracts cross-shard collective operations.
 ///
-/// The current implementation executes collectives inside one process. A future
-/// MPI-backed implementation can provide the same interface while mapping the
-/// partial contributions to rank-local shards and performing a real all-reduce.
+/// Implementations expose rank-local scalar semantics: each rank contributes
+/// one local value and receives the globally reduced scalar.
 pub trait CollectiveCommunicator: Send + Sync {
-    /// Sum one set of per-shard partial contributions into one global scalar.
-    fn all_reduce_sum_f64(&self, values: &[f64]) -> Result<f64>;
+    /// Rank of the current process in the collective world.
+    fn rank(&self) -> usize;
+
+    /// Number of ranks participating in the collective world.
+    fn world_size(&self) -> usize;
+
+    /// Sum one rank-local contribution into one global scalar.
+    fn all_reduce_sum_f64(&self, local_value: f64) -> Result<f64>;
 }
 
-/// In-process collective implementation for the current single-process
-/// distributed path.
+/// Device collective backend selected for GPU-resident reductions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DeviceCollectiveBackend {
+    Local,
+    CudaAwareMpi,
+    Nccl,
+    Unavailable,
+}
+
+/// Abstracts GPU-resident collective operations.
+pub trait DeviceCollectiveCommunicator: Send + Sync {
+    fn backend_kind(&self) -> DeviceCollectiveBackend;
+
+    /// # Safety
+    ///
+    /// Callers must ensure the raw pointers and stream are valid for the
+    /// selected CUDA device and that `recv_ptr` can hold `count` `f32` values.
+    unsafe fn all_reduce_sum_f32_device(
+        &self,
+        send_ptr: *const c_void,
+        recv_ptr: *mut c_void,
+        count: usize,
+        device_id: usize,
+        stream: *mut c_void,
+    ) -> Result<()>;
+}
+
+/// In-process collective implementation for the single-rank path.
 #[derive(Default, Debug, Clone, Copy)]
 pub struct LocalCollectiveCommunicator;
 
 impl CollectiveCommunicator for LocalCollectiveCommunicator {
-    fn all_reduce_sum_f64(&self, values: &[f64]) -> Result<f64> {
-        if values.is_empty() {
-            return Err(MahoutError::InvalidInput(
-                "Collective reduction requires at least one partial contribution".to_string(),
-            ));
-        }
+    fn rank(&self) -> usize {
+        0
+    }
 
-        Ok(values.iter().copied().sum())
+    fn world_size(&self) -> usize {
+        1
+    }
+
+    fn all_reduce_sum_f64(&self, local_value: f64) -> Result<f64> {
+        Ok(local_value)
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct MpiDeviceCollectiveCommunicator;
+
+impl DeviceCollectiveCommunicator for MpiDeviceCollectiveCommunicator {
+    fn backend_kind(&self) -> DeviceCollectiveBackend {
+        DeviceCollectiveBackend::CudaAwareMpi
+    }
+
+    unsafe fn all_reduce_sum_f32_device(
+        &self,
+        _send_ptr: *const c_void,
+        _recv_ptr: *mut c_void,
+        _count: usize,
+        _device_id: usize,
+        _stream: *mut c_void,
+    ) -> Result<()> {
+        Err(MahoutError::NotImplemented(
+            "CUDA-aware MPI device collectives are reserved but not implemented".to_string(),
+        ))
+    }
+}
+
+#[derive(Default, Debug, Clone, Copy)]
+pub struct NcclDeviceCollectiveCommunicator;
+
+impl DeviceCollectiveCommunicator for NcclDeviceCollectiveCommunicator {
+    fn backend_kind(&self) -> DeviceCollectiveBackend {
+        DeviceCollectiveBackend::Nccl
+    }
+
+    unsafe fn all_reduce_sum_f32_device(
+        &self,
+        _send_ptr: *const c_void,
+        _recv_ptr: *mut c_void,
+        _count: usize,
+        _device_id: usize,
+        _stream: *mut c_void,
+    ) -> Result<()> {
+        Err(MahoutError::NotImplemented(
+            "NCCL device collectives are reserved but not implemented".to_string(),
+        ))
     }
 }

--- a/qdp/qdp-core/src/gpu/cuda_ffi.rs
+++ b/qdp/qdp-core/src/gpu/cuda_ffi.rs
@@ -67,7 +67,14 @@ unsafe extern "C" {
         ptr: *const c_void,
     ) -> i32;
 
+    pub(crate) fn cudaGetDevice(device: *mut i32) -> i32;
+    pub(crate) fn cudaSetDevice(device: i32) -> i32;
     pub(crate) fn cudaMemGetInfo(free: *mut usize, total: *mut usize) -> i32;
+    pub(crate) fn cudaDeviceCanAccessPeer(
+        can_access_peer: *mut i32,
+        device: i32,
+        peer_device: i32,
+    ) -> i32;
 
     pub(crate) fn cudaMemcpyAsync(
         dst: *mut c_void,
@@ -76,7 +83,6 @@ unsafe extern "C" {
         kind: u32,
         stream: *mut c_void,
     ) -> i32;
-
     pub(crate) fn cudaEventCreateWithFlags(event: *mut *mut c_void, flags: u32) -> i32;
     pub(crate) fn cudaEventRecord(event: *mut c_void, stream: *mut c_void) -> i32;
     pub(crate) fn cudaEventDestroy(event: *mut c_void) -> i32;

--- a/qdp/qdp-core/src/gpu/cuda_ffi.rs
+++ b/qdp/qdp-core/src/gpu/cuda_ffi.rs
@@ -155,7 +155,23 @@ mod no_cuda_stubs {
         QDP_CUDA_UNAVAILABLE
     }
 
+    pub(crate) unsafe fn cudaGetDevice(_device: *mut i32) -> i32 {
+        QDP_CUDA_UNAVAILABLE
+    }
+
+    pub(crate) unsafe fn cudaSetDevice(_device: i32) -> i32 {
+        QDP_CUDA_UNAVAILABLE
+    }
+
     pub(crate) unsafe fn cudaMemGetInfo(_free: *mut usize, _total: *mut usize) -> i32 {
+        QDP_CUDA_UNAVAILABLE
+    }
+
+    pub(crate) unsafe fn cudaDeviceCanAccessPeer(
+        _can_access_peer: *mut i32,
+        _device: i32,
+        _peer_device: i32,
+    ) -> i32 {
         QDP_CUDA_UNAVAILABLE
     }
 

--- a/qdp/qdp-core/src/gpu/distributed/amplitude.rs
+++ b/qdp/qdp-core/src/gpu/distributed/amplitude.rs
@@ -1,0 +1,132 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::{MahoutError, Result};
+use crate::gpu::distributed::{
+    DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest, ShardPlacement,
+    ShardPolicy,
+};
+use crate::gpu::encodings::MAX_QUBITS;
+use crate::gpu::topology::DeviceMesh;
+
+/// Shared planning math for amplitude-sharded state construction.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DistributedAmplitudePlan {
+    pub request: PlacementRequest,
+    pub placement: PlacementPlan,
+    pub num_qubits: usize,
+    pub global_len: usize,
+    pub num_devices: usize,
+    pub shard_bits: Option<usize>,
+    pub uniform_shard_len: Option<usize>,
+}
+
+/// Result of preparing a distributed amplitude encode without yet allocating
+/// concrete shard buffers. This fixes the public API surface for later PRs that
+/// will populate `state` with real device allocations.
+#[derive(Clone)]
+pub struct PreparedDistributedAmplitudeEncode {
+    pub mesh: DeviceMesh,
+    pub plan: DistributedAmplitudePlan,
+    pub inv_norm: f64,
+    pub layout: super::layout::DistributedStateLayout,
+}
+
+impl DistributedAmplitudePlan {
+    pub fn for_request(mesh: &DeviceMesh, request: PlacementRequest) -> Result<Self> {
+        if request.num_qubits == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Number of qubits must be at least 1 for distributed amplitude planning"
+                    .to_string(),
+            ));
+        }
+        if mesh.num_devices() == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Distributed amplitude planning requires at least one device".to_string(),
+            ));
+        }
+        if request.mode != DistributionMode::ShardedCapacity {
+            return Err(MahoutError::InvalidInput(format!(
+                "Distributed amplitude planning currently supports only {:?}, got {:?}",
+                DistributionMode::ShardedCapacity,
+                request.mode
+            )));
+        }
+
+        let num_devices = mesh.num_devices();
+        let placement = PlacementPlanner::plan(mesh, &request)?;
+        Self::validate_local_shard_capacity(request.num_qubits, &placement)?;
+        let global_len = placement.global_len;
+        let num_qubits = request.num_qubits;
+        let (shard_bits, uniform_shard_len) = match request.shard_policy {
+            ShardPolicy::Equal => {
+                debug_assert!(num_devices.is_power_of_two());
+                let shard_bits = num_devices.trailing_zeros() as usize;
+                if shard_bits > request.num_qubits {
+                    return Err(MahoutError::InvalidInput(format!(
+                        "Cannot shard {} qubits across {} devices: shard bits {} exceed qubit count",
+                        request.num_qubits, num_devices, shard_bits
+                    )));
+                }
+                (Some(shard_bits), Some(placement.shard_len()?))
+            }
+            ShardPolicy::BalancedUneven => (None, None),
+        };
+
+        Ok(Self {
+            request,
+            placement,
+            num_qubits,
+            global_len,
+            num_devices,
+            shard_bits,
+            uniform_shard_len,
+        })
+    }
+
+    pub fn shard_range(&self, shard_id: usize) -> Result<(usize, usize)> {
+        let placement = self.placement.placements.get(shard_id).ok_or_else(|| {
+            MahoutError::InvalidInput(format!(
+                "Shard ID {} out of range for {} devices",
+                shard_id, self.num_devices
+            ))
+        })?;
+        Ok((placement.start_idx, placement.end_idx))
+    }
+
+    fn validate_local_shard_capacity(num_qubits: usize, placement: &PlacementPlan) -> Result<()> {
+        let max_local_len = 1usize << MAX_QUBITS;
+        let required_local_len = placement
+            .placements
+            .iter()
+            .map(ShardPlacement::local_len)
+            .max()
+            .ok_or_else(|| {
+                MahoutError::InvalidInput(
+                    "Placement plan must contain at least one shard".to_string(),
+                )
+            })?;
+
+        if required_local_len > max_local_len {
+            return Err(MahoutError::InvalidInput(format!(
+                "Distributed amplitude request for {} qubits still exceeds per-device capacity: largest shard has {} amplitudes, limit is 2^{} = {}. Add more GPUs or reduce qubits.",
+                num_qubits, required_local_len, MAX_QUBITS, max_local_len
+            )));
+        }
+
+        Ok(())
+    }
+}

--- a/qdp/qdp-core/src/gpu/distributed/amplitude.rs
+++ b/qdp/qdp-core/src/gpu/distributed/amplitude.rs
@@ -46,6 +46,8 @@ pub struct PreparedDistributedAmplitudeEncode {
 }
 
 impl DistributedAmplitudePlan {
+    /// Validate one distributed amplitude request and derive the shard math used
+    /// by later layout and materialization steps.
     pub fn for_request(mesh: &DeviceMesh, request: PlacementRequest) -> Result<Self> {
         if request.num_qubits == 0 {
             return Err(MahoutError::InvalidInput(
@@ -97,6 +99,7 @@ impl DistributedAmplitudePlan {
         })
     }
 
+    /// Logical half-open amplitude range covered by one shard ID.
     pub fn shard_range(&self, shard_id: usize) -> Result<(usize, usize)> {
         let placement = self.placement.placements.get(shard_id).ok_or_else(|| {
             MahoutError::InvalidInput(format!(
@@ -107,6 +110,7 @@ impl DistributedAmplitudePlan {
         Ok((placement.start_idx, placement.end_idx))
     }
 
+    /// Largest local shard length across the current placement.
     pub fn max_local_len(&self) -> usize {
         self.placement
             .placements
@@ -116,6 +120,7 @@ impl DistributedAmplitudePlan {
             .unwrap_or(0)
     }
 
+    /// Estimated bytes required by the largest local shard at one target precision.
     pub fn estimated_max_shard_bytes(&self, precision: Precision) -> Result<usize> {
         estimated_amplitude_bytes(self.max_local_len(), precision)
     }

--- a/qdp/qdp-core/src/gpu/distributed/amplitude.rs
+++ b/qdp/qdp-core/src/gpu/distributed/amplitude.rs
@@ -19,7 +19,7 @@ use crate::gpu::distributed::{
     DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest, ShardPlacement,
     ShardPolicy,
 };
-use crate::gpu::encodings::MAX_QUBITS;
+use crate::gpu::memory::Precision;
 use crate::gpu::topology::DeviceMesh;
 
 /// Shared planning math for amplitude-sharded state construction.
@@ -68,7 +68,7 @@ impl DistributedAmplitudePlan {
 
         let num_devices = mesh.num_devices();
         let placement = PlacementPlanner::plan(mesh, &request)?;
-        Self::validate_local_shard_capacity(request.num_qubits, &placement)?;
+        Self::validate_local_shard_shape(request.num_qubits, &placement)?;
         let global_len = placement.global_len;
         let num_qubits = request.num_qubits;
         let (shard_bits, uniform_shard_len) = match request.shard_policy {
@@ -107,8 +107,20 @@ impl DistributedAmplitudePlan {
         Ok((placement.start_idx, placement.end_idx))
     }
 
-    fn validate_local_shard_capacity(num_qubits: usize, placement: &PlacementPlan) -> Result<()> {
-        let max_local_len = 1usize << MAX_QUBITS;
+    pub fn max_local_len(&self) -> usize {
+        self.placement
+            .placements
+            .iter()
+            .map(ShardPlacement::local_len)
+            .max()
+            .unwrap_or(0)
+    }
+
+    pub fn estimated_max_shard_bytes(&self, precision: Precision) -> Result<usize> {
+        estimated_amplitude_bytes(self.max_local_len(), precision)
+    }
+
+    fn validate_local_shard_shape(num_qubits: usize, placement: &PlacementPlan) -> Result<()> {
         let required_local_len = placement
             .placements
             .iter()
@@ -120,13 +132,32 @@ impl DistributedAmplitudePlan {
                 )
             })?;
 
-        if required_local_len > max_local_len {
+        if required_local_len == 0 {
             return Err(MahoutError::InvalidInput(format!(
-                "Distributed amplitude request for {} qubits still exceeds per-device capacity: largest shard has {} amplitudes, limit is 2^{} = {}. Add more GPUs or reduce qubits.",
-                num_qubits, required_local_len, MAX_QUBITS, max_local_len
+                "Distributed amplitude request for {} qubits produced an empty local shard",
+                num_qubits
             )));
         }
 
+        let _ = estimated_amplitude_bytes(required_local_len, Precision::Float32)?;
+        let _ = estimated_amplitude_bytes(required_local_len, Precision::Float64)?;
+
         Ok(())
     }
+}
+
+fn estimated_amplitude_bytes(local_len: usize, precision: Precision) -> Result<usize> {
+    let bytes_per_amplitude = match precision {
+        Precision::Float32 => 8usize,
+        Precision::Float64 => 16usize,
+    };
+
+    local_len
+        .checked_mul(bytes_per_amplitude)
+        .ok_or_else(|| {
+            MahoutError::InvalidInput(format!(
+                "Distributed amplitude shard byte estimate overflowed for local_len={} and precision={:?}",
+                local_len, precision
+            ))
+        })
 }

--- a/qdp/qdp-core/src/gpu/distributed/amplitude.rs
+++ b/qdp/qdp-core/src/gpu/distributed/amplitude.rs
@@ -16,22 +16,15 @@
 
 use crate::error::{MahoutError, Result};
 use crate::gpu::distributed::{
-    DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest, ShardPlacement,
-    ShardPolicy,
+    DistributedStatePlan, DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest,
 };
-use crate::gpu::memory::Precision;
 use crate::gpu::topology::DeviceMesh;
+use std::ops::Deref;
 
-/// Shared planning math for amplitude-sharded state construction.
+/// Amplitude-specific wrapper around the shared distributed state plan.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct DistributedAmplitudePlan {
-    pub request: PlacementRequest,
-    pub placement: PlacementPlan,
-    pub num_qubits: usize,
-    pub global_len: usize,
-    pub num_devices: usize,
-    pub shard_bits: Option<usize>,
-    pub uniform_shard_len: Option<usize>,
+    pub state: DistributedStatePlan,
 }
 
 /// Result of preparing a distributed amplitude encode without yet allocating
@@ -88,118 +81,22 @@ impl DistributedAmplitudePlan {
     }
 
     fn from_placement(request: PlacementRequest, placement: PlacementPlan) -> Result<Self> {
-        let num_devices = placement.num_devices();
-        Self::validate_local_shard_shape(request.num_qubits, &placement)?;
-        let global_len = placement.global_len;
-        let num_qubits = request.num_qubits;
-        let (shard_bits, uniform_shard_len) = match request.shard_policy {
-            ShardPolicy::Equal => {
-                debug_assert!(num_devices.is_power_of_two());
-                let shard_bits = num_devices.trailing_zeros() as usize;
-                if shard_bits > request.num_qubits {
-                    return Err(MahoutError::InvalidInput(format!(
-                        "Cannot shard {} qubits across {} devices: shard bits {} exceed qubit count",
-                        request.num_qubits, num_devices, shard_bits
-                    )));
-                }
-                (Some(shard_bits), Some(placement.shard_len()?))
-            }
-            ShardPolicy::BalancedUneven => (None, None),
-        };
-
         Ok(Self {
-            request,
-            placement,
-            num_qubits,
-            global_len,
-            num_devices,
-            shard_bits,
-            uniform_shard_len,
+            state: DistributedStatePlan::from_placement(request, placement)?,
         })
-    }
-
-    /// Logical half-open amplitude range covered by one shard ID.
-    pub fn shard_range(&self, shard_id: usize) -> Result<(usize, usize)> {
-        let placement = self.placement.placements.get(shard_id).ok_or_else(|| {
-            MahoutError::InvalidInput(format!(
-                "Shard ID {} out of range for {} devices",
-                shard_id, self.num_devices
-            ))
-        })?;
-        Ok((placement.start_idx, placement.end_idx))
-    }
-
-    /// Largest local shard length across the current placement.
-    pub fn max_local_len(&self) -> usize {
-        self.placement
-            .placements
-            .iter()
-            .map(ShardPlacement::local_len)
-            .max()
-            .unwrap_or(0)
-    }
-
-    /// Number of shards owned by one rank.
-    pub fn num_local_shards(&self, rank: usize) -> usize {
-        self.placement.num_local_shards(rank)
-    }
-
-    /// Logical half-open amplitude ranges owned by one rank.
-    pub fn rank_shard_ranges(&self, rank: usize) -> Vec<(usize, usize)> {
-        self.placement
-            .placements_for_rank_iter(rank)
-            .map(|placement| (placement.start_idx, placement.end_idx))
-            .collect()
-    }
-
-    /// Largest shard length owned by one rank.
-    pub fn max_local_len_for_rank(&self, rank: usize) -> usize {
-        self.placement.local_max_len(rank)
-    }
-
-    /// Estimated bytes required by the largest local shard at one target precision.
-    pub fn estimated_max_shard_bytes(&self, precision: Precision) -> Result<usize> {
-        estimated_amplitude_bytes(self.max_local_len(), precision)
-    }
-
-    fn validate_local_shard_shape(num_qubits: usize, placement: &PlacementPlan) -> Result<()> {
-        let required_local_len = placement
-            .placements
-            .iter()
-            .map(ShardPlacement::local_len)
-            .max()
-            .ok_or_else(|| {
-                MahoutError::InvalidInput(
-                    "Placement plan must contain at least one shard".to_string(),
-                )
-            })?;
-
-        if required_local_len == 0 {
-            return Err(MahoutError::InvalidInput(format!(
-                "Distributed amplitude request for {} qubits produced an empty local shard",
-                num_qubits
-            )));
-        }
-
-        let _ = estimated_amplitude_bytes(required_local_len, Precision::Float32)?;
-        let _ = estimated_amplitude_bytes(required_local_len, Precision::Float64)?;
-
-        Ok(())
     }
 }
 
-fn estimated_amplitude_bytes(local_len: usize, precision: Precision) -> Result<usize> {
-    let bytes_per_amplitude = match precision {
-        Precision::Float32 => 8usize,
-        Precision::Float64 => 16usize,
-    };
+impl AsRef<DistributedStatePlan> for DistributedAmplitudePlan {
+    fn as_ref(&self) -> &DistributedStatePlan {
+        &self.state
+    }
+}
 
-    local_len
-        .checked_mul(bytes_per_amplitude)
-        .ok_or_else(|| {
-            MahoutError::InvalidInput(format!(
-                "Distributed amplitude shard byte estimate overflowed for local_len={} and precision={:?}",
-                local_len, precision
-            ))
-        })
+impl Deref for DistributedAmplitudePlan {
+    type Target = DistributedStatePlan;
+
+    fn deref(&self) -> &Self::Target {
+        &self.state
+    }
 }

--- a/qdp/qdp-core/src/gpu/distributed/amplitude.rs
+++ b/qdp/qdp-core/src/gpu/distributed/amplitude.rs
@@ -49,6 +49,22 @@ impl DistributedAmplitudePlan {
     /// Validate one distributed amplitude request and derive the shard math used
     /// by later layout and materialization steps.
     pub fn for_request(mesh: &DeviceMesh, request: PlacementRequest) -> Result<Self> {
+        let placement = Self::plan_request(mesh, &request, PlacementPlanner::plan)?;
+        Self::from_placement(request, placement)
+    }
+
+    /// Validate one distributed amplitude request against a rank-local mesh and
+    /// derive global shard metadata for all ranks.
+    pub fn for_rank_local_request(mesh: &DeviceMesh, request: PlacementRequest) -> Result<Self> {
+        let placement = Self::plan_request(mesh, &request, PlacementPlanner::plan_rank_local)?;
+        Self::from_placement(request, placement)
+    }
+
+    fn plan_request(
+        mesh: &DeviceMesh,
+        request: &PlacementRequest,
+        planner: fn(&DeviceMesh, &PlacementRequest) -> Result<PlacementPlan>,
+    ) -> Result<PlacementPlan> {
         if request.num_qubits == 0 {
             return Err(MahoutError::InvalidInput(
                 "Number of qubits must be at least 1 for distributed amplitude planning"
@@ -68,8 +84,11 @@ impl DistributedAmplitudePlan {
             )));
         }
 
-        let num_devices = mesh.num_devices();
-        let placement = PlacementPlanner::plan(mesh, &request)?;
+        planner(mesh, request)
+    }
+
+    fn from_placement(request: PlacementRequest, placement: PlacementPlan) -> Result<Self> {
+        let num_devices = placement.num_devices();
         Self::validate_local_shard_shape(request.num_qubits, &placement)?;
         let global_len = placement.global_len;
         let num_qubits = request.num_qubits;

--- a/qdp/qdp-core/src/gpu/distributed/amplitude.rs
+++ b/qdp/qdp-core/src/gpu/distributed/amplitude.rs
@@ -147,8 +147,7 @@ impl DistributedAmplitudePlan {
     /// Logical half-open amplitude ranges owned by one rank.
     pub fn rank_shard_ranges(&self, rank: usize) -> Vec<(usize, usize)> {
         self.placement
-            .placements_for_rank(rank)
-            .into_iter()
+            .placements_for_rank_iter(rank)
             .map(|placement| (placement.start_idx, placement.end_idx))
             .collect()
     }

--- a/qdp/qdp-core/src/gpu/distributed/amplitude.rs
+++ b/qdp/qdp-core/src/gpu/distributed/amplitude.rs
@@ -120,6 +120,25 @@ impl DistributedAmplitudePlan {
             .unwrap_or(0)
     }
 
+    /// Number of shards owned by one rank.
+    pub fn num_local_shards(&self, rank: usize) -> usize {
+        self.placement.num_local_shards(rank)
+    }
+
+    /// Logical half-open amplitude ranges owned by one rank.
+    pub fn rank_shard_ranges(&self, rank: usize) -> Vec<(usize, usize)> {
+        self.placement
+            .placements_for_rank(rank)
+            .into_iter()
+            .map(|placement| (placement.start_idx, placement.end_idx))
+            .collect()
+    }
+
+    /// Largest shard length owned by one rank.
+    pub fn max_local_len_for_rank(&self, rank: usize) -> usize {
+        self.placement.local_max_len(rank)
+    }
+
     /// Estimated bytes required by the largest local shard at one target precision.
     pub fn estimated_max_shard_bytes(&self, precision: Precision) -> Result<usize> {
         estimated_amplitude_bytes(self.max_local_len(), precision)

--- a/qdp/qdp-core/src/gpu/distributed/context.rs
+++ b/qdp/qdp-core/src/gpu/distributed/context.rs
@@ -1,0 +1,51 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::Result;
+use crate::gpu::communicator::CollectiveCommunicator;
+use crate::gpu::topology::DeviceMesh;
+
+/// Bundles the device mesh with the collective implementation that coordinates
+/// those devices.
+///
+/// The current branch uses one process with one mesh covering all participating
+/// devices. A future MPI implementation can construct one context per rank with
+/// a rank-local mesh and an MPI-backed collective implementation.
+pub struct DistributedExecutionContext<'a> {
+    mesh: DeviceMesh,
+    collectives: &'a dyn CollectiveCommunicator,
+}
+
+impl<'a> DistributedExecutionContext<'a> {
+    pub fn new(mesh: DeviceMesh, collectives: &'a dyn CollectiveCommunicator) -> Self {
+        Self { mesh, collectives }
+    }
+
+    pub fn single_process(
+        device_ids: Vec<usize>,
+        collectives: &'a dyn CollectiveCommunicator,
+    ) -> Result<Self> {
+        Ok(Self::new(DeviceMesh::new(device_ids)?, collectives))
+    }
+
+    pub fn mesh(&self) -> &DeviceMesh {
+        &self.mesh
+    }
+
+    pub(crate) fn collectives(&self) -> &dyn CollectiveCommunicator {
+        self.collectives
+    }
+}

--- a/qdp/qdp-core/src/gpu/distributed/context.rs
+++ b/qdp/qdp-core/src/gpu/distributed/context.rs
@@ -30,10 +30,14 @@ pub struct DistributedExecutionContext<'a> {
 }
 
 impl<'a> DistributedExecutionContext<'a> {
+    /// Build one distributed execution context from a validated device mesh and
+    /// one collective implementation.
     pub fn new(mesh: DeviceMesh, collectives: &'a dyn CollectiveCommunicator) -> Self {
         Self { mesh, collectives }
     }
 
+    /// Build the current single-process execution context from one caller-owned
+    /// device list.
     pub fn single_process(
         device_ids: Vec<usize>,
         collectives: &'a dyn CollectiveCommunicator,
@@ -41,6 +45,7 @@ impl<'a> DistributedExecutionContext<'a> {
         Ok(Self::new(DeviceMesh::new(device_ids)?, collectives))
     }
 
+    /// Access the device mesh that owns the distributed state shards.
     pub fn mesh(&self) -> &DeviceMesh {
         &self.mesh
     }

--- a/qdp/qdp-core/src/gpu/distributed/context.rs
+++ b/qdp/qdp-core/src/gpu/distributed/context.rs
@@ -46,18 +46,6 @@ impl fmt::Debug for DistributedExecutionContext<'_> {
 }
 
 impl<'a> DistributedExecutionContext<'a> {
-    /// Build one distributed execution context from a validated device mesh and
-    /// one collective implementation.
-    pub fn new(mesh: DeviceMesh, collectives: &'a dyn CollectiveCommunicator) -> Self {
-        Self {
-            rank: collectives.rank(),
-            world_size: collectives.world_size(),
-            mesh,
-            collectives,
-            device_collectives: None,
-        }
-    }
-
     /// Build the current single-process execution context from one caller-owned
     /// device list.
     pub fn single_process(

--- a/qdp/qdp-core/src/gpu/distributed/context.rs
+++ b/qdp/qdp-core/src/gpu/distributed/context.rs
@@ -64,6 +64,7 @@ impl<'a> DistributedExecutionContext<'a> {
         device_ids: Vec<usize>,
         collectives: &'a dyn CollectiveCommunicator,
     ) -> Result<Self> {
+        Self::validate_collective_metadata(0, 1, collectives)?;
         Ok(Self {
             rank: 0,
             world_size: 1,

--- a/qdp/qdp-core/src/gpu/distributed/context.rs
+++ b/qdp/qdp-core/src/gpu/distributed/context.rs
@@ -65,13 +65,12 @@ impl<'a> DistributedExecutionContext<'a> {
         collectives: &'a dyn CollectiveCommunicator,
     ) -> Result<Self> {
         Self::validate_collective_metadata(0, 1, collectives)?;
-        Ok(Self {
-            rank: 0,
-            world_size: 1,
-            mesh: DeviceMesh::new(device_ids)?,
+        Ok(Self::from_validated_parts(
+            0,
+            1,
+            DeviceMesh::new(device_ids)?,
             collectives,
-            device_collectives: None,
-        })
+        ))
     }
 
     /// Build one rank-local execution context from the CUDA devices owned by
@@ -84,7 +83,12 @@ impl<'a> DistributedExecutionContext<'a> {
     ) -> Result<Self> {
         Self::validate_rank_world(rank, world_size)?;
         Self::validate_collective_metadata(rank, world_size, collectives)?;
-        Self::rank_local_with_mesh(rank, world_size, DeviceMesh::new(device_ids)?, collectives)
+        Ok(Self::from_validated_parts(
+            rank,
+            world_size,
+            DeviceMesh::new(device_ids)?,
+            collectives,
+        ))
     }
 
     /// Build one rank-local execution context from an already constructed mesh.
@@ -96,13 +100,12 @@ impl<'a> DistributedExecutionContext<'a> {
     ) -> Result<Self> {
         Self::validate_rank_world(rank, world_size)?;
         Self::validate_collective_metadata(rank, world_size, collectives)?;
-        Ok(Self {
+        Ok(Self::from_validated_parts(
             rank,
             world_size,
             mesh,
             collectives,
-            device_collectives: None,
-        })
+        ))
     }
 
     /// Rank represented by this execution context.
@@ -128,6 +131,21 @@ impl<'a> DistributedExecutionContext<'a> {
     /// Access optional CUDA-aware device collectives.
     pub fn device_collectives(&self) -> Option<&dyn DeviceCollectiveCommunicator> {
         self.device_collectives
+    }
+
+    fn from_validated_parts(
+        rank: usize,
+        world_size: usize,
+        mesh: DeviceMesh,
+        collectives: &'a dyn CollectiveCommunicator,
+    ) -> Self {
+        Self {
+            rank,
+            world_size,
+            mesh,
+            collectives,
+            device_collectives: None,
+        }
     }
 
     fn validate_rank_world(rank: usize, world_size: usize) -> Result<()> {

--- a/qdp/qdp-core/src/gpu/distributed/context.rs
+++ b/qdp/qdp-core/src/gpu/distributed/context.rs
@@ -82,6 +82,7 @@ impl<'a> DistributedExecutionContext<'a> {
         collectives: &'a dyn CollectiveCommunicator,
     ) -> Result<Self> {
         Self::validate_rank_world(rank, world_size)?;
+        Self::validate_collective_metadata(rank, world_size, collectives)?;
         Self::rank_local_with_mesh(rank, world_size, DeviceMesh::new(device_ids)?, collectives)
     }
 
@@ -93,6 +94,7 @@ impl<'a> DistributedExecutionContext<'a> {
         collectives: &'a dyn CollectiveCommunicator,
     ) -> Result<Self> {
         Self::validate_rank_world(rank, world_size)?;
+        Self::validate_collective_metadata(rank, world_size, collectives)?;
         Ok(Self {
             rank,
             world_size,
@@ -132,6 +134,24 @@ impl<'a> DistributedExecutionContext<'a> {
             return Err(MahoutError::InvalidInput(format!(
                 "Distributed execution rank {} must be within world size {}",
                 rank, world_size
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn validate_collective_metadata(
+        rank: usize,
+        world_size: usize,
+        collectives: &dyn CollectiveCommunicator,
+    ) -> Result<()> {
+        if rank != collectives.rank() || world_size != collectives.world_size() {
+            return Err(MahoutError::InvalidInput(format!(
+                "Distributed execution collective metadata mismatch: requested rank {} within world size {}, collective reports rank {} within world size {}",
+                rank,
+                world_size,
+                collectives.rank(),
+                collectives.world_size()
             )));
         }
 

--- a/qdp/qdp-core/src/gpu/distributed/context.rs
+++ b/qdp/qdp-core/src/gpu/distributed/context.rs
@@ -14,8 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::error::Result;
-use crate::gpu::communicator::CollectiveCommunicator;
+use std::fmt;
+
+use crate::error::{MahoutError, Result};
+use crate::gpu::communicator::{CollectiveCommunicator, DeviceCollectiveCommunicator};
 use crate::gpu::topology::DeviceMesh;
 
 /// Bundles the device mesh with the collective implementation that coordinates
@@ -25,15 +27,35 @@ use crate::gpu::topology::DeviceMesh;
 /// devices. A future MPI implementation can construct one context per rank with
 /// a rank-local mesh and an MPI-backed collective implementation.
 pub struct DistributedExecutionContext<'a> {
+    rank: usize,
+    world_size: usize,
     mesh: DeviceMesh,
     collectives: &'a dyn CollectiveCommunicator,
+    device_collectives: Option<&'a dyn DeviceCollectiveCommunicator>,
+}
+
+impl fmt::Debug for DistributedExecutionContext<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DistributedExecutionContext")
+            .field("rank", &self.rank)
+            .field("world_size", &self.world_size)
+            .field("device_ids", &self.mesh.device_ids)
+            .field("has_device_collectives", &self.device_collectives.is_some())
+            .finish()
+    }
 }
 
 impl<'a> DistributedExecutionContext<'a> {
     /// Build one distributed execution context from a validated device mesh and
     /// one collective implementation.
     pub fn new(mesh: DeviceMesh, collectives: &'a dyn CollectiveCommunicator) -> Self {
-        Self { mesh, collectives }
+        Self {
+            rank: collectives.rank(),
+            world_size: collectives.world_size(),
+            mesh,
+            collectives,
+            device_collectives: None,
+        }
     }
 
     /// Build the current single-process execution context from one caller-owned
@@ -42,7 +64,41 @@ impl<'a> DistributedExecutionContext<'a> {
         device_ids: Vec<usize>,
         collectives: &'a dyn CollectiveCommunicator,
     ) -> Result<Self> {
-        Ok(Self::new(DeviceMesh::new(device_ids)?, collectives))
+        Ok(Self {
+            rank: 0,
+            world_size: 1,
+            mesh: DeviceMesh::new(device_ids)?,
+            collectives,
+            device_collectives: None,
+        })
+    }
+
+    /// Build one rank-local execution context from the CUDA devices owned by
+    /// this rank.
+    pub fn rank_local(
+        rank: usize,
+        world_size: usize,
+        device_ids: Vec<usize>,
+        collectives: &'a dyn CollectiveCommunicator,
+    ) -> Result<Self> {
+        Self::validate_rank_world(rank, world_size)?;
+        Ok(Self {
+            rank,
+            world_size,
+            mesh: DeviceMesh::new(device_ids)?,
+            collectives,
+            device_collectives: None,
+        })
+    }
+
+    /// Rank represented by this execution context.
+    pub fn rank(&self) -> usize {
+        self.rank
+    }
+
+    /// Total number of ranks participating in this distributed execution.
+    pub fn world_size(&self) -> usize {
+        self.world_size
     }
 
     /// Access the device mesh that owns the distributed state shards.
@@ -50,7 +106,24 @@ impl<'a> DistributedExecutionContext<'a> {
         &self.mesh
     }
 
-    pub(crate) fn collectives(&self) -> &dyn CollectiveCommunicator {
+    /// Access scalar collectives used for rank-level reductions.
+    pub fn collectives(&self) -> &dyn CollectiveCommunicator {
         self.collectives
+    }
+
+    /// Access optional CUDA-aware device collectives.
+    pub fn device_collectives(&self) -> Option<&dyn DeviceCollectiveCommunicator> {
+        self.device_collectives
+    }
+
+    fn validate_rank_world(rank: usize, world_size: usize) -> Result<()> {
+        if world_size == 0 || rank >= world_size {
+            return Err(MahoutError::InvalidInput(format!(
+                "Distributed execution rank {} must be within world size {}",
+                rank, world_size
+            )));
+        }
+
+        Ok(())
     }
 }

--- a/qdp/qdp-core/src/gpu/distributed/context.rs
+++ b/qdp/qdp-core/src/gpu/distributed/context.rs
@@ -82,10 +82,21 @@ impl<'a> DistributedExecutionContext<'a> {
         collectives: &'a dyn CollectiveCommunicator,
     ) -> Result<Self> {
         Self::validate_rank_world(rank, world_size)?;
+        Self::rank_local_with_mesh(rank, world_size, DeviceMesh::new(device_ids)?, collectives)
+    }
+
+    /// Build one rank-local execution context from an already constructed mesh.
+    pub fn rank_local_with_mesh(
+        rank: usize,
+        world_size: usize,
+        mesh: DeviceMesh,
+        collectives: &'a dyn CollectiveCommunicator,
+    ) -> Result<Self> {
+        Self::validate_rank_world(rank, world_size)?;
         Ok(Self {
             rank,
             world_size,
-            mesh: DeviceMesh::new(device_ids)?,
+            mesh,
             collectives,
             device_collectives: None,
         })

--- a/qdp/qdp-core/src/gpu/distributed/layout.rs
+++ b/qdp/qdp-core/src/gpu/distributed/layout.rs
@@ -50,6 +50,7 @@ pub struct DistributedStateLayout {
 
 impl DistributedStateLayout {
     #[cfg(target_os = "linux")]
+    /// Device ID preferred for future gather-style readback operations.
     pub fn recommended_gather_device_id(&self) -> Option<usize> {
         shared::policy_device_ids(
             &self.topology,
@@ -59,6 +60,7 @@ impl DistributedStateLayout {
     }
 
     #[cfg(target_os = "linux")]
+    /// Preferred device ordering derived from the current topology metadata.
     pub fn recommended_placement_device_ids(&self) -> Vec<usize> {
         shared::policy_device_ids(
             &self.topology,
@@ -67,10 +69,13 @@ impl DistributedStateLayout {
         .1
     }
 
+    /// Number of logical shards described by this layout.
     pub fn num_shards(&self) -> usize {
         self.shards.len()
     }
 
+    /// Build one distributed state layout from one execution mesh and one
+    /// distributed amplitude plan.
     pub fn new(
         mesh: &DeviceMesh,
         plan: &DistributedAmplitudePlan,

--- a/qdp/qdp-core/src/gpu/distributed/layout.rs
+++ b/qdp/qdp-core/src/gpu/distributed/layout.rs
@@ -1,0 +1,122 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cudarc::driver::CudaDevice;
+
+use crate::error::{MahoutError, Result};
+use crate::gpu::memory::Precision;
+use crate::gpu::topology::{DeviceMesh, GpuTopology};
+
+use super::DistributedAmplitudePlan;
+use super::shared;
+
+/// One shard of a logically distributed state vector.
+#[derive(Clone)]
+pub struct StateShardLayout {
+    pub device: Arc<CudaDevice>,
+    pub device_id: usize,
+    pub shard_id: usize,
+    pub start_idx: usize,
+    pub end_idx: usize,
+    pub local_len: usize,
+}
+
+/// Metadata and placement plan for a future multi-GPU state vector.
+#[derive(Clone)]
+pub struct DistributedStateLayout {
+    pub num_qubits: usize,
+    pub precision: Precision,
+    pub global_len: usize,
+    pub shard_bits: Option<usize>,
+    pub topology: GpuTopology,
+    pub shards: Vec<StateShardLayout>,
+}
+
+impl DistributedStateLayout {
+    #[cfg(target_os = "linux")]
+    pub fn recommended_gather_device_id(&self) -> Option<usize> {
+        shared::policy_device_ids(
+            &self.topology,
+            self.shards.iter().map(|shard| shard.device_id),
+        )
+        .0
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn recommended_placement_device_ids(&self) -> Vec<usize> {
+        shared::policy_device_ids(
+            &self.topology,
+            self.shards.iter().map(|shard| shard.device_id),
+        )
+        .1
+    }
+
+    pub fn num_shards(&self) -> usize {
+        self.shards.len()
+    }
+
+    pub fn new(
+        mesh: &DeviceMesh,
+        plan: &DistributedAmplitudePlan,
+        precision: Precision,
+    ) -> Result<Self> {
+        if mesh.num_devices() != plan.num_devices {
+            return Err(MahoutError::InvalidInput(format!(
+                "Device mesh / amplitude plan mismatch: {} devices vs {} planned shards",
+                mesh.num_devices(),
+                plan.num_devices
+            )));
+        }
+        if mesh.devices.len() != plan.num_devices {
+            return Err(MahoutError::InvalidInput(format!(
+                "Device mesh / device handles mismatch: {} handles for {} planned shards",
+                mesh.devices.len(),
+                plan.num_devices
+            )));
+        }
+        if plan.placement.placements.len() != plan.num_devices {
+            return Err(MahoutError::InvalidInput(format!(
+                "Placement plan mismatch: {} placements for {} planned shards",
+                plan.placement.placements.len(),
+                plan.num_devices
+            )));
+        }
+
+        let mut shards = Vec::with_capacity(mesh.num_devices());
+        for (placement, device) in plan.placement.placements.iter().zip(mesh.devices.iter()) {
+            let (start_idx, end_idx) = (placement.start_idx, placement.end_idx);
+            shards.push(StateShardLayout {
+                device: Arc::clone(device),
+                device_id: placement.device_id,
+                shard_id: placement.shard_id,
+                start_idx,
+                end_idx,
+                local_len: placement.local_len(),
+            });
+        }
+
+        Ok(Self {
+            num_qubits: plan.num_qubits,
+            precision,
+            global_len: plan.global_len,
+            shard_bits: plan.shard_bits,
+            topology: mesh.topology.clone(),
+            shards,
+        })
+    }
+}

--- a/qdp/qdp-core/src/gpu/distributed/layout.rs
+++ b/qdp/qdp-core/src/gpu/distributed/layout.rs
@@ -36,7 +36,8 @@ pub struct StateShardLayout {
     pub local_len: usize,
 }
 
-/// Metadata and placement plan for a future multi-GPU state vector.
+/// Metadata describing how one distributed state is mapped onto one execution
+/// context.
 #[derive(Clone)]
 pub struct DistributedStateLayout {
     pub num_qubits: usize,
@@ -98,10 +99,10 @@ impl DistributedStateLayout {
         }
 
         let mut shards = Vec::with_capacity(mesh.num_devices());
-        for (placement, device) in plan.placement.placements.iter().zip(mesh.devices.iter()) {
+        for placement in &plan.placement.placements {
             let (start_idx, end_idx) = (placement.start_idx, placement.end_idx);
             shards.push(StateShardLayout {
-                device: Arc::clone(device),
+                device: mesh.device_for_id(placement.device_id)?,
                 device_id: placement.device_id,
                 shard_id: placement.shard_id,
                 start_idx,

--- a/qdp/qdp-core/src/gpu/distributed/layout.rs
+++ b/qdp/qdp-core/src/gpu/distributed/layout.rs
@@ -145,9 +145,8 @@ impl DistributedStateLayout {
             )));
         }
 
-        let placements = plan.placement.placements_for_rank(rank_id);
-        let mut shards = Vec::with_capacity(placements.len());
-        for placement in placements {
+        let mut shards = Vec::with_capacity(plan.num_local_shards(rank_id));
+        for placement in plan.placement.placements_for_rank_iter(rank_id) {
             let (start_idx, end_idx) = (placement.start_idx, placement.end_idx);
             shards.push(StateShardLayout {
                 rank_id: placement.rank_id,

--- a/qdp/qdp-core/src/gpu/distributed/layout.rs
+++ b/qdp/qdp-core/src/gpu/distributed/layout.rs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::fmt;
 use std::sync::Arc;
 
 use cudarc::driver::CudaDevice;
@@ -28,6 +29,7 @@ use super::shared;
 /// One shard of a logically distributed state vector.
 #[derive(Clone)]
 pub struct StateShardLayout {
+    pub rank_id: usize,
     pub device: Arc<CudaDevice>,
     pub device_id: usize,
     pub shard_id: usize,
@@ -36,16 +38,45 @@ pub struct StateShardLayout {
     pub local_len: usize,
 }
 
+impl fmt::Debug for StateShardLayout {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StateShardLayout")
+            .field("rank_id", &self.rank_id)
+            .field("device_id", &self.device_id)
+            .field("shard_id", &self.shard_id)
+            .field("start_idx", &self.start_idx)
+            .field("end_idx", &self.end_idx)
+            .field("local_len", &self.local_len)
+            .finish()
+    }
+}
+
 /// Metadata describing how one distributed state is mapped onto one execution
 /// context.
 #[derive(Clone)]
 pub struct DistributedStateLayout {
+    pub rank_id: usize,
+    pub world_size: usize,
     pub num_qubits: usize,
     pub precision: Precision,
     pub global_len: usize,
     pub shard_bits: Option<usize>,
     pub topology: GpuTopology,
     pub shards: Vec<StateShardLayout>,
+}
+
+impl fmt::Debug for DistributedStateLayout {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("DistributedStateLayout")
+            .field("rank_id", &self.rank_id)
+            .field("world_size", &self.world_size)
+            .field("num_qubits", &self.num_qubits)
+            .field("precision", &self.precision)
+            .field("global_len", &self.global_len)
+            .field("shard_bits", &self.shard_bits)
+            .field("shards", &self.shards)
+            .finish()
+    }
 }
 
 impl DistributedStateLayout {
@@ -81,20 +112,24 @@ impl DistributedStateLayout {
         plan: &DistributedAmplitudePlan,
         precision: Precision,
     ) -> Result<Self> {
-        if mesh.num_devices() != plan.num_devices {
+        Self::new_for_rank(mesh, plan, precision, 0)
+    }
+
+    /// Build one rank-local distributed state layout from placements owned by
+    /// `rank_id`.
+    pub fn new_for_rank(
+        mesh: &DeviceMesh,
+        plan: &DistributedAmplitudePlan,
+        precision: Precision,
+        rank_id: usize,
+    ) -> Result<Self> {
+        if rank_id >= plan.request.world_size {
             return Err(MahoutError::InvalidInput(format!(
-                "Device mesh / amplitude plan mismatch: {} devices vs {} planned shards",
-                mesh.num_devices(),
-                plan.num_devices
+                "rank {} is out of range for world size {}",
+                rank_id, plan.request.world_size
             )));
         }
-        if mesh.devices.len() != plan.num_devices {
-            return Err(MahoutError::InvalidInput(format!(
-                "Device mesh / device handles mismatch: {} handles for {} planned shards",
-                mesh.devices.len(),
-                plan.num_devices
-            )));
-        }
+
         if plan.placement.placements.len() != plan.num_devices {
             return Err(MahoutError::InvalidInput(format!(
                 "Placement plan mismatch: {} placements for {} planned shards",
@@ -102,11 +137,20 @@ impl DistributedStateLayout {
                 plan.num_devices
             )));
         }
+        if mesh.devices.len() != mesh.device_ids.len() {
+            return Err(MahoutError::InvalidInput(format!(
+                "Device mesh / device handles mismatch: {} handles for {} device IDs",
+                mesh.devices.len(),
+                mesh.device_ids.len()
+            )));
+        }
 
-        let mut shards = Vec::with_capacity(mesh.num_devices());
-        for placement in &plan.placement.placements {
+        let placements = plan.placement.placements_for_rank(rank_id);
+        let mut shards = Vec::with_capacity(placements.len());
+        for placement in placements {
             let (start_idx, end_idx) = (placement.start_idx, placement.end_idx);
             shards.push(StateShardLayout {
+                rank_id: placement.rank_id,
                 device: mesh.device_for_id(placement.device_id)?,
                 device_id: placement.device_id,
                 shard_id: placement.shard_id,
@@ -117,6 +161,8 @@ impl DistributedStateLayout {
         }
 
         Ok(Self {
+            rank_id,
+            world_size: plan.request.world_size,
             num_qubits: plan.num_qubits,
             precision,
             global_len: plan.global_len,

--- a/qdp/qdp-core/src/gpu/distributed/layout.rs
+++ b/qdp/qdp-core/src/gpu/distributed/layout.rs
@@ -23,7 +23,7 @@ use crate::error::{MahoutError, Result};
 use crate::gpu::memory::Precision;
 use crate::gpu::topology::{DeviceMesh, GpuTopology};
 
-use super::DistributedAmplitudePlan;
+use super::DistributedStatePlan;
 use super::shared;
 
 /// One shard of a logically distributed state vector.
@@ -62,7 +62,7 @@ pub struct DistributedStateLayout {
     pub global_len: usize,
     pub shard_bits: Option<usize>,
     pub topology: GpuTopology,
-    pub shards: Vec<StateShardLayout>,
+    shards: Vec<StateShardLayout>,
 }
 
 impl fmt::Debug for DistributedStateLayout {
@@ -105,11 +105,25 @@ impl DistributedStateLayout {
         self.shards.len()
     }
 
+    /// Borrow all rank-local shard layout records.
+    pub fn shards(&self) -> &[StateShardLayout] {
+        &self.shards
+    }
+
+    /// Iterate over rank-local shard layout records.
+    pub fn iter_shards(&self) -> impl Iterator<Item = &StateShardLayout> {
+        self.shards.iter()
+    }
+
+    pub(crate) fn into_shards(self) -> Vec<StateShardLayout> {
+        self.shards
+    }
+
     /// Build one distributed state layout from one execution mesh and one
-    /// distributed amplitude plan.
+    /// distributed state plan.
     pub fn new(
         mesh: &DeviceMesh,
-        plan: &DistributedAmplitudePlan,
+        plan: &(impl AsRef<DistributedStatePlan> + ?Sized),
         precision: Precision,
     ) -> Result<Self> {
         Self::new_for_rank(mesh, plan, precision, 0)
@@ -119,34 +133,23 @@ impl DistributedStateLayout {
     /// `rank_id`.
     pub fn new_for_rank(
         mesh: &DeviceMesh,
-        plan: &DistributedAmplitudePlan,
+        plan: &(impl AsRef<DistributedStatePlan> + ?Sized),
         precision: Precision,
         rank_id: usize,
     ) -> Result<Self> {
-        if rank_id >= plan.request.world_size {
+        let plan = plan.as_ref();
+        if rank_id >= plan.request().world_size {
             return Err(MahoutError::InvalidInput(format!(
                 "rank {} is out of range for world size {}",
-                rank_id, plan.request.world_size
+                rank_id,
+                plan.request().world_size
             )));
         }
 
-        if plan.placement.placements.len() != plan.num_devices {
-            return Err(MahoutError::InvalidInput(format!(
-                "Placement plan mismatch: {} placements for {} planned shards",
-                plan.placement.placements.len(),
-                plan.num_devices
-            )));
-        }
-        if mesh.devices.len() != mesh.device_ids.len() {
-            return Err(MahoutError::InvalidInput(format!(
-                "Device mesh / device handles mismatch: {} handles for {} device IDs",
-                mesh.devices.len(),
-                mesh.device_ids.len()
-            )));
-        }
+        plan.validate_against_mesh(mesh)?;
 
         let mut shards = Vec::with_capacity(plan.num_local_shards(rank_id));
-        for placement in plan.placement.placements_for_rank_iter(rank_id) {
+        for placement in plan.placements_for_rank_iter(rank_id) {
             let (start_idx, end_idx) = (placement.start_idx, placement.end_idx);
             shards.push(StateShardLayout {
                 rank_id: placement.rank_id,
@@ -161,7 +164,7 @@ impl DistributedStateLayout {
 
         Ok(Self {
             rank_id,
-            world_size: plan.request.world_size,
+            world_size: plan.request().world_size,
             num_qubits: plan.num_qubits,
             precision,
             global_len: plan.global_len,

--- a/qdp/qdp-core/src/gpu/distributed/layout.rs
+++ b/qdp/qdp-core/src/gpu/distributed/layout.rs
@@ -119,16 +119,6 @@ impl DistributedStateLayout {
         self.shards
     }
 
-    /// Build one distributed state layout from one execution mesh and one
-    /// distributed state plan.
-    pub fn new(
-        mesh: &DeviceMesh,
-        plan: &(impl AsRef<DistributedStatePlan> + ?Sized),
-        precision: Precision,
-    ) -> Result<Self> {
-        Self::new_for_rank(mesh, plan, precision, 0)
-    }
-
     /// Build one rank-local distributed state layout from placements owned by
     /// `rank_id`.
     pub fn new_for_rank(

--- a/qdp/qdp-core/src/gpu/distributed/mod.rs
+++ b/qdp/qdp-core/src/gpu/distributed/mod.rs
@@ -1,0 +1,30 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod amplitude;
+mod layout;
+mod planner;
+pub(crate) mod runtime;
+mod shared;
+mod state;
+
+pub use amplitude::{DistributedAmplitudePlan, PreparedDistributedAmplitudeEncode};
+pub use layout::{DistributedStateLayout, StateShardLayout};
+pub use planner::{
+    DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest, ShardPlacement,
+    ShardPolicy,
+};
+pub use state::{DistributedStateVector, StateShard};

--- a/qdp/qdp-core/src/gpu/distributed/mod.rs
+++ b/qdp/qdp-core/src/gpu/distributed/mod.rs
@@ -15,6 +15,7 @@
 // limitations under the License.
 
 mod amplitude;
+mod context;
 mod layout;
 mod planner;
 pub(crate) mod runtime;
@@ -22,6 +23,7 @@ mod shared;
 mod state;
 
 pub use amplitude::{DistributedAmplitudePlan, PreparedDistributedAmplitudeEncode};
+pub use context::DistributedExecutionContext;
 pub use layout::{DistributedStateLayout, StateShardLayout};
 pub use planner::{
     DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest, ShardPlacement,

--- a/qdp/qdp-core/src/gpu/distributed/mod.rs
+++ b/qdp/qdp-core/src/gpu/distributed/mod.rs
@@ -21,6 +21,7 @@ mod planner;
 pub(crate) mod runtime;
 mod shared;
 mod state;
+mod state_plan;
 
 pub use amplitude::{DistributedAmplitudePlan, PreparedDistributedAmplitudeEncode};
 pub use context::DistributedExecutionContext;
@@ -30,3 +31,4 @@ pub use planner::{
     ShardPolicy,
 };
 pub use state::{DistributedStateVector, LocalShardView, StateShard};
+pub use state_plan::DistributedStatePlan;

--- a/qdp/qdp-core/src/gpu/distributed/mod.rs
+++ b/qdp/qdp-core/src/gpu/distributed/mod.rs
@@ -29,4 +29,4 @@ pub use planner::{
     DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest, ShardPlacement,
     ShardPolicy,
 };
-pub use state::{DistributedStateVector, StateShard};
+pub use state::{DistributedStateVector, LocalShardView, StateShard};

--- a/qdp/qdp-core/src/gpu/distributed/planner.rs
+++ b/qdp/qdp-core/src/gpu/distributed/planner.rs
@@ -17,7 +17,7 @@
 use crate::error::{MahoutError, Result};
 use crate::gpu::topology::DeviceMesh;
 
-/// Runtime distribution modes for future multi-GPU state construction.
+/// Runtime distribution modes for distributed state construction.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum DistributionMode {
     Single,
@@ -78,7 +78,8 @@ impl ShardPlacement {
     }
 }
 
-/// Planner output consumed by distributed encoders and future gather/export APIs.
+/// Planner output consumed by distributed encoders and by any later
+/// gather/export layer that needs stable shard ranges.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PlacementPlan {
     pub mode: DistributionMode,

--- a/qdp/qdp-core/src/gpu/distributed/planner.rs
+++ b/qdp/qdp-core/src/gpu/distributed/planner.rs
@@ -45,6 +45,7 @@ pub struct PlacementRequest {
 }
 
 impl PlacementRequest {
+    /// Create one placement request for one logical distributed state.
     pub fn new(num_qubits: usize, mode: DistributionMode, shard_policy: ShardPolicy) -> Self {
         Self {
             num_qubits,
@@ -53,6 +54,7 @@ impl PlacementRequest {
         }
     }
 
+    /// Compute the global amplitude length implied by `num_qubits`.
     pub fn global_len(&self) -> Result<usize> {
         1usize.checked_shl(self.num_qubits as u32).ok_or_else(|| {
             MahoutError::InvalidInput(format!(
@@ -73,6 +75,7 @@ pub struct ShardPlacement {
 }
 
 impl ShardPlacement {
+    /// Number of amplitudes assigned to this shard.
     pub fn local_len(&self) -> usize {
         self.end_idx - self.start_idx
     }
@@ -89,10 +92,12 @@ pub struct PlacementPlan {
 }
 
 impl PlacementPlan {
+    /// Number of participating devices in this placement plan.
     pub fn num_devices(&self) -> usize {
         self.placements.len()
     }
 
+    /// Return the common shard length when every shard is evenly sized.
     pub fn shard_len(&self) -> Result<usize> {
         let Some(first) = self.placements.first() else {
             return Err(MahoutError::InvalidInput(
@@ -118,6 +123,7 @@ impl PlacementPlan {
 pub struct PlacementPlanner;
 
 impl PlacementPlanner {
+    /// Build one placement plan from one validated device mesh and request.
     pub fn plan(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<PlacementPlan> {
         if mesh.num_devices() == 0 {
             return Err(MahoutError::InvalidInput(

--- a/qdp/qdp-core/src/gpu/distributed/planner.rs
+++ b/qdp/qdp-core/src/gpu/distributed/planner.rs
@@ -1,0 +1,247 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::{MahoutError, Result};
+use crate::gpu::topology::DeviceMesh;
+
+/// Runtime distribution modes for future multi-GPU state construction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DistributionMode {
+    Single,
+    ShardedCapacity,
+    Replicated,
+}
+
+/// Placement policy for slicing the logical output state across devices.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ShardPolicy {
+    /// Evenly partition the logical state into contiguous shards.
+    ///
+    /// Because the global state length is always `2^n`, equal-width integer
+    /// shards are only possible for power-of-two device counts.
+    Equal,
+    BalancedUneven,
+}
+
+/// Planner input describing the logical distributed state request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlacementRequest {
+    pub num_qubits: usize,
+    pub mode: DistributionMode,
+    pub shard_policy: ShardPolicy,
+}
+
+impl PlacementRequest {
+    pub fn new(num_qubits: usize, mode: DistributionMode, shard_policy: ShardPolicy) -> Self {
+        Self {
+            num_qubits,
+            mode,
+            shard_policy,
+        }
+    }
+
+    pub fn global_len(&self) -> Result<usize> {
+        1usize.checked_shl(self.num_qubits as u32).ok_or_else(|| {
+            MahoutError::InvalidInput(format!(
+                "Global amplitude length overflow for {} qubits",
+                self.num_qubits
+            ))
+        })
+    }
+}
+
+/// One logical placement decision produced by the planner.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ShardPlacement {
+    pub device_id: usize,
+    pub shard_id: usize,
+    pub start_idx: usize,
+    pub end_idx: usize,
+}
+
+impl ShardPlacement {
+    pub fn local_len(&self) -> usize {
+        self.end_idx - self.start_idx
+    }
+}
+
+/// Planner output consumed by distributed encoders and future gather/export APIs.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PlacementPlan {
+    pub mode: DistributionMode,
+    pub global_len: usize,
+    pub placements: Vec<ShardPlacement>,
+    pub gather_device_id: Option<usize>,
+}
+
+impl PlacementPlan {
+    pub fn num_devices(&self) -> usize {
+        self.placements.len()
+    }
+
+    pub fn shard_len(&self) -> Result<usize> {
+        let Some(first) = self.placements.first() else {
+            return Err(MahoutError::InvalidInput(
+                "Placement plan must contain at least one shard".to_string(),
+            ));
+        };
+        let shard_len = first.local_len();
+        if self
+            .placements
+            .iter()
+            .any(|placement| placement.local_len() != shard_len)
+        {
+            return Err(MahoutError::InvalidInput(
+                "Placement plan contains uneven shard lengths".to_string(),
+            ));
+        }
+        Ok(shard_len)
+    }
+}
+
+/// Stateless planner for device placement decisions.
+#[derive(Clone, Debug, Default)]
+pub struct PlacementPlanner;
+
+impl PlacementPlanner {
+    pub fn plan(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<PlacementPlan> {
+        if mesh.num_devices() == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Placement planner requires at least one device".to_string(),
+            ));
+        }
+
+        let global_len = request.global_len()?;
+        match request.mode {
+            DistributionMode::Single => {
+                let device_ids = Self::select_device_ids(mesh, request)?;
+                let device_id = *device_ids.first().ok_or_else(|| {
+                    MahoutError::InvalidInput(
+                        "Single-device placement requires one device ID".to_string(),
+                    )
+                })?;
+                Ok(PlacementPlan {
+                    mode: request.mode,
+                    global_len,
+                    placements: vec![ShardPlacement {
+                        device_id,
+                        shard_id: 0,
+                        start_idx: 0,
+                        end_idx: global_len,
+                    }],
+                    gather_device_id: Some(device_id),
+                })
+            }
+            DistributionMode::ShardedCapacity => {
+                let device_ids = Self::select_device_ids(mesh, request)?;
+                let shard_lengths =
+                    Self::plan_shard_lengths(global_len, device_ids.len(), request.shard_policy)?;
+                let placements = Self::build_shard_placements(&device_ids, &shard_lengths);
+
+                Ok(PlacementPlan {
+                    mode: request.mode,
+                    global_len,
+                    placements,
+                    gather_device_id: mesh.recommended_gather_device_id(),
+                })
+            }
+            DistributionMode::Replicated => Err(MahoutError::NotImplemented(
+                "Replicated placement is not implemented yet".to_string(),
+            )),
+        }
+    }
+
+    fn select_device_ids(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<Vec<usize>> {
+        match request.mode {
+            DistributionMode::Single => mesh
+                .device_ids
+                .first()
+                .copied()
+                .map(|device_id| vec![device_id])
+                .ok_or_else(|| {
+                    MahoutError::InvalidInput(
+                        "Single-device placement requires one device ID".to_string(),
+                    )
+                }),
+            DistributionMode::ShardedCapacity => {
+                let recommended = mesh.recommended_placement_device_ids();
+                if recommended.is_empty() {
+                    Ok(mesh.device_ids.clone())
+                } else {
+                    Ok(recommended)
+                }
+            }
+            DistributionMode::Replicated => Err(MahoutError::NotImplemented(
+                "Replicated placement is not implemented yet".to_string(),
+            )),
+        }
+    }
+
+    fn plan_shard_lengths(
+        global_len: usize,
+        num_devices: usize,
+        shard_policy: ShardPolicy,
+    ) -> Result<Vec<usize>> {
+        if num_devices == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Shard planning requires at least one device".to_string(),
+            ));
+        }
+
+        match shard_policy {
+            ShardPolicy::Equal => {
+                if !num_devices.is_power_of_two() {
+                    return Err(MahoutError::InvalidInput(format!(
+                        "Equal shard policy requires a power-of-two device count, got {}",
+                        num_devices
+                    )));
+                }
+                Ok(vec![global_len / num_devices; num_devices])
+            }
+            ShardPolicy::BalancedUneven => {
+                let base_len = global_len / num_devices;
+                let remainder = global_len % num_devices;
+                Ok((0..num_devices)
+                    .map(|shard_id| base_len + usize::from(shard_id < remainder))
+                    .collect())
+            }
+        }
+    }
+
+    fn build_shard_placements(
+        device_ids: &[usize],
+        shard_lengths: &[usize],
+    ) -> Vec<ShardPlacement> {
+        let mut start_idx = 0usize;
+        device_ids
+            .iter()
+            .copied()
+            .zip(shard_lengths.iter().copied())
+            .enumerate()
+            .map(|(shard_id, (device_id, local_len))| {
+                let end_idx = start_idx + local_len;
+                let placement = ShardPlacement {
+                    device_id,
+                    shard_id,
+                    start_idx,
+                    end_idx,
+                };
+                start_idx = end_idx;
+                placement
+            })
+            .collect()
+    }
+}

--- a/qdp/qdp-core/src/gpu/distributed/planner.rs
+++ b/qdp/qdp-core/src/gpu/distributed/planner.rs
@@ -42,6 +42,7 @@ pub struct PlacementRequest {
     pub num_qubits: usize,
     pub mode: DistributionMode,
     pub shard_policy: ShardPolicy,
+    pub world_size: usize,
 }
 
 impl PlacementRequest {
@@ -51,7 +52,29 @@ impl PlacementRequest {
             num_qubits,
             mode,
             shard_policy,
+            world_size: 1,
         }
+    }
+
+    /// Create one placement request with explicit rank-world metadata.
+    pub fn new_with_world(
+        num_qubits: usize,
+        mode: DistributionMode,
+        shard_policy: ShardPolicy,
+        world_size: usize,
+    ) -> Result<Self> {
+        if world_size == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Distributed placement world size must be at least 1".to_string(),
+            ));
+        }
+
+        Ok(Self {
+            num_qubits,
+            mode,
+            shard_policy,
+            world_size,
+        })
     }
 
     /// Compute the global amplitude length implied by `num_qubits`.
@@ -68,6 +91,7 @@ impl PlacementRequest {
 /// One logical placement decision produced by the planner.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ShardPlacement {
+    pub rank_id: usize,
     pub device_id: usize,
     pub shard_id: usize,
     pub start_idx: usize,
@@ -116,6 +140,28 @@ impl PlacementPlan {
         }
         Ok(shard_len)
     }
+
+    /// Return all placements owned by one rank.
+    pub fn placements_for_rank(&self, rank: usize) -> Vec<&ShardPlacement> {
+        self.placements
+            .iter()
+            .filter(|placement| placement.rank_id == rank)
+            .collect()
+    }
+
+    /// Number of shards owned by one rank.
+    pub fn num_local_shards(&self, rank: usize) -> usize {
+        self.placements_for_rank(rank).len()
+    }
+
+    /// Largest shard length owned by one rank.
+    pub fn local_max_len(&self, rank: usize) -> usize {
+        self.placements_for_rank(rank)
+            .into_iter()
+            .map(ShardPlacement::local_len)
+            .max()
+            .unwrap_or(0)
+    }
 }
 
 /// Stateless planner for device placement decisions.
@@ -144,6 +190,7 @@ impl PlacementPlanner {
                     mode: request.mode,
                     global_len,
                     placements: vec![ShardPlacement {
+                        rank_id: 0,
                         device_id,
                         shard_id: 0,
                         start_idx: 0,
@@ -156,7 +203,8 @@ impl PlacementPlanner {
                 let device_ids = Self::select_device_ids(mesh, request)?;
                 let shard_lengths =
                     Self::plan_shard_lengths(global_len, device_ids.len(), request.shard_policy)?;
-                let placements = Self::build_shard_placements(&device_ids, &shard_lengths);
+                let placements =
+                    Self::build_shard_placements(&device_ids, &shard_lengths, request.world_size);
 
                 Ok(PlacementPlan {
                     mode: request.mode,
@@ -231,6 +279,7 @@ impl PlacementPlanner {
     fn build_shard_placements(
         device_ids: &[usize],
         shard_lengths: &[usize],
+        world_size: usize,
     ) -> Vec<ShardPlacement> {
         let mut start_idx = 0usize;
         device_ids
@@ -241,6 +290,7 @@ impl PlacementPlanner {
             .map(|(shard_id, (device_id, local_len))| {
                 let end_idx = start_idx + local_len;
                 let placement = ShardPlacement {
+                    rank_id: shard_id % world_size,
                     device_id,
                     shard_id,
                     start_idx,

--- a/qdp/qdp-core/src/gpu/distributed/planner.rs
+++ b/qdp/qdp-core/src/gpu/distributed/planner.rs
@@ -141,23 +141,21 @@ impl PlacementPlan {
         Ok(shard_len)
     }
 
-    /// Return all placements owned by one rank.
-    pub fn placements_for_rank(&self, rank: usize) -> Vec<&ShardPlacement> {
+    /// Iterate over placements owned by one rank without allocating.
+    pub fn placements_for_rank_iter(&self, rank: usize) -> impl Iterator<Item = &ShardPlacement> {
         self.placements
             .iter()
-            .filter(|placement| placement.rank_id == rank)
-            .collect()
+            .filter(move |placement| placement.rank_id == rank)
     }
 
     /// Number of shards owned by one rank.
-    pub fn num_local_shards(&self, rank: usize) -> usize {
-        self.placements_for_rank(rank).len()
+    pub(crate) fn num_local_shards(&self, rank: usize) -> usize {
+        self.placements_for_rank_iter(rank).count()
     }
 
     /// Largest shard length owned by one rank.
     pub fn local_max_len(&self, rank: usize) -> usize {
-        self.placements_for_rank(rank)
-            .into_iter()
+        self.placements_for_rank_iter(rank)
             .map(ShardPlacement::local_len)
             .max()
             .unwrap_or(0)
@@ -171,23 +169,12 @@ pub struct PlacementPlanner;
 impl PlacementPlanner {
     /// Build one placement plan from one validated device mesh and request.
     pub fn plan(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<PlacementPlan> {
-        if request.world_size == 0 {
-            return Err(MahoutError::InvalidInput(
-                "Distributed placement world size must be at least 1".to_string(),
-            ));
-        }
-
-        if mesh.num_devices() == 0 {
-            return Err(MahoutError::InvalidInput(
-                "Placement planner requires at least one device".to_string(),
-            ));
-        }
+        Self::validate_inputs(mesh, request)?;
 
         let global_len = request.global_len()?;
         match request.mode {
             DistributionMode::Single => {
-                let device_ids = Self::select_device_ids(mesh, request)?;
-                let device_id = *device_ids.first().ok_or_else(|| {
+                let device_id = mesh.device_ids.first().copied().ok_or_else(|| {
                     MahoutError::InvalidInput(
                         "Single-device placement requires one device ID".to_string(),
                     )
@@ -206,7 +193,7 @@ impl PlacementPlanner {
                 })
             }
             DistributionMode::ShardedCapacity => {
-                let device_ids = Self::select_device_ids(mesh, request)?;
+                let device_ids = Self::select_sharded_device_ids(mesh);
                 let shard_lengths =
                     Self::plan_shard_lengths(global_len, device_ids.len(), request.shard_policy)?;
                 let placements =
@@ -231,24 +218,14 @@ impl PlacementPlanner {
     /// local devices `[0, 1]` in a two-rank world, the rank/device sequence is
     /// `(0, 0), (1, 0), (0, 1), (1, 1)`.
     pub fn plan_rank_local(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<PlacementPlan> {
-        if request.world_size == 0 {
-            return Err(MahoutError::InvalidInput(
-                "Distributed placement world size must be at least 1".to_string(),
-            ));
-        }
-
-        if mesh.num_devices() == 0 {
-            return Err(MahoutError::InvalidInput(
-                "Placement planner requires at least one device".to_string(),
-            ));
-        }
+        Self::validate_inputs(mesh, request)?;
 
         if request.mode != DistributionMode::ShardedCapacity {
             return Self::plan(mesh, request);
         }
 
         let global_len = request.global_len()?;
-        let device_ids = Self::select_device_ids(mesh, request)?;
+        let device_ids = Self::select_sharded_device_ids(mesh);
         let total_shards = device_ids
             .len()
             .checked_mul(request.world_size)
@@ -275,29 +252,28 @@ impl PlacementPlanner {
         })
     }
 
-    fn select_device_ids(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<Vec<usize>> {
-        match request.mode {
-            DistributionMode::Single => mesh
-                .device_ids
-                .first()
-                .copied()
-                .map(|device_id| vec![device_id])
-                .ok_or_else(|| {
-                    MahoutError::InvalidInput(
-                        "Single-device placement requires one device ID".to_string(),
-                    )
-                }),
-            DistributionMode::ShardedCapacity => {
-                let recommended = mesh.recommended_placement_device_ids();
-                if recommended.is_empty() {
-                    Ok(mesh.device_ids.clone())
-                } else {
-                    Ok(recommended)
-                }
-            }
-            DistributionMode::Replicated => Err(MahoutError::NotImplemented(
-                "Replicated placement is not implemented yet".to_string(),
-            )),
+    fn validate_inputs(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<()> {
+        if request.world_size == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Distributed placement world size must be at least 1".to_string(),
+            ));
+        }
+
+        if mesh.num_devices() == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Placement planner requires at least one device".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn select_sharded_device_ids(mesh: &DeviceMesh) -> Vec<usize> {
+        let recommended = mesh.recommended_placement_device_ids();
+        if recommended.is_empty() {
+            mesh.device_ids.clone()
+        } else {
+            recommended
         }
     }
 

--- a/qdp/qdp-core/src/gpu/distributed/planner.rs
+++ b/qdp/qdp-core/src/gpu/distributed/planner.rs
@@ -77,11 +77,11 @@ impl PlacementRequest {
         })
     }
 
-    /// Compute the global amplitude length implied by `num_qubits`.
+    /// Compute the global state-vector length implied by `num_qubits`.
     pub fn global_len(&self) -> Result<usize> {
         1usize.checked_shl(self.num_qubits as u32).ok_or_else(|| {
             MahoutError::InvalidInput(format!(
-                "Global amplitude length overflow for {} qubits",
+                "Global state-vector length overflow for {} qubits",
                 self.num_qubits
             ))
         })
@@ -99,7 +99,7 @@ pub struct ShardPlacement {
 }
 
 impl ShardPlacement {
-    /// Number of amplitudes assigned to this shard.
+    /// Number of state-vector entries assigned to this shard.
     pub fn local_len(&self) -> usize {
         self.end_idx - self.start_idx
     }

--- a/qdp/qdp-core/src/gpu/distributed/planner.rs
+++ b/qdp/qdp-core/src/gpu/distributed/planner.rs
@@ -225,6 +225,56 @@ impl PlacementPlanner {
         }
     }
 
+    /// Build a global placement plan from one rank's local device mesh.
+    ///
+    /// Placements are emitted shard-major by local device, then rank. For
+    /// local devices `[0, 1]` in a two-rank world, the rank/device sequence is
+    /// `(0, 0), (1, 0), (0, 1), (1, 1)`.
+    pub fn plan_rank_local(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<PlacementPlan> {
+        if request.world_size == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Distributed placement world size must be at least 1".to_string(),
+            ));
+        }
+
+        if mesh.num_devices() == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Placement planner requires at least one device".to_string(),
+            ));
+        }
+
+        if request.mode != DistributionMode::ShardedCapacity {
+            return Self::plan(mesh, request);
+        }
+
+        let global_len = request.global_len()?;
+        let device_ids = Self::select_device_ids(mesh, request)?;
+        let total_shards = device_ids
+            .len()
+            .checked_mul(request.world_size)
+            .ok_or_else(|| {
+                MahoutError::InvalidInput(format!(
+                    "Rank-local shard count overflowed for {} devices across world size {}",
+                    device_ids.len(),
+                    request.world_size
+                ))
+            })?;
+        let shard_lengths =
+            Self::plan_shard_lengths(global_len, total_shards, request.shard_policy)?;
+        let placements = Self::build_rank_local_shard_placements(
+            &device_ids,
+            &shard_lengths,
+            request.world_size,
+        );
+
+        Ok(PlacementPlan {
+            mode: request.mode,
+            global_len,
+            placements,
+            gather_device_id: mesh.recommended_gather_device_id(),
+        })
+    }
+
     fn select_device_ids(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<Vec<usize>> {
         match request.mode {
             DistributionMode::Single => mesh
@@ -297,6 +347,33 @@ impl PlacementPlanner {
                 let end_idx = start_idx + local_len;
                 let placement = ShardPlacement {
                     rank_id: shard_id % world_size,
+                    device_id,
+                    shard_id,
+                    start_idx,
+                    end_idx,
+                };
+                start_idx = end_idx;
+                placement
+            })
+            .collect()
+    }
+
+    fn build_rank_local_shard_placements(
+        device_ids: &[usize],
+        shard_lengths: &[usize],
+        world_size: usize,
+    ) -> Vec<ShardPlacement> {
+        let mut start_idx = 0usize;
+        device_ids
+            .iter()
+            .copied()
+            .flat_map(|device_id| (0..world_size).map(move |rank_id| (rank_id, device_id)))
+            .zip(shard_lengths.iter().copied())
+            .enumerate()
+            .map(|(shard_id, ((rank_id, device_id), local_len))| {
+                let end_idx = start_idx + local_len;
+                let placement = ShardPlacement {
+                    rank_id,
                     device_id,
                     shard_id,
                     start_idx,

--- a/qdp/qdp-core/src/gpu/distributed/planner.rs
+++ b/qdp/qdp-core/src/gpu/distributed/planner.rs
@@ -171,6 +171,12 @@ pub struct PlacementPlanner;
 impl PlacementPlanner {
     /// Build one placement plan from one validated device mesh and request.
     pub fn plan(mesh: &DeviceMesh, request: &PlacementRequest) -> Result<PlacementPlan> {
+        if request.world_size == 0 {
+            return Err(MahoutError::InvalidInput(
+                "Distributed placement world size must be at least 1".to_string(),
+            ));
+        }
+
         if mesh.num_devices() == 0 {
             return Err(MahoutError::InvalidInput(
                 "Placement planner requires at least one device".to_string(),

--- a/qdp/qdp-core/src/gpu/distributed/planner.rs
+++ b/qdp/qdp-core/src/gpu/distributed/planner.rs
@@ -148,11 +148,6 @@ impl PlacementPlan {
             .filter(move |placement| placement.rank_id == rank)
     }
 
-    /// Number of shards owned by one rank.
-    pub(crate) fn num_local_shards(&self, rank: usize) -> usize {
-        self.placements_for_rank_iter(rank).count()
-    }
-
     /// Largest shard length owned by one rank.
     pub fn local_max_len(&self, rank: usize) -> usize {
         self.placements_for_rank_iter(rank)

--- a/qdp/qdp-core/src/gpu/distributed/runtime.rs
+++ b/qdp/qdp-core/src/gpu/distributed/runtime.rs
@@ -19,11 +19,12 @@ use std::sync::Arc;
 #[cfg(target_os = "linux")]
 use crate::error::cuda_error_to_string;
 use crate::error::{MahoutError, Result};
-use crate::gpu::communicator::Communicator;
+#[cfg(target_os = "linux")]
+use crate::gpu::cuda_ffi::{CUDA_SUCCESS, cudaGetDevice, cudaSetDevice};
+use crate::gpu::distributed::DistributedExecutionContext;
 #[cfg(target_os = "linux")]
 use crate::gpu::memory::{BufferStorage, GpuBufferRaw};
 use crate::gpu::memory::{Precision, ensure_device_memory_available, map_allocation_error};
-use crate::gpu::topology::DeviceMesh;
 use crate::gpu::{
     DistributedAmplitudePlan, DistributedStateLayout, DistributedStateVector, PlacementRequest,
 };
@@ -35,6 +36,45 @@ use qdp_kernels::{
 };
 #[cfg(target_os = "linux")]
 use std::ffi::c_void;
+
+#[cfg(target_os = "linux")]
+struct DistributedDeviceContextGuard {
+    original_device: i32,
+}
+
+#[cfg(target_os = "linux")]
+impl DistributedDeviceContextGuard {
+    fn switch_to(device_id: usize) -> Result<Self> {
+        let mut original_device = 0i32;
+        let get_ret = unsafe { cudaGetDevice(&mut original_device as *mut i32) };
+        if get_ret != CUDA_SUCCESS {
+            return Err(MahoutError::Cuda(format!(
+                "cudaGetDevice failed before distributed shard launch: {} ({})",
+                get_ret,
+                cuda_error_to_string(get_ret)
+            )));
+        }
+
+        let set_ret = unsafe { cudaSetDevice(device_id as i32) };
+        if set_ret != CUDA_SUCCESS {
+            return Err(MahoutError::Cuda(format!(
+                "cudaSetDevice(cuda:{}) failed before distributed shard launch: {} ({})",
+                device_id,
+                set_ret,
+                cuda_error_to_string(set_ret)
+            )));
+        }
+
+        Ok(Self { original_device })
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for DistributedDeviceContextGuard {
+    fn drop(&mut self) {
+        let _ = unsafe { cudaSetDevice(self.original_device) };
+    }
+}
 
 pub(crate) fn validate_distributed_input(
     host_data: &[f64],
@@ -65,12 +105,12 @@ pub(crate) fn validate_distributed_input(
 }
 
 pub(crate) fn plan_distributed_encode(
-    mesh: &DeviceMesh,
+    execution: &DistributedExecutionContext<'_>,
     host_data: &[f64],
     request: PlacementRequest,
 ) -> Result<DistributedAmplitudePlan> {
     validate_distributed_input(host_data, &request)?;
-    DistributedAmplitudePlan::for_request(mesh, request)
+    DistributedAmplitudePlan::for_request(execution.mesh(), request)
 }
 
 pub(crate) fn calculate_local_norm_sq(
@@ -105,7 +145,7 @@ pub(crate) fn calculate_local_norm_sq(
 pub(crate) fn calculate_inv_norm_distributed(
     plan: &DistributedAmplitudePlan,
     host_data: &[f64],
-    communicator: &dyn Communicator,
+    execution: &DistributedExecutionContext<'_>,
 ) -> Result<f64> {
     let mut partials = Vec::with_capacity(plan.num_devices);
     for shard_id in 0..plan.num_devices {
@@ -113,7 +153,7 @@ pub(crate) fn calculate_inv_norm_distributed(
         partials.push(calculate_local_norm_sq(host_data, start_idx, end_idx)?);
     }
 
-    let global_norm_sq = communicator.reduce_sum_f64(&partials)?;
+    let global_norm_sq = execution.collectives().all_reduce_sum_f64(&partials)?;
     if global_norm_sq <= 0.0 || !global_norm_sq.is_finite() {
         return Err(MahoutError::InvalidInput(
             "Input data has zero or non-finite norm (contains NaN, Inf, or all zeros)".to_string(),
@@ -124,33 +164,33 @@ pub(crate) fn calculate_inv_norm_distributed(
 }
 
 pub(crate) fn prepare_distributed_encode(
-    mesh: &DeviceMesh,
+    execution: &DistributedExecutionContext<'_>,
     host_data: &[f64],
     precision: Precision,
     request: PlacementRequest,
-    communicator: &dyn Communicator,
 ) -> Result<(DistributedAmplitudePlan, f64, DistributedStateLayout)> {
-    let plan = plan_distributed_encode(mesh, host_data, request)?;
-    let inv_norm = calculate_inv_norm_distributed(&plan, host_data, communicator)?;
-    let layout = DistributedStateLayout::new(mesh, &plan, precision)?;
+    let plan = plan_distributed_encode(execution, host_data, request)?;
+    let inv_norm = calculate_inv_norm_distributed(&plan, host_data, execution)?;
+    let layout = DistributedStateLayout::new(execution.mesh(), &plan, precision)?;
     Ok((plan, inv_norm, layout))
 }
 
 #[cfg(target_os = "linux")]
 pub(crate) fn encode_distributed_to_shards(
-    mesh: &DeviceMesh,
+    execution: &DistributedExecutionContext<'_>,
     host_data: &[f64],
     precision: Precision,
     request: PlacementRequest,
-    communicator: &dyn Communicator,
 ) -> Result<DistributedStateVector> {
     let (plan, inv_norm, layout) =
-        prepare_distributed_encode(mesh, host_data, precision, request, communicator)?;
+        prepare_distributed_encode(execution, host_data, precision, request)?;
     let num_qubits = plan.request.num_qubits;
 
     let mut buffers = Vec::with_capacity(plan.num_devices);
-    for (shard_id, device) in mesh.devices.iter().enumerate() {
-        let (start_idx, end_idx) = plan.shard_range(shard_id)?;
+    for placement in &plan.placement.placements {
+        let device = execution.mesh().device_for_id(placement.device_id)?;
+        let _device_guard = DistributedDeviceContextGuard::switch_to(placement.device_id)?;
+        let (start_idx, end_idx) = (placement.start_idx, placement.end_idx);
         let local_len = end_idx - start_idx;
         let slice_end = end_idx.min(host_data.len());
         let present_len = slice_end.saturating_sub(start_idx);
@@ -162,14 +202,14 @@ pub(crate) fn encode_distributed_to_shards(
                     requested_bytes,
                     "distributed amplitude shard allocation (f32)",
                     Some(num_qubits),
-                    Some(device.ordinal()),
+                    Some(placement.device_id),
                 )?;
                 let mut state_slice = device.alloc_zeros::<CuComplex>(local_len).map_err(|e| {
                     map_allocation_error(
                         requested_bytes,
                         "distributed amplitude shard allocation (f32)",
                         Some(num_qubits),
-                        Some(device.ordinal()),
+                        Some(placement.device_id),
                         e,
                     )
                 })?;
@@ -200,7 +240,7 @@ pub(crate) fn encode_distributed_to_shards(
                     if ret != 0 {
                         return Err(MahoutError::KernelLaunch(format!(
                             "Distributed amplitude shard kernel failed on cuda:{} with CUDA error code: {} ({})",
-                            device.ordinal(),
+                            placement.device_id,
                             ret,
                             cuda_error_to_string(ret)
                         )));
@@ -209,8 +249,7 @@ pub(crate) fn encode_distributed_to_shards(
                     device.synchronize().map_err(|e| {
                         MahoutError::Cuda(format!(
                             "Distributed amplitude shard synchronize failed on cuda:{}: {:?}",
-                            device.ordinal(),
-                            e
+                            placement.device_id, e
                         ))
                     })?;
                 }
@@ -223,7 +262,7 @@ pub(crate) fn encode_distributed_to_shards(
                     requested_bytes,
                     "distributed amplitude shard allocation",
                     Some(num_qubits),
-                    Some(device.ordinal()),
+                    Some(placement.device_id),
                 )?;
                 let mut state_slice =
                     device
@@ -233,7 +272,7 @@ pub(crate) fn encode_distributed_to_shards(
                                 requested_bytes,
                                 "distributed amplitude shard allocation",
                                 Some(num_qubits),
-                                Some(device.ordinal()),
+                                Some(placement.device_id),
                                 e,
                             )
                         })?;
@@ -262,7 +301,7 @@ pub(crate) fn encode_distributed_to_shards(
                     if ret != 0 {
                         return Err(MahoutError::KernelLaunch(format!(
                             "Distributed amplitude shard kernel failed on cuda:{} with CUDA error code: {} ({})",
-                            device.ordinal(),
+                            placement.device_id,
                             ret,
                             cuda_error_to_string(ret)
                         )));
@@ -271,8 +310,7 @@ pub(crate) fn encode_distributed_to_shards(
                     device.synchronize().map_err(|e| {
                         MahoutError::Cuda(format!(
                             "Distributed amplitude shard synchronize failed on cuda:{}: {:?}",
-                            device.ordinal(),
-                            e
+                            placement.device_id, e
                         ))
                     })?;
                 }

--- a/qdp/qdp-core/src/gpu/distributed/runtime.rs
+++ b/qdp/qdp-core/src/gpu/distributed/runtime.rs
@@ -1,0 +1,298 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+#[cfg(target_os = "linux")]
+use crate::error::cuda_error_to_string;
+use crate::error::{MahoutError, Result};
+use crate::gpu::communicator::Communicator;
+#[cfg(target_os = "linux")]
+use crate::gpu::memory::{BufferStorage, GpuBufferRaw};
+use crate::gpu::memory::{Precision, ensure_device_memory_available, map_allocation_error};
+use crate::gpu::topology::DeviceMesh;
+use crate::gpu::{
+    DistributedAmplitudePlan, DistributedStateLayout, DistributedStateVector, PlacementRequest,
+};
+#[cfg(target_os = "linux")]
+use cudarc::driver::{DevicePtr, DevicePtrMut};
+#[cfg(target_os = "linux")]
+use qdp_kernels::{
+    CuComplex, CuDoubleComplex, launch_amplitude_encode, launch_amplitude_encode_f32,
+};
+#[cfg(target_os = "linux")]
+use std::ffi::c_void;
+
+pub(crate) fn validate_distributed_input(
+    host_data: &[f64],
+    request: &PlacementRequest,
+) -> Result<()> {
+    if request.num_qubits == 0 {
+        return Err(MahoutError::InvalidInput(
+            "Number of qubits must be at least 1 for distributed amplitude planning".to_string(),
+        ));
+    }
+
+    if host_data.is_empty() {
+        return Err(MahoutError::InvalidInput(
+            "Input data cannot be empty".to_string(),
+        ));
+    }
+
+    let state_len = request.global_len()?;
+    if host_data.len() > state_len {
+        return Err(MahoutError::InvalidInput(format!(
+            "Input data length {} exceeds state vector size {}",
+            host_data.len(),
+            state_len
+        )));
+    }
+
+    Ok(())
+}
+
+pub(crate) fn plan_distributed_encode(
+    mesh: &DeviceMesh,
+    host_data: &[f64],
+    request: PlacementRequest,
+) -> Result<DistributedAmplitudePlan> {
+    validate_distributed_input(host_data, &request)?;
+    DistributedAmplitudePlan::for_request(mesh, request)
+}
+
+pub(crate) fn calculate_local_norm_sq(
+    host_data: &[f64],
+    start_idx: usize,
+    end_idx: usize,
+) -> Result<f64> {
+    if start_idx > end_idx {
+        return Err(MahoutError::InvalidInput(format!(
+            "Invalid shard range: start {} exceeds end {}",
+            start_idx, end_idx
+        )));
+    }
+
+    let slice_end = end_idx.min(host_data.len());
+    if start_idx >= slice_end {
+        return Ok(0.0);
+    }
+
+    let mut local_sum = 0.0f64;
+    for &value in &host_data[start_idx..slice_end] {
+        if !value.is_finite() {
+            return Err(MahoutError::InvalidInput(
+                "Input data contains NaN or Inf".to_string(),
+            ));
+        }
+        local_sum += value * value;
+    }
+    Ok(local_sum)
+}
+
+pub(crate) fn calculate_inv_norm_distributed(
+    plan: &DistributedAmplitudePlan,
+    host_data: &[f64],
+    communicator: &dyn Communicator,
+) -> Result<f64> {
+    let mut partials = Vec::with_capacity(plan.num_devices);
+    for shard_id in 0..plan.num_devices {
+        let (start_idx, end_idx) = plan.shard_range(shard_id)?;
+        partials.push(calculate_local_norm_sq(host_data, start_idx, end_idx)?);
+    }
+
+    let global_norm_sq = communicator.reduce_sum_f64(&partials)?;
+    if global_norm_sq <= 0.0 || !global_norm_sq.is_finite() {
+        return Err(MahoutError::InvalidInput(
+            "Input data has zero or non-finite norm (contains NaN, Inf, or all zeros)".to_string(),
+        ));
+    }
+
+    Ok(1.0 / global_norm_sq.sqrt())
+}
+
+pub(crate) fn prepare_distributed_encode(
+    mesh: &DeviceMesh,
+    host_data: &[f64],
+    precision: Precision,
+    request: PlacementRequest,
+    communicator: &dyn Communicator,
+) -> Result<(DistributedAmplitudePlan, f64, DistributedStateLayout)> {
+    let plan = plan_distributed_encode(mesh, host_data, request)?;
+    let inv_norm = calculate_inv_norm_distributed(&plan, host_data, communicator)?;
+    let layout = DistributedStateLayout::new(mesh, &plan, precision)?;
+    Ok((plan, inv_norm, layout))
+}
+
+#[cfg(target_os = "linux")]
+pub(crate) fn encode_distributed_to_shards(
+    mesh: &DeviceMesh,
+    host_data: &[f64],
+    precision: Precision,
+    request: PlacementRequest,
+    communicator: &dyn Communicator,
+) -> Result<DistributedStateVector> {
+    let (plan, inv_norm, layout) =
+        prepare_distributed_encode(mesh, host_data, precision, request, communicator)?;
+    let num_qubits = plan.request.num_qubits;
+
+    let mut buffers = Vec::with_capacity(plan.num_devices);
+    for (shard_id, device) in mesh.devices.iter().enumerate() {
+        let (start_idx, end_idx) = plan.shard_range(shard_id)?;
+        let local_len = end_idx - start_idx;
+        let slice_end = end_idx.min(host_data.len());
+        let present_len = slice_end.saturating_sub(start_idx);
+
+        let buffer = match precision {
+            Precision::Float32 => {
+                let requested_bytes = distributed_shard_bytes::<CuComplex>(local_len)?;
+                ensure_device_memory_available(
+                    requested_bytes,
+                    "distributed amplitude shard allocation (f32)",
+                    Some(num_qubits),
+                    Some(device.ordinal()),
+                )?;
+                let mut state_slice = device.alloc_zeros::<CuComplex>(local_len).map_err(|e| {
+                    map_allocation_error(
+                        requested_bytes,
+                        "distributed amplitude shard allocation (f32)",
+                        Some(num_qubits),
+                        Some(device.ordinal()),
+                        e,
+                    )
+                })?;
+
+                if present_len > 0 {
+                    let host_input = host_data[start_idx..slice_end]
+                        .iter()
+                        .map(|&value| value as f32)
+                        .collect::<Vec<_>>();
+                    let input_slice = device.htod_sync_copy(&host_input).map_err(|e| {
+                        MahoutError::MemoryAllocation(format!(
+                            "Failed to upload distributed amplitude shard input (f32): {:?}",
+                            e
+                        ))
+                    })?;
+
+                    let ret = unsafe {
+                        launch_amplitude_encode_f32(
+                            *input_slice.device_ptr() as *const f32,
+                            *state_slice.device_ptr_mut() as *mut c_void,
+                            present_len,
+                            local_len,
+                            inv_norm as f32,
+                            std::ptr::null_mut(),
+                        )
+                    };
+
+                    if ret != 0 {
+                        return Err(MahoutError::KernelLaunch(format!(
+                            "Distributed amplitude shard kernel failed on cuda:{} with CUDA error code: {} ({})",
+                            device.ordinal(),
+                            ret,
+                            cuda_error_to_string(ret)
+                        )));
+                    }
+
+                    device.synchronize().map_err(|e| {
+                        MahoutError::Cuda(format!(
+                            "Distributed amplitude shard synchronize failed on cuda:{}: {:?}",
+                            device.ordinal(),
+                            e
+                        ))
+                    })?;
+                }
+
+                Arc::new(BufferStorage::F32(GpuBufferRaw { slice: state_slice }))
+            }
+            Precision::Float64 => {
+                let requested_bytes = distributed_shard_bytes::<CuDoubleComplex>(local_len)?;
+                ensure_device_memory_available(
+                    requested_bytes,
+                    "distributed amplitude shard allocation",
+                    Some(num_qubits),
+                    Some(device.ordinal()),
+                )?;
+                let mut state_slice =
+                    device
+                        .alloc_zeros::<CuDoubleComplex>(local_len)
+                        .map_err(|e| {
+                            map_allocation_error(
+                                requested_bytes,
+                                "distributed amplitude shard allocation",
+                                Some(num_qubits),
+                                Some(device.ordinal()),
+                                e,
+                            )
+                        })?;
+
+                if present_len > 0 {
+                    let input_slice = device
+                        .htod_sync_copy(&host_data[start_idx..slice_end])
+                        .map_err(|e| {
+                            MahoutError::MemoryAllocation(format!(
+                                "Failed to upload distributed amplitude shard input: {:?}",
+                                e
+                            ))
+                        })?;
+
+                    let ret = unsafe {
+                        launch_amplitude_encode(
+                            *input_slice.device_ptr() as *const f64,
+                            *state_slice.device_ptr_mut() as *mut c_void,
+                            present_len,
+                            local_len,
+                            inv_norm,
+                            std::ptr::null_mut(),
+                        )
+                    };
+
+                    if ret != 0 {
+                        return Err(MahoutError::KernelLaunch(format!(
+                            "Distributed amplitude shard kernel failed on cuda:{} with CUDA error code: {} ({})",
+                            device.ordinal(),
+                            ret,
+                            cuda_error_to_string(ret)
+                        )));
+                    }
+
+                    device.synchronize().map_err(|e| {
+                        MahoutError::Cuda(format!(
+                            "Distributed amplitude shard synchronize failed on cuda:{}: {:?}",
+                            device.ordinal(),
+                            e
+                        ))
+                    })?;
+                }
+
+                Arc::new(BufferStorage::F64(GpuBufferRaw { slice: state_slice }))
+            }
+        };
+
+        buffers.push(buffer);
+    }
+
+    DistributedStateVector::new_with_buffers(layout, buffers)
+}
+
+#[cfg(target_os = "linux")]
+fn distributed_shard_bytes<T>(len: usize) -> Result<usize> {
+    len.checked_mul(std::mem::size_of::<T>()).ok_or_else(|| {
+        MahoutError::MemoryAllocation(format!(
+            "Distributed shard allocation size overflow (elements={})",
+            len
+        ))
+    })
+}

--- a/qdp/qdp-core/src/gpu/distributed/runtime.rs
+++ b/qdp/qdp-core/src/gpu/distributed/runtime.rs
@@ -147,13 +147,12 @@ pub(crate) fn calculate_inv_norm_distributed(
     host_data: &[f64],
     execution: &DistributedExecutionContext<'_>,
 ) -> Result<f64> {
-    let mut partials = Vec::with_capacity(plan.num_devices);
-    for shard_id in 0..plan.num_devices {
-        let (start_idx, end_idx) = plan.shard_range(shard_id)?;
-        partials.push(calculate_local_norm_sq(host_data, start_idx, end_idx)?);
+    let mut local_norm_sq = 0.0f64;
+    for placement in plan.placement.placements_for_rank(execution.rank()) {
+        local_norm_sq +=
+            calculate_local_norm_sq(host_data, placement.start_idx, placement.end_idx)?;
     }
 
-    let local_norm_sq = partials.iter().copied().sum();
     let global_norm_sq = execution.collectives().all_reduce_sum_f64(local_norm_sq)?;
     if global_norm_sq <= 0.0 || !global_norm_sq.is_finite() {
         return Err(MahoutError::InvalidInput(
@@ -172,7 +171,8 @@ pub(crate) fn prepare_distributed_encode(
 ) -> Result<(DistributedAmplitudePlan, f64, DistributedStateLayout)> {
     let plan = plan_distributed_encode(execution, host_data, request)?;
     let inv_norm = calculate_inv_norm_distributed(&plan, host_data, execution)?;
-    let layout = DistributedStateLayout::new(execution.mesh(), &plan, precision)?;
+    let layout =
+        DistributedStateLayout::new_for_rank(execution.mesh(), &plan, precision, execution.rank())?;
     Ok((plan, inv_norm, layout))
 }
 
@@ -187,8 +187,8 @@ pub(crate) fn encode_distributed_to_shards(
         prepare_distributed_encode(execution, host_data, precision, request)?;
     let num_qubits = plan.request.num_qubits;
 
-    let mut buffers = Vec::with_capacity(plan.num_devices);
-    for placement in &plan.placement.placements {
+    let mut buffers = Vec::with_capacity(plan.num_local_shards(execution.rank()));
+    for placement in plan.placement.placements_for_rank(execution.rank()) {
         let device = execution.mesh().device_for_id(placement.device_id)?;
         let _device_guard = DistributedDeviceContextGuard::switch_to(placement.device_id)?;
         let (start_idx, end_idx) = (placement.start_idx, placement.end_idx);

--- a/qdp/qdp-core/src/gpu/distributed/runtime.rs
+++ b/qdp/qdp-core/src/gpu/distributed/runtime.rs
@@ -146,7 +146,7 @@ pub(crate) fn calculate_inv_norm_distributed(
     execution: &DistributedExecutionContext<'_>,
 ) -> Result<f64> {
     let mut local_norm_sq = 0.0f64;
-    for placement in plan.placement.placements_for_rank_iter(execution.rank()) {
+    for placement in plan.placements_for_rank_iter(execution.rank()) {
         local_norm_sq +=
             calculate_local_norm_sq(host_data, placement.start_idx, placement.end_idx)?;
     }
@@ -183,10 +183,10 @@ pub(crate) fn encode_distributed_to_shards(
 ) -> Result<DistributedStateVector> {
     let (plan, inv_norm, layout) =
         prepare_distributed_encode(execution, host_data, precision, request)?;
-    let num_qubits = plan.request.num_qubits;
+    let num_qubits = plan.request().num_qubits;
 
     let mut buffers = Vec::with_capacity(plan.num_local_shards(execution.rank()));
-    for placement in plan.placement.placements_for_rank_iter(execution.rank()) {
+    for placement in plan.placements_for_rank_iter(execution.rank()) {
         let device = execution.mesh().device_for_id(placement.device_id)?;
         let _device_guard = DistributedDeviceContextGuard::switch_to(placement.device_id)?;
         let (start_idx, end_idx) = (placement.start_idx, placement.end_idx);

--- a/qdp/qdp-core/src/gpu/distributed/runtime.rs
+++ b/qdp/qdp-core/src/gpu/distributed/runtime.rs
@@ -110,7 +110,7 @@ pub(crate) fn plan_distributed_encode(
     request: PlacementRequest,
 ) -> Result<DistributedAmplitudePlan> {
     validate_distributed_input(host_data, &request)?;
-    DistributedAmplitudePlan::for_request(execution.mesh(), request)
+    DistributedAmplitudePlan::for_rank_local_request(execution.mesh(), request)
 }
 
 pub(crate) fn calculate_local_norm_sq(

--- a/qdp/qdp-core/src/gpu/distributed/runtime.rs
+++ b/qdp/qdp-core/src/gpu/distributed/runtime.rs
@@ -133,9 +133,7 @@ pub(crate) fn calculate_local_norm_sq(
     let mut local_sum = 0.0f64;
     for &value in &host_data[start_idx..slice_end] {
         if !value.is_finite() {
-            return Err(MahoutError::InvalidInput(
-                "Input data contains NaN or Inf".to_string(),
-            ));
+            return Ok(f64::NAN);
         }
         local_sum += value * value;
     }

--- a/qdp/qdp-core/src/gpu/distributed/runtime.rs
+++ b/qdp/qdp-core/src/gpu/distributed/runtime.rs
@@ -153,7 +153,8 @@ pub(crate) fn calculate_inv_norm_distributed(
         partials.push(calculate_local_norm_sq(host_data, start_idx, end_idx)?);
     }
 
-    let global_norm_sq = execution.collectives().all_reduce_sum_f64(&partials)?;
+    let local_norm_sq = partials.iter().copied().sum();
+    let global_norm_sq = execution.collectives().all_reduce_sum_f64(local_norm_sq)?;
     if global_norm_sq <= 0.0 || !global_norm_sq.is_finite() {
         return Err(MahoutError::InvalidInput(
             "Input data has zero or non-finite norm (contains NaN, Inf, or all zeros)".to_string(),

--- a/qdp/qdp-core/src/gpu/distributed/runtime.rs
+++ b/qdp/qdp-core/src/gpu/distributed/runtime.rs
@@ -146,7 +146,7 @@ pub(crate) fn calculate_inv_norm_distributed(
     execution: &DistributedExecutionContext<'_>,
 ) -> Result<f64> {
     let mut local_norm_sq = 0.0f64;
-    for placement in plan.placement.placements_for_rank(execution.rank()) {
+    for placement in plan.placement.placements_for_rank_iter(execution.rank()) {
         local_norm_sq +=
             calculate_local_norm_sq(host_data, placement.start_idx, placement.end_idx)?;
     }
@@ -186,7 +186,7 @@ pub(crate) fn encode_distributed_to_shards(
     let num_qubits = plan.request.num_qubits;
 
     let mut buffers = Vec::with_capacity(plan.num_local_shards(execution.rank()));
-    for placement in plan.placement.placements_for_rank(execution.rank()) {
+    for placement in plan.placement.placements_for_rank_iter(execution.rank()) {
         let device = execution.mesh().device_for_id(placement.device_id)?;
         let _device_guard = DistributedDeviceContextGuard::switch_to(placement.device_id)?;
         let (start_idx, end_idx) = (placement.start_idx, placement.end_idx);

--- a/qdp/qdp-core/src/gpu/distributed/shared.rs
+++ b/qdp/qdp-core/src/gpu/distributed/shared.rs
@@ -1,0 +1,64 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::gpu::topology::GpuTopology;
+
+pub(crate) fn policy_device_ids(
+    topology: &GpuTopology,
+    shard_device_ids: impl IntoIterator<Item = usize>,
+) -> (Option<usize>, Vec<usize>) {
+    let shard_device_ids = shard_device_ids.into_iter().collect::<Vec<_>>();
+    let recommended_gather_device_id = topology
+        .preferred_gather_index()
+        .and_then(|idx| shard_device_ids.get(idx).copied());
+    let recommended_placement_device_ids = topology
+        .recommended_placement_order()
+        .into_iter()
+        .filter_map(|idx| shard_device_ids.get(idx).copied())
+        .collect();
+
+    (
+        recommended_gather_device_id,
+        recommended_placement_device_ids,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::policy_device_ids;
+    use crate::gpu::topology::{GpuTopology, LinkKind};
+
+    #[test]
+    fn policy_device_ids_skips_out_of_range_topology_indices() {
+        let topology = GpuTopology {
+            peer_access: vec![
+                vec![true, true, false],
+                vec![true, true, true],
+                vec![false, true, true],
+            ],
+            links: vec![
+                vec![LinkKind::SameDevice, LinkKind::Pix, LinkKind::Unknown],
+                vec![LinkKind::Pix, LinkKind::SameDevice, LinkKind::Node],
+                vec![LinkKind::Unknown, LinkKind::Node, LinkKind::SameDevice],
+            ],
+        };
+
+        let (gather, placement) = policy_device_ids(&topology, [17, 23]);
+
+        assert_eq!(gather, Some(23));
+        assert_eq!(placement, vec![23, 17]);
+    }
+}

--- a/qdp/qdp-core/src/gpu/distributed/state.rs
+++ b/qdp/qdp-core/src/gpu/distributed/state.rs
@@ -1,0 +1,162 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cudarc::driver::CudaDevice;
+#[cfg(target_os = "linux")]
+use qdp_kernels::{CuComplex, CuDoubleComplex};
+
+use crate::error::{MahoutError, Result};
+use crate::gpu::memory::{BufferStorage, Precision};
+
+use super::DistributedStateLayout;
+use super::shared;
+
+/// One materialized shard of a distributed state vector.
+#[derive(Clone)]
+pub struct StateShard {
+    pub device: Arc<CudaDevice>,
+    pub device_id: usize,
+    pub shard_id: usize,
+    pub start_idx: usize,
+    pub end_idx: usize,
+    pub local_len: usize,
+    pub buffer: Arc<BufferStorage>,
+}
+
+/// Materialized multi-GPU state vector with one live buffer per shard.
+#[derive(Clone)]
+pub struct DistributedStateVector {
+    pub num_qubits: usize,
+    pub precision: Precision,
+    pub global_len: usize,
+    pub shard_bits: Option<usize>,
+    pub topology: crate::gpu::topology::GpuTopology,
+    pub shards: Vec<StateShard>,
+}
+
+impl DistributedStateVector {
+    pub fn recommended_gather_device_id(&self) -> Option<usize> {
+        shared::policy_device_ids(
+            &self.topology,
+            self.shards.iter().map(|shard| shard.device_id),
+        )
+        .0
+    }
+
+    pub fn recommended_placement_device_ids(&self) -> Vec<usize> {
+        shared::policy_device_ids(
+            &self.topology,
+            self.shards.iter().map(|shard| shard.device_id),
+        )
+        .1
+    }
+
+    pub fn num_shards(&self) -> usize {
+        self.shards.len()
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn copy_shard_to_host_f64(&self, shard_id: usize) -> Result<Vec<CuDoubleComplex>> {
+        let shard = self.shards.get(shard_id).ok_or_else(|| {
+            MahoutError::InvalidInput(format!(
+                "Shard ID {} out of range for {} shards",
+                shard_id,
+                self.shards.len()
+            ))
+        })?;
+        match shard.buffer.as_ref() {
+            BufferStorage::F64(buf) => shard.device.dtoh_sync_copy(&buf.slice).map_err(|e| {
+                MahoutError::Cuda(format!(
+                    "Failed to copy distributed float64 shard {} to host: {:?}",
+                    shard_id, e
+                ))
+            }),
+            BufferStorage::F32(_) => Err(MahoutError::InvalidInput(format!(
+                "Shard {} stores float32 data, not float64",
+                shard_id
+            ))),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn copy_shard_to_host_f32(&self, shard_id: usize) -> Result<Vec<CuComplex>> {
+        let shard = self.shards.get(shard_id).ok_or_else(|| {
+            MahoutError::InvalidInput(format!(
+                "Shard ID {} out of range for {} shards",
+                shard_id,
+                self.shards.len()
+            ))
+        })?;
+        match shard.buffer.as_ref() {
+            BufferStorage::F32(buf) => shard.device.dtoh_sync_copy(&buf.slice).map_err(|e| {
+                MahoutError::Cuda(format!(
+                    "Failed to copy distributed float32 shard {} to host: {:?}",
+                    shard_id, e
+                ))
+            }),
+            BufferStorage::F64(_) => Err(MahoutError::InvalidInput(format!(
+                "Shard {} stores float64 data, not float32",
+                shard_id
+            ))),
+        }
+    }
+
+    /// Construct a distributed state vector with concrete shard buffers already allocated.
+    pub fn new_with_buffers(
+        layout: DistributedStateLayout,
+        buffers: Vec<Arc<BufferStorage>>,
+    ) -> Result<Self> {
+        if buffers.len() != layout.shards.len() {
+            return Err(MahoutError::InvalidInput(format!(
+                "Distributed state buffer mismatch: {} buffers for {} shards",
+                buffers.len(),
+                layout.shards.len()
+            )));
+        }
+
+        let mut shards = Vec::with_capacity(layout.shards.len());
+        for (shard_layout, buffer) in layout.shards.into_iter().zip(buffers.into_iter()) {
+            if buffer.precision() != layout.precision {
+                return Err(MahoutError::InvalidInput(format!(
+                    "Distributed shard precision mismatch on shard {}: expected {:?}, got {:?}",
+                    shard_layout.shard_id,
+                    layout.precision,
+                    buffer.precision()
+                )));
+            }
+            shards.push(StateShard {
+                device: shard_layout.device,
+                device_id: shard_layout.device_id,
+                shard_id: shard_layout.shard_id,
+                start_idx: shard_layout.start_idx,
+                end_idx: shard_layout.end_idx,
+                local_len: shard_layout.local_len,
+                buffer,
+            });
+        }
+
+        Ok(Self {
+            num_qubits: layout.num_qubits,
+            precision: layout.precision,
+            global_len: layout.global_len,
+            shard_bits: layout.shard_bits,
+            topology: layout.topology,
+            shards,
+        })
+    }
+}

--- a/qdp/qdp-core/src/gpu/distributed/state.rs
+++ b/qdp/qdp-core/src/gpu/distributed/state.rs
@@ -50,6 +50,7 @@ pub struct DistributedStateVector {
 }
 
 impl DistributedStateVector {
+    /// Device ID preferred for future gather-style readback operations.
     pub fn recommended_gather_device_id(&self) -> Option<usize> {
         shared::policy_device_ids(
             &self.topology,
@@ -58,6 +59,7 @@ impl DistributedStateVector {
         .0
     }
 
+    /// Preferred device ordering derived from the current topology metadata.
     pub fn recommended_placement_device_ids(&self) -> Vec<usize> {
         shared::policy_device_ids(
             &self.topology,
@@ -66,11 +68,13 @@ impl DistributedStateVector {
         .1
     }
 
+    /// Number of materialized shards in this distributed state.
     pub fn num_shards(&self) -> usize {
         self.shards.len()
     }
 
     #[cfg(target_os = "linux")]
+    /// Copy one float64 shard back to host memory for validation or inspection.
     pub fn copy_shard_to_host_f64(&self, shard_id: usize) -> Result<Vec<CuDoubleComplex>> {
         let shard = self.shards.get(shard_id).ok_or_else(|| {
             MahoutError::InvalidInput(format!(
@@ -94,6 +98,7 @@ impl DistributedStateVector {
     }
 
     #[cfg(target_os = "linux")]
+    /// Copy one float32 shard back to host memory for validation or inspection.
     pub fn copy_shard_to_host_f32(&self, shard_id: usize) -> Result<Vec<CuComplex>> {
         let shard = self.shards.get(shard_id).ok_or_else(|| {
             MahoutError::InvalidInput(format!(

--- a/qdp/qdp-core/src/gpu/distributed/state.rs
+++ b/qdp/qdp-core/src/gpu/distributed/state.rs
@@ -92,19 +92,22 @@ impl DistributedStateVector {
 
     /// Return zero-copy metadata for all materialized local shards.
     pub fn local_shard_views(&self) -> Vec<LocalShardView> {
-        self.shards
-            .iter()
-            .map(|shard| LocalShardView {
-                rank_id: shard.rank_id,
-                device_id: shard.device_id,
-                shard_id: shard.shard_id,
-                start_idx: shard.start_idx,
-                end_idx: shard.end_idx,
-                local_len: shard.local_len,
-                precision: self.precision,
-                ptr: shard.buffer.ptr_void(),
-            })
-            .collect()
+        self.iter_local_shard_views().collect()
+    }
+
+    /// Iterate zero-copy metadata for materialized local shards without
+    /// allocating an intermediate vector.
+    pub fn iter_local_shard_views(&self) -> impl Iterator<Item = LocalShardView> + '_ {
+        self.shards.iter().map(|shard| LocalShardView {
+            rank_id: shard.rank_id,
+            device_id: shard.device_id,
+            shard_id: shard.shard_id,
+            start_idx: shard.start_idx,
+            end_idx: shard.end_idx,
+            local_len: shard.local_len,
+            precision: self.precision,
+            ptr: shard.buffer.ptr_void(),
+        })
     }
 
     #[cfg(target_os = "linux")]
@@ -169,7 +172,7 @@ impl DistributedStateVector {
         }
 
         let mut shards = Vec::with_capacity(layout.shards.len());
-        for (shard_layout, buffer) in layout.shards.into_iter().zip(buffers.into_iter()) {
+        for (shard_layout, buffer) in layout.shards.into_iter().zip(buffers) {
             if buffer.precision() != layout.precision {
                 return Err(MahoutError::InvalidInput(format!(
                     "Distributed shard precision mismatch on shard {}: expected {:?}, got {:?}",

--- a/qdp/qdp-core/src/gpu/distributed/state.rs
+++ b/qdp/qdp-core/src/gpu/distributed/state.rs
@@ -63,7 +63,7 @@ pub struct DistributedStateVector {
     pub global_len: usize,
     pub shard_bits: Option<usize>,
     pub topology: crate::gpu::topology::GpuTopology,
-    pub shards: Vec<StateShard>,
+    shards: Vec<StateShard>,
 }
 
 impl DistributedStateVector {
@@ -88,6 +88,16 @@ impl DistributedStateVector {
     /// Number of materialized shards in this distributed state.
     pub fn num_shards(&self) -> usize {
         self.shards.len()
+    }
+
+    /// Borrow all materialized local shards.
+    pub fn shards(&self) -> &[StateShard] {
+        &self.shards
+    }
+
+    /// Iterate over materialized local shards.
+    pub fn iter_shards(&self) -> impl Iterator<Item = &StateShard> {
+        self.shards.iter()
     }
 
     /// Return zero-copy metadata for all materialized local shards.
@@ -163,21 +173,30 @@ impl DistributedStateVector {
         layout: DistributedStateLayout,
         buffers: Vec<Arc<BufferStorage>>,
     ) -> Result<Self> {
-        if buffers.len() != layout.shards.len() {
+        let layout_shards_len = layout.num_shards();
+        if buffers.len() != layout_shards_len {
             return Err(MahoutError::InvalidInput(format!(
                 "Distributed state buffer mismatch: {} buffers for {} shards",
                 buffers.len(),
-                layout.shards.len()
+                layout_shards_len
             )));
         }
 
-        let mut shards = Vec::with_capacity(layout.shards.len());
-        for (shard_layout, buffer) in layout.shards.into_iter().zip(buffers) {
-            if buffer.precision() != layout.precision {
+        let rank_id = layout.rank_id;
+        let world_size = layout.world_size;
+        let num_qubits = layout.num_qubits;
+        let precision = layout.precision;
+        let global_len = layout.global_len;
+        let shard_bits = layout.shard_bits;
+        let topology = layout.topology.clone();
+
+        let mut shards = Vec::with_capacity(layout_shards_len);
+        for (shard_layout, buffer) in layout.into_shards().into_iter().zip(buffers) {
+            if buffer.precision() != precision {
                 return Err(MahoutError::InvalidInput(format!(
                     "Distributed shard precision mismatch on shard {}: expected {:?}, got {:?}",
                     shard_layout.shard_id,
-                    layout.precision,
+                    precision,
                     buffer.precision()
                 )));
             }
@@ -194,13 +213,13 @@ impl DistributedStateVector {
         }
 
         Ok(Self {
-            rank_id: layout.rank_id,
-            world_size: layout.world_size,
-            num_qubits: layout.num_qubits,
-            precision: layout.precision,
-            global_len: layout.global_len,
-            shard_bits: layout.shard_bits,
-            topology: layout.topology,
+            rank_id,
+            world_size,
+            num_qubits,
+            precision,
+            global_len,
+            shard_bits,
+            topology,
             shards,
         })
     }

--- a/qdp/qdp-core/src/gpu/distributed/state.rs
+++ b/qdp/qdp-core/src/gpu/distributed/state.rs
@@ -14,6 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::ffi::c_void;
 use std::sync::Arc;
 
 use cudarc::driver::CudaDevice;
@@ -26,9 +27,23 @@ use crate::gpu::memory::{BufferStorage, Precision};
 use super::DistributedStateLayout;
 use super::shared;
 
+/// Borrowed metadata for one local GPU shard suitable for zero-copy handoff.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct LocalShardView {
+    pub rank_id: usize,
+    pub device_id: usize,
+    pub shard_id: usize,
+    pub start_idx: usize,
+    pub end_idx: usize,
+    pub local_len: usize,
+    pub precision: Precision,
+    pub ptr: *mut c_void,
+}
+
 /// One materialized shard of a distributed state vector.
 #[derive(Clone)]
 pub struct StateShard {
+    pub rank_id: usize,
     pub device: Arc<CudaDevice>,
     pub device_id: usize,
     pub shard_id: usize,
@@ -41,6 +56,8 @@ pub struct StateShard {
 /// Materialized multi-GPU state vector with one live buffer per shard.
 #[derive(Clone)]
 pub struct DistributedStateVector {
+    pub rank_id: usize,
+    pub world_size: usize,
     pub num_qubits: usize,
     pub precision: Precision,
     pub global_len: usize,
@@ -71,6 +88,23 @@ impl DistributedStateVector {
     /// Number of materialized shards in this distributed state.
     pub fn num_shards(&self) -> usize {
         self.shards.len()
+    }
+
+    /// Return zero-copy metadata for all materialized local shards.
+    pub fn local_shard_views(&self) -> Vec<LocalShardView> {
+        self.shards
+            .iter()
+            .map(|shard| LocalShardView {
+                rank_id: shard.rank_id,
+                device_id: shard.device_id,
+                shard_id: shard.shard_id,
+                start_idx: shard.start_idx,
+                end_idx: shard.end_idx,
+                local_len: shard.local_len,
+                precision: self.precision,
+                ptr: shard.buffer.ptr_void(),
+            })
+            .collect()
     }
 
     #[cfg(target_os = "linux")]
@@ -145,6 +179,7 @@ impl DistributedStateVector {
                 )));
             }
             shards.push(StateShard {
+                rank_id: shard_layout.rank_id,
                 device: shard_layout.device,
                 device_id: shard_layout.device_id,
                 shard_id: shard_layout.shard_id,
@@ -156,6 +191,8 @@ impl DistributedStateVector {
         }
 
         Ok(Self {
+            rank_id: layout.rank_id,
+            world_size: layout.world_size,
             num_qubits: layout.num_qubits,
             precision: layout.precision,
             global_len: layout.global_len,

--- a/qdp/qdp-core/src/gpu/distributed/state_plan.rs
+++ b/qdp/qdp-core/src/gpu/distributed/state_plan.rs
@@ -1,0 +1,189 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::error::{MahoutError, Result};
+use crate::gpu::distributed::{PlacementPlan, PlacementRequest, ShardPlacement, ShardPolicy};
+use crate::gpu::memory::Precision;
+use crate::gpu::topology::DeviceMesh;
+
+/// Workload-neutral plan for one logically distributed GPU state.
+///
+/// Encoder-specific plans should wrap this type instead of duplicating shard
+/// placement, rank ownership, and byte-estimation metadata.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DistributedStatePlan {
+    request: PlacementRequest,
+    placement: PlacementPlan,
+    pub num_qubits: usize,
+    pub global_len: usize,
+    pub num_devices: usize,
+    pub shard_bits: Option<usize>,
+    pub uniform_shard_len: Option<usize>,
+}
+
+impl DistributedStatePlan {
+    /// Build shared distributed state metadata from one validated placement.
+    pub fn from_placement(request: PlacementRequest, placement: PlacementPlan) -> Result<Self> {
+        let num_devices = placement.num_devices();
+        Self::validate_local_shard_shape(request.num_qubits, &placement)?;
+        let global_len = placement.global_len;
+        let num_qubits = request.num_qubits;
+        let (shard_bits, uniform_shard_len) = match request.shard_policy {
+            ShardPolicy::Equal => {
+                debug_assert!(num_devices.is_power_of_two());
+                let shard_bits = num_devices.trailing_zeros() as usize;
+                if shard_bits > request.num_qubits {
+                    return Err(MahoutError::InvalidInput(format!(
+                        "Cannot shard {} qubits across {} devices: shard bits {} exceed qubit count",
+                        request.num_qubits, num_devices, shard_bits
+                    )));
+                }
+                (Some(shard_bits), Some(placement.shard_len()?))
+            }
+            ShardPolicy::BalancedUneven => (None, None),
+        };
+
+        Ok(Self {
+            request,
+            placement,
+            num_qubits,
+            global_len,
+            num_devices,
+            shard_bits,
+            uniform_shard_len,
+        })
+    }
+
+    /// Original placement request used to build this distributed state plan.
+    pub fn request(&self) -> &PlacementRequest {
+        &self.request
+    }
+
+    /// Raw planner output backing this shared state plan.
+    pub fn placement(&self) -> &PlacementPlan {
+        &self.placement
+    }
+
+    /// Logical half-open state range covered by one shard ID.
+    pub fn shard_range(&self, shard_id: usize) -> Result<(usize, usize)> {
+        let placement = self.placement.placements.get(shard_id).ok_or_else(|| {
+            MahoutError::InvalidInput(format!(
+                "Shard ID {} out of range for {} devices",
+                shard_id, self.num_devices
+            ))
+        })?;
+        Ok((placement.start_idx, placement.end_idx))
+    }
+
+    /// Largest local shard length across the current placement.
+    pub fn max_local_len(&self) -> usize {
+        self.placement
+            .placements
+            .iter()
+            .map(ShardPlacement::local_len)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Iterate over placements owned by one rank without allocating.
+    pub fn placements_for_rank_iter(&self, rank: usize) -> impl Iterator<Item = &ShardPlacement> {
+        self.placement.placements_for_rank_iter(rank)
+    }
+
+    /// Number of shards owned by one rank.
+    pub fn num_local_shards(&self, rank: usize) -> usize {
+        self.placements_for_rank_iter(rank).count()
+    }
+
+    /// Logical half-open state ranges owned by one rank.
+    pub fn rank_shard_ranges(&self, rank: usize) -> Vec<(usize, usize)> {
+        self.placements_for_rank_iter(rank)
+            .map(|placement| (placement.start_idx, placement.end_idx))
+            .collect()
+    }
+
+    /// Largest shard length owned by one rank.
+    pub fn max_local_len_for_rank(&self, rank: usize) -> usize {
+        self.placements_for_rank_iter(rank)
+            .map(ShardPlacement::local_len)
+            .max()
+            .unwrap_or(0)
+    }
+
+    /// Estimated bytes required by the largest local shard at one target precision.
+    pub fn estimated_max_shard_bytes(&self, precision: Precision) -> Result<usize> {
+        estimated_state_bytes(self.max_local_len(), precision)
+    }
+
+    /// Validate that this plan can be materialized by the provided local mesh.
+    pub fn validate_against_mesh(&self, mesh: &DeviceMesh) -> Result<()> {
+        if self.placement.placements.len() != self.num_devices {
+            return Err(MahoutError::InvalidInput(format!(
+                "Placement plan mismatch: {} placements for {} planned shards",
+                self.placement.placements.len(),
+                self.num_devices
+            )));
+        }
+        if mesh.devices.len() != mesh.device_ids.len() {
+            return Err(MahoutError::InvalidInput(format!(
+                "Device mesh / device handles mismatch: {} handles for {} device IDs",
+                mesh.devices.len(),
+                mesh.device_ids.len()
+            )));
+        }
+
+        Ok(())
+    }
+
+    fn validate_local_shard_shape(num_qubits: usize, placement: &PlacementPlan) -> Result<()> {
+        let required_local_len = placement
+            .placements
+            .iter()
+            .map(ShardPlacement::local_len)
+            .max()
+            .ok_or_else(|| {
+                MahoutError::InvalidInput(
+                    "Placement plan must contain at least one shard".to_string(),
+                )
+            })?;
+
+        if required_local_len == 0 {
+            return Err(MahoutError::InvalidInput(format!(
+                "Distributed state request for {} qubits produced an empty local shard",
+                num_qubits
+            )));
+        }
+
+        let _ = estimated_state_bytes(required_local_len, Precision::Float32)?;
+        let _ = estimated_state_bytes(required_local_len, Precision::Float64)?;
+
+        Ok(())
+    }
+}
+
+fn estimated_state_bytes(local_len: usize, precision: Precision) -> Result<usize> {
+    let bytes_per_state_entry = match precision {
+        Precision::Float32 => 8usize,
+        Precision::Float64 => 16usize,
+    };
+
+    local_len.checked_mul(bytes_per_state_entry).ok_or_else(|| {
+        MahoutError::InvalidInput(format!(
+            "Distributed state shard byte estimate overflowed for local_len={} and precision={:?}",
+            local_len, precision
+        ))
+    })
+}

--- a/qdp/qdp-core/src/gpu/encodings/amplitude.rs
+++ b/qdp/qdp-core/src/gpu/encodings/amplitude.rs
@@ -86,6 +86,7 @@ impl QuantumEncoder for AmplitudeEncoder {
                     input_bytes,
                     "input staging buffer",
                     Some(num_qubits),
+                    Some(_device.ordinal()),
                 )?;
 
                 let input_slice = {
@@ -95,6 +96,7 @@ impl QuantumEncoder for AmplitudeEncoder {
                             input_bytes,
                             "input staging buffer",
                             Some(num_qubits),
+                            Some(_device.ordinal()),
                             e,
                         )
                     })?
@@ -720,6 +722,29 @@ impl QuantumEncoder for AmplitudeEncoder {
 }
 
 impl AmplitudeEncoder {
+    #[cfg(target_os = "linux")]
+    fn async_chunk_state_len(
+        state_len: usize,
+        chunk_offset: usize,
+        chunk_len: usize,
+    ) -> Result<usize> {
+        let remaining = state_len.checked_sub(chunk_offset).ok_or_else(|| {
+            MahoutError::InvalidInput(format!(
+                "Async amplitude chunk offset {} exceeds state length {}",
+                chunk_offset, state_len
+            ))
+        })?;
+
+        if chunk_len > remaining {
+            return Err(MahoutError::InvalidInput(format!(
+                "Async amplitude chunk length {} at offset {} exceeds remaining state length {}",
+                chunk_len, chunk_offset, remaining
+            )));
+        }
+
+        Ok(chunk_len)
+    }
+
     /// Async pipeline encoding for large data
     ///
     /// Uses the generic dual-stream pipeline infrastructure to overlap
@@ -747,6 +772,8 @@ impl AmplitudeEncoder {
             device,
             host_data,
             |stream, input_ptr, chunk_offset, chunk_len| {
+                let chunk_state_len =
+                    Self::async_chunk_state_len(state_len, chunk_offset, chunk_len)?;
                 // Calculate offset pointer for state vector (type-safe pointer arithmetic)
                 // Offset is in complex numbers (CuDoubleComplex), not f64 elements
                 let state_ptr_offset = unsafe {
@@ -762,7 +789,7 @@ impl AmplitudeEncoder {
                         input_ptr,
                         state_ptr_offset,
                         chunk_len,
-                        state_len,
+                        chunk_state_len,
                         inv_norm,
                         stream.stream as *mut c_void,
                     )
@@ -1200,5 +1227,64 @@ impl AmplitudeEncoder {
             &state_vector,
         )?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::AmplitudeEncoder;
+    #[cfg(target_os = "linux")]
+    use crate::gpu::QuantumEncoder;
+    #[cfg(target_os = "linux")]
+    use cudarc::driver::CudaDevice;
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn async_chunk_state_len_uses_chunk_local_extent() {
+        assert_eq!(
+            AmplitudeEncoder::async_chunk_state_len(1024, 256, 128).unwrap(),
+            128
+        );
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn async_chunk_state_len_rejects_overrun() {
+        let err = AmplitudeEncoder::async_chunk_state_len(1024, 1000, 64).unwrap_err();
+        assert!(matches!(err, crate::error::MahoutError::InvalidInput(_)));
+    }
+
+    #[test]
+    #[cfg(target_os = "linux")]
+    fn async_pipeline_large_encode_q22_matches_reference_slices() {
+        let device = match CudaDevice::new(0) {
+            Ok(device) => device,
+            Err(_) => return,
+        };
+
+        let num_qubits = 22usize;
+        let state_len = 1usize << num_qubits;
+        let mut input = vec![0.0f64; state_len];
+        for (idx, value) in input.iter_mut().enumerate() {
+            *value = ((idx % 1024) as f64) + 1.0;
+        }
+
+        let encoder = AmplitudeEncoder;
+        let state = encoder.encode(&device, &input, num_qubits).unwrap();
+        let host = state.copy_to_host_f64(&device).unwrap();
+        let norm = input.iter().map(|value| value * value).sum::<f64>().sqrt();
+
+        for idx in [0usize, 1, 1024, state_len / 2, state_len - 1] {
+            let expected = input[idx] / norm;
+            let actual = host[idx].x;
+            assert!(
+                (actual - expected).abs() < 1e-12,
+                "Mismatch at amplitude {}: actual={} expected={}",
+                idx,
+                actual,
+                expected
+            );
+            assert_eq!(host[idx].y, 0.0);
+        }
     }
 }

--- a/qdp/qdp-core/src/gpu/encodings/angle.rs
+++ b/qdp/qdp-core/src/gpu/encodings/angle.rs
@@ -57,7 +57,13 @@ impl QuantumEncoder for AngleEncoder {
             let angles_gpu = {
                 crate::profile_scope!("GPU::H2D_Angles");
                 device.htod_sync_copy(data).map_err(|e| {
-                    map_allocation_error(input_bytes, "angle input upload", Some(num_qubits), e)
+                    map_allocation_error(
+                        input_bytes,
+                        "angle input upload",
+                        Some(num_qubits),
+                        Some(device.ordinal()),
+                        e,
+                    )
                 })?
             };
 
@@ -187,7 +193,13 @@ impl QuantumEncoder for AngleEncoder {
         let angles_gpu = {
             crate::profile_scope!("GPU::H2D_BatchAngles");
             device.htod_sync_copy(batch_data).map_err(|e| {
-                map_allocation_error(input_bytes, "angle batch upload", Some(num_qubits), e)
+                map_allocation_error(
+                    input_bytes,
+                    "angle batch upload",
+                    Some(num_qubits),
+                    Some(device.ordinal()),
+                    e,
+                )
             })?
         };
 
@@ -452,7 +464,13 @@ impl QuantumEncoder for AngleEncoder {
         let angles_gpu = {
             crate::profile_scope!("GPU::H2D_BatchAnglesF32");
             device.htod_sync_copy(batch_data).map_err(|e| {
-                map_allocation_error(input_bytes, "angle batch upload", Some(num_qubits), e)
+                map_allocation_error(
+                    input_bytes,
+                    "angle batch upload",
+                    Some(num_qubits),
+                    Some(device.ordinal()),
+                    e,
+                )
             })?
         };
 

--- a/qdp/qdp-core/src/gpu/encodings/basis.rs
+++ b/qdp/qdp-core/src/gpu/encodings/basis.rs
@@ -180,6 +180,7 @@ impl QuantumEncoder for BasisEncoder {
                     num_samples * std::mem::size_of::<usize>(),
                     "basis indices upload",
                     Some(num_qubits),
+                    Some(device.ordinal()),
                     e,
                 )
             })?

--- a/qdp/qdp-core/src/gpu/encodings/basis.rs
+++ b/qdp/qdp-core/src/gpu/encodings/basis.rs
@@ -425,6 +425,7 @@ impl QuantumEncoder for BasisEncoder {
                     num_samples * std::mem::size_of::<usize>(),
                     "basis indices f32 upload",
                     Some(num_qubits),
+                    Some(device.ordinal()),
                     e,
                 )
             })?

--- a/qdp/qdp-core/src/gpu/encodings/iqp.rs
+++ b/qdp/qdp-core/src/gpu/encodings/iqp.rs
@@ -83,7 +83,13 @@ impl QuantumEncoder for IqpEncoder {
             let data_gpu = {
                 crate::profile_scope!("GPU::H2D_IqpData");
                 device.htod_sync_copy(data).map_err(|e| {
-                    map_allocation_error(input_bytes, "IQP input upload", Some(num_qubits), e)
+                    map_allocation_error(
+                        input_bytes,
+                        "IQP input upload",
+                        Some(num_qubits),
+                        Some(device.ordinal()),
+                        e,
+                    )
                 })?
             };
 
@@ -194,7 +200,13 @@ impl QuantumEncoder for IqpEncoder {
         let data_gpu = {
             crate::profile_scope!("GPU::H2D_BatchIqpData");
             device.htod_sync_copy(batch_data).map_err(|e| {
-                map_allocation_error(input_bytes, "IQP batch upload", Some(num_qubits), e)
+                map_allocation_error(
+                    input_bytes,
+                    "IQP batch upload",
+                    Some(num_qubits),
+                    Some(device.ordinal()),
+                    e,
+                )
             })?
         };
 

--- a/qdp/qdp-core/src/gpu/encodings/phase.rs
+++ b/qdp/qdp-core/src/gpu/encodings/phase.rs
@@ -80,7 +80,13 @@ impl QuantumEncoder for PhaseEncoder {
             let phases_gpu = {
                 crate::profile_scope!("GPU::H2D_Phases");
                 device.htod_sync_copy(data).map_err(|e| {
-                    map_allocation_error(input_bytes, "phase input upload", Some(num_qubits), e)
+                    map_allocation_error(
+                        input_bytes,
+                        "phase input upload",
+                        Some(num_qubits),
+                        Some(device.ordinal()),
+                        e,
+                    )
                 })?
             };
 
@@ -199,7 +205,13 @@ impl QuantumEncoder for PhaseEncoder {
         let phases_gpu = {
             crate::profile_scope!("GPU::H2D_BatchPhases");
             device.htod_sync_copy(batch_data).map_err(|e| {
-                map_allocation_error(input_bytes, "phase batch upload", Some(num_qubits), e)
+                map_allocation_error(
+                    input_bytes,
+                    "phase batch upload",
+                    Some(num_qubits),
+                    Some(device.ordinal()),
+                    e,
+                )
             })?
         };
 

--- a/qdp/qdp-core/src/gpu/memory.rs
+++ b/qdp/qdp-core/src/gpu/memory.rs
@@ -43,7 +43,9 @@ pub enum GpuDeviceType {
 }
 
 #[cfg(target_os = "linux")]
-use crate::gpu::cuda_ffi::{cudaFreeHost, cudaHostAlloc, cudaMemGetInfo};
+use crate::gpu::cuda_ffi::{
+    CUDA_SUCCESS, cudaFreeHost, cudaGetDevice, cudaHostAlloc, cudaMemGetInfo, cudaSetDevice,
+};
 
 #[cfg(target_os = "linux")]
 fn bytes_to_mib(bytes: usize) -> f64 {
@@ -51,7 +53,49 @@ fn bytes_to_mib(bytes: usize) -> f64 {
 }
 
 #[cfg(target_os = "linux")]
-fn query_cuda_mem_info() -> Result<(usize, usize)> {
+struct DeviceContextGuard {
+    original_device: i32,
+}
+
+#[cfg(target_os = "linux")]
+impl DeviceContextGuard {
+    fn switch_to(target_device: Option<usize>) -> Result<Self> {
+        let mut original_device = 0i32;
+        let get_ret = unsafe { cudaGetDevice(&mut original_device as *mut i32) };
+        if get_ret != CUDA_SUCCESS {
+            return Err(MahoutError::Cuda(format!(
+                "cudaGetDevice failed: {} ({})",
+                get_ret,
+                cuda_error_to_string(get_ret)
+            )));
+        }
+
+        if let Some(device_id) = target_device {
+            let set_ret = unsafe { cudaSetDevice(device_id as i32) };
+            if set_ret != CUDA_SUCCESS {
+                return Err(MahoutError::Cuda(format!(
+                    "cudaSetDevice(cuda:{}) failed: {} ({})",
+                    device_id,
+                    set_ret,
+                    cuda_error_to_string(set_ret)
+                )));
+            }
+        }
+
+        Ok(Self { original_device })
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl Drop for DeviceContextGuard {
+    fn drop(&mut self) {
+        let _ = unsafe { cudaSetDevice(self.original_device) };
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn query_cuda_mem_info(device_id: Option<usize>) -> Result<(usize, usize)> {
+    let _guard = DeviceContextGuard::switch_to(device_id)?;
     unsafe {
         let mut free_bytes: usize = 0;
         let mut total_bytes: usize = 0;
@@ -101,8 +145,9 @@ pub(crate) fn ensure_device_memory_available(
     requested_bytes: usize,
     context: &str,
     qubits: Option<usize>,
+    device_id: Option<usize>,
 ) -> Result<()> {
-    let (free, total) = query_cuda_mem_info()?;
+    let (free, total) = query_cuda_mem_info(device_id)?;
 
     if (requested_bytes as u64) > (free as u64) {
         return Err(MahoutError::MemoryAllocation(build_oom_message(
@@ -123,9 +168,10 @@ pub(crate) fn map_allocation_error(
     requested_bytes: usize,
     context: &str,
     qubits: Option<usize>,
+    device_id: Option<usize>,
     source: impl std::fmt::Debug,
 ) -> MahoutError {
-    match query_cuda_mem_info() {
+    match query_cuda_mem_info(device_id) {
         Ok((free, total)) => {
             if (requested_bytes as u64) > (free as u64) {
                 MahoutError::MemoryAllocation(build_oom_message(
@@ -175,28 +221,28 @@ pub enum BufferStorage {
 }
 
 impl BufferStorage {
-    fn precision(&self) -> Precision {
+    pub(crate) fn precision(&self) -> Precision {
         match self {
             BufferStorage::F32(_) => Precision::Float32,
             BufferStorage::F64(_) => Precision::Float64,
         }
     }
 
-    fn ptr_void(&self) -> *mut c_void {
+    pub(crate) fn ptr_void(&self) -> *mut c_void {
         match self {
             BufferStorage::F32(buf) => buf.ptr() as *mut c_void,
             BufferStorage::F64(buf) => buf.ptr() as *mut c_void,
         }
     }
 
-    fn ptr_f64(&self) -> Option<*mut CuDoubleComplex> {
+    pub(crate) fn ptr_f64(&self) -> Option<*mut CuDoubleComplex> {
         match self {
             BufferStorage::F64(buf) => Some(buf.ptr()),
             _ => None,
         }
     }
 
-    fn ptr_f32(&self) -> Option<*mut CuComplex> {
+    pub(crate) fn ptr_f32(&self) -> Option<*mut CuComplex> {
         match self {
             BufferStorage::F32(buf) => Some(buf.ptr()),
             _ => None,
@@ -250,6 +296,7 @@ impl GpuStateVector {
                     requested_bytes,
                     "state vector allocation (f32)",
                     Some(qubits),
+                    Some(_device.ordinal()),
                 )?;
 
                 let slice = unsafe { _device.alloc::<CuComplex>(_size_elements) }.map_err(|e| {
@@ -257,6 +304,7 @@ impl GpuStateVector {
                         requested_bytes,
                         "state vector allocation (f32)",
                         Some(qubits),
+                        Some(_device.ordinal()),
                         e,
                     )
                 })?;
@@ -277,6 +325,7 @@ impl GpuStateVector {
                     requested_bytes,
                     "state vector allocation",
                     Some(qubits),
+                    Some(_device.ordinal()),
                 )?;
 
                 let slice =
@@ -285,6 +334,7 @@ impl GpuStateVector {
                             requested_bytes,
                             "state vector allocation",
                             Some(qubits),
+                            Some(_device.ordinal()),
                             e,
                         )
                     })?;
@@ -339,6 +389,30 @@ impl GpuStateVector {
         self.num_qubits
     }
 
+    #[cfg(target_os = "linux")]
+    pub fn copy_to_host_f64(&self, device: &Arc<CudaDevice>) -> Result<Vec<CuDoubleComplex>> {
+        match self.buffer.as_ref() {
+            BufferStorage::F64(buf) => device.dtoh_sync_copy(&buf.slice).map_err(|e| {
+                MahoutError::Cuda(format!("Failed to copy float64 state to host: {:?}", e))
+            }),
+            BufferStorage::F32(_) => Err(MahoutError::InvalidInput(
+                "State vector stores float32 data, not float64".to_string(),
+            )),
+        }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn copy_to_host_f32(&self, device: &Arc<CudaDevice>) -> Result<Vec<CuComplex>> {
+        match self.buffer.as_ref() {
+            BufferStorage::F32(buf) => device.dtoh_sync_copy(&buf.slice).map_err(|e| {
+                MahoutError::Cuda(format!("Failed to copy float32 state to host: {:?}", e))
+            }),
+            BufferStorage::F64(_) => Err(MahoutError::InvalidInput(
+                "State vector stores float64 data, not float32".to_string(),
+            )),
+        }
+    }
+
     /// Get the size in elements (2^n where n is number of qubits)
     pub fn size_elements(&self) -> usize {
         self.size_elements
@@ -374,11 +448,22 @@ impl GpuStateVector {
                         })?;
 
                     let context = "batch state vector allocation (f32)";
-                    ensure_device_memory_available(requested_bytes, context, Some(qubits))?;
+                    ensure_device_memory_available(
+                        requested_bytes,
+                        context,
+                        Some(qubits),
+                        Some(_device.ordinal()),
+                    )?;
 
                     let slice =
                         unsafe { _device.alloc::<CuComplex>(total_elements) }.map_err(|e| {
-                            map_allocation_error(requested_bytes, context, Some(qubits), e)
+                            map_allocation_error(
+                                requested_bytes,
+                                context,
+                                Some(qubits),
+                                Some(_device.ordinal()),
+                                e,
+                            )
                         })?;
 
                     BufferStorage::F32(GpuBufferRaw { slice })
@@ -394,11 +479,22 @@ impl GpuStateVector {
                         })?;
 
                     let context = "batch state vector allocation";
-                    ensure_device_memory_available(requested_bytes, context, Some(qubits))?;
+                    ensure_device_memory_available(
+                        requested_bytes,
+                        context,
+                        Some(qubits),
+                        Some(_device.ordinal()),
+                    )?;
 
                     let slice = unsafe { _device.alloc::<CuDoubleComplex>(total_elements) }
                         .map_err(|e| {
-                            map_allocation_error(requested_bytes, context, Some(qubits), e)
+                            map_allocation_error(
+                                requested_bytes,
+                                context,
+                                Some(qubits),
+                                Some(_device.ordinal()),
+                                e,
+                            )
                         })?;
 
                     BufferStorage::F64(GpuBufferRaw { slice })
@@ -450,6 +546,7 @@ impl GpuStateVector {
                         requested_bytes,
                         "state vector precision conversion",
                         Some(self.num_qubits),
+                        Some(device.ordinal()),
                     )?;
 
                     let slice = unsafe { device.alloc::<CuDoubleComplex>(self.size_elements) }
@@ -458,6 +555,7 @@ impl GpuStateVector {
                                 requested_bytes,
                                 "state vector precision conversion",
                                 Some(self.num_qubits),
+                                Some(device.ordinal()),
                                 e,
                             )
                         })?;
@@ -526,6 +624,7 @@ impl GpuStateVector {
                         requested_bytes,
                         "state vector precision conversion",
                         Some(self.num_qubits),
+                        Some(device.ordinal()),
                     )?;
 
                     let slice =
@@ -534,6 +633,7 @@ impl GpuStateVector {
                                 requested_bytes,
                                 "state vector precision conversion",
                                 Some(self.num_qubits),
+                                Some(device.ordinal()),
                                 e,
                             )
                         })?;

--- a/qdp/qdp-core/src/gpu/mod.rs
+++ b/qdp/qdp-core/src/gpu/mod.rs
@@ -31,9 +31,9 @@ pub mod overlap_tracker;
 pub mod pipeline;
 #[cfg(target_os = "linux")]
 pub mod pool_metrics;
+pub mod topology;
 #[cfg(target_os = "linux")]
 pub(crate) mod validation;
-pub mod topology;
 
 #[cfg(target_os = "linux")]
 pub(crate) mod cuda_ffi;
@@ -46,7 +46,7 @@ pub use distributed::{
     DistributedStateVector, DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest,
     PreparedDistributedAmplitudeEncode, ShardPlacement, ShardPolicy, StateShard, StateShardLayout,
 };
-pub use encodings::{AmplitudeEncoder, AngleEncoder, BasisEncoder, QuantumEncoder, get_encoder};
+pub use encodings::{AmplitudeEncoder, AngleEncoder, BasisEncoder, QuantumEncoder};
 pub use memory::GpuStateVector;
 #[cfg(target_os = "linux")]
 #[doc(hidden)]

--- a/qdp/qdp-core/src/gpu/mod.rs
+++ b/qdp/qdp-core/src/gpu/mod.rs
@@ -46,8 +46,9 @@ pub use communicator::{
 };
 pub use distributed::{
     DistributedAmplitudePlan, DistributedExecutionContext, DistributedStateLayout,
-    DistributedStateVector, DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest,
-    PreparedDistributedAmplitudeEncode, ShardPlacement, ShardPolicy, StateShard, StateShardLayout,
+    DistributedStateVector, DistributionMode, LocalShardView, PlacementPlan, PlacementPlanner,
+    PlacementRequest, PreparedDistributedAmplitudeEncode, ShardPlacement, ShardPolicy, StateShard,
+    StateShardLayout,
 };
 pub use encodings::{AmplitudeEncoder, AngleEncoder, BasisEncoder, QuantumEncoder};
 pub use memory::GpuStateVector;

--- a/qdp/qdp-core/src/gpu/mod.rs
+++ b/qdp/qdp-core/src/gpu/mod.rs
@@ -46,9 +46,9 @@ pub use communicator::{
 };
 pub use distributed::{
     DistributedAmplitudePlan, DistributedExecutionContext, DistributedStateLayout,
-    DistributedStateVector, DistributionMode, LocalShardView, PlacementPlan, PlacementPlanner,
-    PlacementRequest, PreparedDistributedAmplitudeEncode, ShardPlacement, ShardPolicy, StateShard,
-    StateShardLayout,
+    DistributedStatePlan, DistributedStateVector, DistributionMode, LocalShardView, PlacementPlan,
+    PlacementPlanner, PlacementRequest, PreparedDistributedAmplitudeEncode, ShardPlacement,
+    ShardPolicy, StateShard, StateShardLayout,
 };
 pub use encodings::{AmplitudeEncoder, AngleEncoder, BasisEncoder, QuantumEncoder};
 pub use memory::GpuStateVector;

--- a/qdp/qdp-core/src/gpu/mod.rs
+++ b/qdp/qdp-core/src/gpu/mod.rs
@@ -40,7 +40,10 @@ pub(crate) mod cuda_ffi;
 
 #[cfg(target_os = "linux")]
 pub use buffer_pool::{PinnedBufferHandle, PinnedBufferPool};
-pub use communicator::{CollectiveCommunicator, LocalCollectiveCommunicator};
+pub use communicator::{
+    CollectiveCommunicator, DeviceCollectiveBackend, DeviceCollectiveCommunicator,
+    LocalCollectiveCommunicator, MpiDeviceCollectiveCommunicator, NcclDeviceCollectiveCommunicator,
+};
 pub use distributed::{
     DistributedAmplitudePlan, DistributedExecutionContext, DistributedStateLayout,
     DistributedStateVector, DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest,

--- a/qdp/qdp-core/src/gpu/mod.rs
+++ b/qdp/qdp-core/src/gpu/mod.rs
@@ -16,8 +16,10 @@
 
 #[cfg(target_os = "linux")]
 pub mod buffer_pool;
+pub mod communicator;
 #[cfg(target_os = "linux")]
 pub(crate) mod cuda_sync;
+pub mod distributed;
 pub mod encodings;
 pub mod memory;
 /// Test-only fidelity / trace-distance helpers. Public so integration tests in
@@ -31,13 +33,20 @@ pub mod pipeline;
 pub mod pool_metrics;
 #[cfg(target_os = "linux")]
 pub(crate) mod validation;
+pub mod topology;
 
 #[cfg(target_os = "linux")]
 pub(crate) mod cuda_ffi;
 
 #[cfg(target_os = "linux")]
 pub use buffer_pool::{PinnedBufferHandle, PinnedBufferPool};
-pub use encodings::{AmplitudeEncoder, AngleEncoder, BasisEncoder, QuantumEncoder};
+pub use communicator::{Communicator, HostCommunicator};
+pub use distributed::{
+    DistributedAmplitudePlan, DistributedStateLayout, DistributedStateVector, DistributionMode,
+    PlacementPlan, PlacementPlanner, PlacementRequest, PreparedDistributedAmplitudeEncode,
+    ShardPlacement, ShardPolicy, StateShard, StateShardLayout,
+};
+pub use encodings::{AmplitudeEncoder, AngleEncoder, BasisEncoder, QuantumEncoder, get_encoder};
 pub use memory::GpuStateVector;
 #[cfg(target_os = "linux")]
 #[doc(hidden)]
@@ -48,6 +57,7 @@ pub use metrics::{
     trace_distance_f32, trace_distance_f64,
 };
 pub use pipeline::run_dual_stream_pipeline;
+pub use topology::{DeviceMesh, GpuTopology, LinkKind};
 
 #[cfg(target_os = "linux")]
 pub use overlap_tracker::OverlapTracker;

--- a/qdp/qdp-core/src/gpu/mod.rs
+++ b/qdp/qdp-core/src/gpu/mod.rs
@@ -40,11 +40,11 @@ pub(crate) mod cuda_ffi;
 
 #[cfg(target_os = "linux")]
 pub use buffer_pool::{PinnedBufferHandle, PinnedBufferPool};
-pub use communicator::{Communicator, HostCommunicator};
+pub use communicator::{CollectiveCommunicator, LocalCollectiveCommunicator};
 pub use distributed::{
-    DistributedAmplitudePlan, DistributedStateLayout, DistributedStateVector, DistributionMode,
-    PlacementPlan, PlacementPlanner, PlacementRequest, PreparedDistributedAmplitudeEncode,
-    ShardPlacement, ShardPolicy, StateShard, StateShardLayout,
+    DistributedAmplitudePlan, DistributedExecutionContext, DistributedStateLayout,
+    DistributedStateVector, DistributionMode, PlacementPlan, PlacementPlanner, PlacementRequest,
+    PreparedDistributedAmplitudeEncode, ShardPlacement, ShardPolicy, StateShard, StateShardLayout,
 };
 pub use encodings::{AmplitudeEncoder, AngleEncoder, BasisEncoder, QuantumEncoder, get_encoder};
 pub use memory::GpuStateVector;

--- a/qdp/qdp-core/src/gpu/pipeline.rs
+++ b/qdp/qdp-core/src/gpu/pipeline.rs
@@ -420,12 +420,23 @@ where
         crate::profile_scope!("GPU::ChunkProcess");
 
         let chunk_bytes = std::mem::size_of_val(chunk);
-        ensure_device_memory_available(chunk_bytes, "pipeline chunk buffer allocation", None)?;
+        ensure_device_memory_available(
+            chunk_bytes,
+            "pipeline chunk buffer allocation",
+            None,
+            Some(device.ordinal()),
+        )?;
 
         // Allocate temporary device buffer for this chunk
         #[allow(clippy::collapsible_if, clippy::manual_is_multiple_of)]
         let input_chunk_dev = unsafe { device.alloc::<T>(chunk.len()) }.map_err(|e| {
-            map_allocation_error(chunk_bytes, "pipeline chunk buffer allocation", None, e)
+            map_allocation_error(
+                chunk_bytes,
+                "pipeline chunk buffer allocation",
+                None,
+                Some(device.ordinal()),
+                e,
+            )
         })?;
 
         // Acquire pinned staging buffer and populate it with the current chunk

--- a/qdp/qdp-core/src/gpu/topology.rs
+++ b/qdp/qdp-core/src/gpu/topology.rs
@@ -1,0 +1,293 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use cudarc::driver::CudaDevice;
+
+use crate::error::{MahoutError, Result};
+#[cfg(target_os = "linux")]
+use crate::{
+    cuda_error_to_string,
+    gpu::cuda_ffi::{CUDA_SUCCESS, cudaDeviceCanAccessPeer},
+};
+
+/// Coarse-grained GPU interconnect classification used for future placement policies.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LinkKind {
+    SameDevice,
+    Pix,
+    Node,
+    Sys,
+    Unknown,
+}
+
+impl LinkKind {
+    fn score(self) -> usize {
+        match self {
+            LinkKind::SameDevice => 4,
+            LinkKind::Pix => 3,
+            LinkKind::Node => 2,
+            LinkKind::Sys => 1,
+            LinkKind::Unknown => 0,
+        }
+    }
+}
+
+/// Runtime topology metadata for a device mesh.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct GpuTopology {
+    pub peer_access: Vec<Vec<bool>>,
+    pub links: Vec<Vec<LinkKind>>,
+}
+
+impl GpuTopology {
+    /// Create a placeholder topology where only self-access is guaranteed.
+    pub fn placeholder(num_devices: usize) -> Self {
+        let mut peer_access = vec![vec![false; num_devices]; num_devices];
+        let mut links = vec![vec![LinkKind::Unknown; num_devices]; num_devices];
+
+        for idx in 0..num_devices {
+            peer_access[idx][idx] = true;
+            links[idx][idx] = LinkKind::SameDevice;
+        }
+
+        Self { peer_access, links }
+    }
+
+    #[cfg(target_os = "linux")]
+    pub fn probe(device_ids: &[usize]) -> Result<Self> {
+        let num_devices = device_ids.len();
+        let mut topology = Self::placeholder(num_devices);
+
+        for (src_idx, &src_device_id) in device_ids.iter().enumerate() {
+            for (dst_idx, &dst_device_id) in device_ids.iter().enumerate() {
+                if src_idx == dst_idx {
+                    continue;
+                }
+
+                let mut can_access_peer = 0i32;
+                let ret = unsafe {
+                    cudaDeviceCanAccessPeer(
+                        &mut can_access_peer as *mut i32,
+                        src_device_id as i32,
+                        dst_device_id as i32,
+                    )
+                };
+
+                if ret != CUDA_SUCCESS {
+                    return Err(MahoutError::Cuda(format!(
+                        "cudaDeviceCanAccessPeer(cuda:{}, cuda:{}) failed: {} ({})",
+                        src_device_id,
+                        dst_device_id,
+                        ret,
+                        cuda_error_to_string(ret)
+                    )));
+                }
+
+                topology.peer_access[src_idx][dst_idx] = can_access_peer != 0;
+            }
+        }
+
+        Ok(topology)
+    }
+
+    pub fn preferred_gather_index(&self) -> Option<usize> {
+        if self.peer_access.is_empty() {
+            return None;
+        }
+
+        let mut best_idx = 0usize;
+        let mut best_score = 0usize;
+        for idx in 0..self.peer_access.len() {
+            let mut score = 0usize;
+            for peer_idx in 0..self.peer_access.len() {
+                if self.peer_access[idx][peer_idx] {
+                    score += 10 + self.links[idx][peer_idx].score();
+                }
+                if self.peer_access[peer_idx][idx] {
+                    score += 10 + self.links[peer_idx][idx].score();
+                }
+            }
+
+            if score > best_score {
+                best_score = score;
+                best_idx = idx;
+            }
+        }
+
+        Some(best_idx)
+    }
+
+    pub fn recommended_placement_order(&self) -> Vec<usize> {
+        let Some(root_idx) = self.preferred_gather_index() else {
+            return Vec::new();
+        };
+
+        let mut indices: Vec<usize> = (0..self.peer_access.len()).collect();
+        indices.sort_by_key(|&idx| {
+            let mut score = 0usize;
+            if self.peer_access[root_idx][idx] {
+                score += 10 + self.links[root_idx][idx].score();
+            }
+            if self.peer_access[idx][root_idx] {
+                score += 10 + self.links[idx][root_idx].score();
+            }
+            (usize::MAX - score, idx)
+        });
+        indices
+    }
+}
+
+/// A validated collection of CUDA devices that will eventually back distributed state vectors.
+#[derive(Clone)]
+pub struct DeviceMesh {
+    pub device_ids: Vec<usize>,
+    pub devices: Vec<Arc<CudaDevice>>,
+    pub topology: GpuTopology,
+}
+
+impl DeviceMesh {
+    /// Build a mesh from CUDA device IDs with a placeholder topology.
+    ///
+    /// This intentionally keeps PR1 lightweight: it validates shape and initializes
+    /// CUDA devices, while a later PR can replace placeholder topology discovery with
+    /// explicit peer-access probing and richer link metadata.
+    pub fn new(device_ids: Vec<usize>) -> Result<Self> {
+        Self::validate_device_ids(&device_ids)?;
+
+        let mut devices = Vec::with_capacity(device_ids.len());
+        for &device_id in &device_ids {
+            let device = CudaDevice::new(device_id).map_err(|e| {
+                MahoutError::Cuda(format!(
+                    "Failed to initialize CUDA device {} for device mesh: {:?}",
+                    device_id, e
+                ))
+            })?;
+            devices.push(device);
+        }
+
+        #[cfg(target_os = "linux")]
+        let topology = GpuTopology::probe(&device_ids)?;
+        #[cfg(not(target_os = "linux"))]
+        let topology = GpuTopology::placeholder(device_ids.len());
+
+        Ok(Self {
+            device_ids,
+            devices,
+            topology,
+        })
+    }
+
+    /// Build a mesh from explicit parts. Intended for tests and future topology injection.
+    pub fn from_parts(
+        device_ids: Vec<usize>,
+        devices: Vec<Arc<CudaDevice>>,
+        topology: GpuTopology,
+    ) -> Result<Self> {
+        Self::validate_device_ids(&device_ids)?;
+
+        if device_ids.len() != devices.len() {
+            return Err(MahoutError::InvalidInput(format!(
+                "Device mesh mismatch: {} device IDs but {} device handles",
+                device_ids.len(),
+                devices.len()
+            )));
+        }
+        for (&device_id, device) in device_ids.iter().zip(devices.iter()) {
+            if device.ordinal() != device_id {
+                return Err(MahoutError::InvalidInput(format!(
+                    "Device mesh ordinal mismatch: declared cuda:{} but handle targets cuda:{}",
+                    device_id,
+                    device.ordinal()
+                )));
+            }
+        }
+
+        let num_devices = device_ids.len();
+        if topology.peer_access.len() != num_devices || topology.links.len() != num_devices {
+            return Err(MahoutError::InvalidInput(format!(
+                "Topology dimension mismatch for {} devices",
+                num_devices
+            )));
+        }
+        if topology
+            .peer_access
+            .iter()
+            .any(|row| row.len() != num_devices)
+            || topology.links.iter().any(|row| row.len() != num_devices)
+        {
+            return Err(MahoutError::InvalidInput(format!(
+                "Topology row width mismatch for {} devices",
+                num_devices
+            )));
+        }
+
+        Ok(Self {
+            device_ids,
+            devices,
+            topology,
+        })
+    }
+
+    pub fn num_devices(&self) -> usize {
+        self.device_ids.len()
+    }
+
+    pub fn validate_power_of_two(&self) -> Result<()> {
+        let num_devices = self.num_devices();
+        if !num_devices.is_power_of_two() {
+            return Err(MahoutError::InvalidInput(format!(
+                "Distributed QDP currently requires a power-of-two device count, got {}",
+                num_devices
+            )));
+        }
+        Ok(())
+    }
+
+    pub fn recommended_gather_device_id(&self) -> Option<usize> {
+        self.topology
+            .preferred_gather_index()
+            .map(|idx| self.device_ids[idx])
+    }
+
+    pub fn recommended_placement_device_ids(&self) -> Vec<usize> {
+        self.topology
+            .recommended_placement_order()
+            .into_iter()
+            .map(|idx| self.device_ids[idx])
+            .collect()
+    }
+
+    fn validate_device_ids(device_ids: &[usize]) -> Result<()> {
+        if device_ids.is_empty() {
+            return Err(MahoutError::InvalidInput(
+                "Device mesh requires at least one device ID".to_string(),
+            ));
+        }
+
+        let mut sorted = device_ids.to_vec();
+        sorted.sort_unstable();
+        sorted.dedup();
+        if sorted.len() != device_ids.len() {
+            return Err(MahoutError::InvalidInput(
+                "Device mesh contains duplicate device IDs".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+}

--- a/qdp/qdp-core/src/gpu/topology.rs
+++ b/qdp/qdp-core/src/gpu/topology.rs
@@ -25,7 +25,7 @@ use crate::{
     gpu::cuda_ffi::{CUDA_SUCCESS, cudaDeviceCanAccessPeer},
 };
 
-/// Coarse-grained GPU interconnect classification used for future placement policies.
+/// Coarse-grained GPU interconnect classification used by placement policies.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LinkKind {
     SameDevice,
@@ -152,7 +152,7 @@ impl GpuTopology {
     }
 }
 
-/// A validated collection of CUDA devices that will eventually back distributed state vectors.
+/// A validated collection of CUDA devices that back one distributed execution context.
 #[derive(Clone)]
 pub struct DeviceMesh {
     pub device_ids: Vec<usize>,
@@ -161,11 +161,11 @@ pub struct DeviceMesh {
 }
 
 impl DeviceMesh {
-    /// Build a mesh from CUDA device IDs with a placeholder topology.
+    /// Build a mesh from CUDA device IDs.
     ///
-    /// This intentionally keeps PR1 lightweight: it validates shape and initializes
-    /// CUDA devices, while a later PR can replace placeholder topology discovery with
-    /// explicit peer-access probing and richer link metadata.
+    /// On Linux this probes peer-access reachability so placement policies can
+    /// prefer the most connected devices without changing the caller-provided
+    /// device set.
     pub fn new(device_ids: Vec<usize>) -> Result<Self> {
         Self::validate_device_ids(&device_ids)?;
 
@@ -192,7 +192,8 @@ impl DeviceMesh {
         })
     }
 
-    /// Build a mesh from explicit parts. Intended for tests and future topology injection.
+    /// Build a mesh from explicit parts. Intended for tests and injected
+    /// topology metadata.
     pub fn from_parts(
         device_ids: Vec<usize>,
         devices: Vec<Arc<CudaDevice>>,
@@ -270,6 +271,20 @@ impl DeviceMesh {
             .into_iter()
             .map(|idx| self.device_ids[idx])
             .collect()
+    }
+
+    pub fn device_for_id(&self, device_id: usize) -> Result<Arc<CudaDevice>> {
+        let index = self
+            .device_ids
+            .iter()
+            .position(|&candidate| candidate == device_id)
+            .ok_or_else(|| {
+                MahoutError::InvalidInput(format!(
+                    "Device mesh does not contain cuda:{}",
+                    device_id
+                ))
+            })?;
+        Ok(Arc::clone(&self.devices[index]))
     }
 
     fn validate_device_ids(device_ids: &[usize]) -> Result<()> {

--- a/qdp/qdp-core/src/gpu/topology.rs
+++ b/qdp/qdp-core/src/gpu/topology.rs
@@ -69,6 +69,7 @@ impl GpuTopology {
     }
 
     #[cfg(target_os = "linux")]
+    /// Probe peer-access reachability for one caller-provided device list.
     pub fn probe(device_ids: &[usize]) -> Result<Self> {
         let num_devices = device_ids.len();
         let mut topology = Self::placeholder(num_devices);
@@ -105,6 +106,7 @@ impl GpuTopology {
         Ok(topology)
     }
 
+    /// Choose the most connected device index as the preferred gather root.
     pub fn preferred_gather_index(&self) -> Option<usize> {
         if self.peer_access.is_empty() {
             return None;
@@ -132,6 +134,7 @@ impl GpuTopology {
         Some(best_idx)
     }
 
+    /// Rank device indices by how favorable they are for distributed placement.
     pub fn recommended_placement_order(&self) -> Vec<usize> {
         let Some(root_idx) = self.preferred_gather_index() else {
             return Vec::new();
@@ -244,10 +247,12 @@ impl DeviceMesh {
         })
     }
 
+    /// Number of devices represented by this mesh.
     pub fn num_devices(&self) -> usize {
         self.device_ids.len()
     }
 
+    /// Enforce a power-of-two device count for policies that require equal shards.
     pub fn validate_power_of_two(&self) -> Result<()> {
         let num_devices = self.num_devices();
         if !num_devices.is_power_of_two() {
@@ -259,12 +264,14 @@ impl DeviceMesh {
         Ok(())
     }
 
+    /// Recommended gather device ID derived from the current topology metadata.
     pub fn recommended_gather_device_id(&self) -> Option<usize> {
         self.topology
             .preferred_gather_index()
             .map(|idx| self.device_ids[idx])
     }
 
+    /// Preferred device IDs for placement in topology-aware order.
     pub fn recommended_placement_device_ids(&self) -> Vec<usize> {
         self.topology
             .recommended_placement_order()
@@ -273,6 +280,7 @@ impl DeviceMesh {
             .collect()
     }
 
+    /// Resolve one CUDA device handle by declared device ID.
     pub fn device_for_id(&self, device_id: usize) -> Result<Arc<CudaDevice>> {
         let index = self
             .device_ids

--- a/qdp/qdp-core/src/lib.rs
+++ b/qdp/qdp-core/src/lib.rs
@@ -38,10 +38,9 @@ mod profiling;
 pub use error::{MahoutError, Result, cuda_error_to_string};
 pub use gpu::memory::Precision;
 pub use gpu::{
-    Communicator, DeviceMesh, DistributedAmplitudePlan, DistributedStateLayout,
-    DistributedStateVector, DistributionMode, GpuTopology, HostCommunicator, LinkKind,
-    PlacementPlan, PlacementPlanner, PlacementRequest, PreparedDistributedAmplitudeEncode,
-    ShardPlacement, ShardPolicy,
+    DeviceMesh, DistributedAmplitudePlan, DistributedExecutionContext, DistributedStateVector,
+    DistributionMode, GpuTopology, LinkKind, PlacementRequest, PreparedDistributedAmplitudeEncode,
+    ShardPolicy,
 };
 pub use reader::{FloatElem, NullHandling, handle_float32_nulls, handle_float64_nulls};
 pub use types::{Dtype, Encoding};
@@ -147,19 +146,15 @@ impl QdpEngine {
         })
     }
 
-    /// Build a validated multi-GPU mesh for future distributed encoding paths.
-    ///
-    /// PR1 exposes mesh construction without changing the single-device engine shape.
+    /// Build a validated device mesh for one distributed execution context.
     pub fn new_distributed_mesh(device_ids: Vec<usize>) -> Result<DeviceMesh> {
         DeviceMesh::new(device_ids)
     }
 
-    /// Prepare a distributed amplitude encode on a validated multi-GPU mesh.
+    /// Prepare a distributed amplitude encode on a single-process device mesh.
     ///
-    /// This stage performs input validation, shard planning, and host-coordinated
-    /// global norm reduction, then returns metadata for the future distributed
-    /// state layout. It does not yet allocate per-shard buffers or launch
-    /// multi-GPU kernels.
+    /// This is a convenience wrapper over `prepare_distributed_amplitude_on`
+    /// using an in-process collective implementation.
     #[doc(hidden)]
     pub fn prepare_distributed_amplitude(
         device_ids: Vec<usize>,
@@ -168,50 +163,49 @@ impl QdpEngine {
         precision: Precision,
         request: Option<PlacementRequest>,
     ) -> Result<PreparedDistributedAmplitudeEncode> {
-        let communicator = HostCommunicator;
-        Self::prepare_distributed_amplitude_with_communicator(
-            device_ids,
+        let request = Self::resolve_distributed_request(num_qubits, request)?;
+        runtime::validate_distributed_input(data, &request)?;
+        let collectives = crate::gpu::LocalCollectiveCommunicator;
+        let execution = DistributedExecutionContext::single_process(device_ids, &collectives)?;
+        Self::prepare_distributed_amplitude_on(
+            &execution,
             data,
             num_qubits,
             precision,
-            request,
-            &communicator,
+            Some(request),
         )
     }
 
-    /// Prepare a distributed amplitude encode with an injected collective
-    /// implementation. This keeps the execution path compatible with future
-    /// MPI-backed or NCCL-backed coordination without hard-coding a specific
-    /// transport into the engine surface.
+    /// Prepare a distributed amplitude encode on an explicit execution context.
+    ///
+    /// The execution context owns the participating device mesh and the
+    /// collective implementation that coordinates those shards.
     #[doc(hidden)]
-    pub fn prepare_distributed_amplitude_with_communicator(
-        device_ids: Vec<usize>,
+    pub fn prepare_distributed_amplitude_on(
+        execution: &DistributedExecutionContext<'_>,
         data: &[f64],
         num_qubits: usize,
         precision: Precision,
         request: Option<PlacementRequest>,
-        communicator: &dyn Communicator,
     ) -> Result<PreparedDistributedAmplitudeEncode> {
         let request = Self::resolve_distributed_request(num_qubits, request)?;
         runtime::validate_distributed_input(data, &request)?;
-        let mesh = Self::new_distributed_mesh(device_ids)?;
         let (plan, inv_norm, layout) =
-            runtime::prepare_distributed_encode(&mesh, data, precision, request, communicator)?;
+            runtime::prepare_distributed_encode(execution, data, precision, request)?;
 
         Ok(PreparedDistributedAmplitudeEncode {
-            mesh,
+            mesh: execution.mesh().clone(),
             plan,
             inv_norm,
             layout,
         })
     }
 
-    /// Encode amplitude data into real per-device shard buffers for a distributed
-    /// state vector on a single host.
+    /// Encode amplitude data into real per-device shard buffers on a
+    /// single-process device mesh.
     ///
-    /// This is the first executable distributed path: it returns a sharded state
-    /// object with one GPU buffer per shard. It does not expose DLPack or gather
-    /// semantics yet.
+    /// This is a convenience wrapper over `encode_distributed_amplitude_to_shards_on`
+    /// using an in-process collective implementation.
     #[doc(hidden)]
     pub fn encode_distributed_amplitude_to_shards(
         device_ids: Vec<usize>,
@@ -220,33 +214,32 @@ impl QdpEngine {
         precision: Precision,
         request: Option<PlacementRequest>,
     ) -> Result<DistributedStateVector> {
-        let communicator = HostCommunicator;
-        Self::encode_distributed_amplitude_to_shards_with_communicator(
-            device_ids,
+        let request = Self::resolve_distributed_request(num_qubits, request)?;
+        runtime::validate_distributed_input(data, &request)?;
+        let collectives = crate::gpu::LocalCollectiveCommunicator;
+        let execution = DistributedExecutionContext::single_process(device_ids, &collectives)?;
+        Self::encode_distributed_amplitude_to_shards_on(
+            &execution,
             data,
             num_qubits,
             precision,
-            request,
-            &communicator,
+            Some(request),
         )
     }
 
-    /// Materialize a distributed amplitude state with an injected collective
-    /// implementation. This is the execution-oriented companion to
-    /// `prepare_distributed_amplitude_with_communicator`.
+    /// Materialize a distributed amplitude state on an explicit execution
+    /// context.
     #[doc(hidden)]
-    pub fn encode_distributed_amplitude_to_shards_with_communicator(
-        device_ids: Vec<usize>,
+    pub fn encode_distributed_amplitude_to_shards_on(
+        execution: &DistributedExecutionContext<'_>,
         data: &[f64],
         num_qubits: usize,
         precision: Precision,
         request: Option<PlacementRequest>,
-        communicator: &dyn Communicator,
     ) -> Result<DistributedStateVector> {
         let request = Self::resolve_distributed_request(num_qubits, request)?;
         runtime::validate_distributed_input(data, &request)?;
-        let mesh = Self::new_distributed_mesh(device_ids)?;
-        runtime::encode_distributed_to_shards(&mesh, data, precision, request, communicator)
+        runtime::encode_distributed_to_shards(execution, data, precision, request)
     }
 
     fn resolve_distributed_request(

--- a/qdp/qdp-core/src/lib.rs
+++ b/qdp/qdp-core/src/lib.rs
@@ -38,9 +38,8 @@ mod profiling;
 pub use error::{MahoutError, Result, cuda_error_to_string};
 pub use gpu::memory::Precision;
 pub use gpu::{
-    DeviceMesh, DistributedAmplitudePlan, DistributedExecutionContext, DistributedStateVector,
-    DistributionMode, GpuTopology, LinkKind, PlacementRequest, PreparedDistributedAmplitudeEncode,
-    ShardPolicy,
+    DeviceMesh, DistributedExecutionContext, DistributedStateVector, DistributionMode,
+    PlacementRequest, PreparedDistributedAmplitudeEncode, ShardPolicy,
 };
 pub use reader::{FloatElem, NullHandling, handle_float32_nulls, handle_float64_nulls};
 pub use types::{Dtype, Encoding};

--- a/qdp/qdp-core/src/lib.rs
+++ b/qdp/qdp-core/src/lib.rs
@@ -37,6 +37,11 @@ mod profiling;
 
 pub use error::{MahoutError, Result, cuda_error_to_string};
 pub use gpu::memory::Precision;
+pub use gpu::{
+    DeviceMesh, DistributedAmplitudePlan, DistributedStateLayout, DistributedStateVector,
+    DistributionMode, GpuTopology, LinkKind, PlacementPlan, PlacementPlanner, PlacementRequest,
+    PreparedDistributedAmplitudeEncode, ShardPlacement, ShardPolicy,
+};
 pub use reader::{FloatElem, NullHandling, handle_float32_nulls, handle_float64_nulls};
 pub use types::{Dtype, Encoding};
 
@@ -54,6 +59,9 @@ use std::ffi::c_void;
 use std::sync::Arc;
 
 use crate::dlpack::DLManagedTensor;
+use crate::gpu::HostCommunicator;
+use crate::gpu::distributed::runtime;
+use crate::gpu::get_encoder;
 use cudarc::driver::CudaDevice;
 
 #[cfg(target_os = "linux")]
@@ -137,6 +145,85 @@ impl QdpEngine {
             device, // CudaDevice::new already returns Arc<CudaDevice> in cudarc 0.11
             precision,
         })
+    }
+
+    /// Build a validated multi-GPU mesh for future distributed encoding paths.
+    ///
+    /// PR1 exposes mesh construction without changing the single-device engine shape.
+    pub fn new_distributed_mesh(device_ids: Vec<usize>) -> Result<DeviceMesh> {
+        DeviceMesh::new(device_ids)
+    }
+
+    /// Prepare a distributed amplitude encode on a validated multi-GPU mesh.
+    ///
+    /// This stage performs input validation, shard planning, and host-coordinated
+    /// global norm reduction, then returns metadata for the future distributed
+    /// state layout. It does not yet allocate per-shard buffers or launch
+    /// multi-GPU kernels.
+    #[doc(hidden)]
+    pub fn prepare_distributed_amplitude(
+        device_ids: Vec<usize>,
+        data: &[f64],
+        num_qubits: usize,
+        precision: Precision,
+        request: Option<PlacementRequest>,
+    ) -> Result<PreparedDistributedAmplitudeEncode> {
+        let request = Self::resolve_distributed_request(num_qubits, request)?;
+        runtime::validate_distributed_input(data, &request)?;
+        let mesh = Self::new_distributed_mesh(device_ids)?;
+        let communicator = HostCommunicator;
+        let (plan, inv_norm, layout) =
+            runtime::prepare_distributed_encode(&mesh, data, precision, request, &communicator)?;
+
+        Ok(PreparedDistributedAmplitudeEncode {
+            mesh,
+            plan,
+            inv_norm,
+            layout,
+        })
+    }
+
+    /// Encode amplitude data into real per-device shard buffers for a distributed
+    /// state vector on a single host.
+    ///
+    /// This is the first executable distributed path: it returns a sharded state
+    /// object with one GPU buffer per shard. It does not expose DLPack or gather
+    /// semantics yet.
+    #[doc(hidden)]
+    pub fn encode_distributed_amplitude_to_shards(
+        device_ids: Vec<usize>,
+        data: &[f64],
+        num_qubits: usize,
+        precision: Precision,
+        request: Option<PlacementRequest>,
+    ) -> Result<DistributedStateVector> {
+        let request = Self::resolve_distributed_request(num_qubits, request)?;
+        runtime::validate_distributed_input(data, &request)?;
+        let mesh = Self::new_distributed_mesh(device_ids)?;
+        let communicator = HostCommunicator;
+        runtime::encode_distributed_to_shards(&mesh, data, precision, request, &communicator)
+    }
+
+    fn resolve_distributed_request(
+        num_qubits: usize,
+        request: Option<PlacementRequest>,
+    ) -> Result<PlacementRequest> {
+        match request {
+            Some(request) => {
+                if request.num_qubits != num_qubits {
+                    return Err(MahoutError::InvalidInput(format!(
+                        "Distributed request qubit mismatch: argument specifies {} qubits but request specifies {}",
+                        num_qubits, request.num_qubits
+                    )));
+                }
+                Ok(request)
+            }
+            None => Ok(PlacementRequest::new(
+                num_qubits,
+                DistributionMode::ShardedCapacity,
+                ShardPolicy::Equal,
+            )),
+        }
     }
 
     /// Encode classical data into quantum state

--- a/qdp/qdp-core/src/lib.rs
+++ b/qdp/qdp-core/src/lib.rs
@@ -187,7 +187,8 @@ impl QdpEngine {
         precision: Precision,
         request: Option<PlacementRequest>,
     ) -> Result<PreparedDistributedAmplitudeEncode> {
-        let request = Self::resolve_distributed_request(num_qubits, request)?;
+        let request =
+            Self::resolve_distributed_request_for_execution(num_qubits, request, execution)?;
         runtime::validate_distributed_input(data, &request)?;
         let (plan, inv_norm, layout) =
             runtime::prepare_distributed_encode(execution, data, precision, request)?;
@@ -236,7 +237,8 @@ impl QdpEngine {
         precision: Precision,
         request: Option<PlacementRequest>,
     ) -> Result<DistributedStateVector> {
-        let request = Self::resolve_distributed_request(num_qubits, request)?;
+        let request =
+            Self::resolve_distributed_request_for_execution(num_qubits, request, execution)?;
         runtime::validate_distributed_input(data, &request)?;
         runtime::encode_distributed_to_shards(execution, data, precision, request)
     }
@@ -260,6 +262,32 @@ impl QdpEngine {
                 DistributionMode::ShardedCapacity,
                 ShardPolicy::Equal,
             )),
+        }
+    }
+
+    fn resolve_distributed_request_for_execution(
+        num_qubits: usize,
+        request: Option<PlacementRequest>,
+        execution: &DistributedExecutionContext<'_>,
+    ) -> Result<PlacementRequest> {
+        match request {
+            Some(request) => {
+                let request = Self::resolve_distributed_request(num_qubits, Some(request))?;
+                if request.world_size != execution.world_size() {
+                    return Err(MahoutError::InvalidInput(format!(
+                        "Distributed request world size mismatch: execution world size {} but request specifies {}",
+                        execution.world_size(),
+                        request.world_size
+                    )));
+                }
+                Ok(request)
+            }
+            None => PlacementRequest::new_with_world(
+                num_qubits,
+                DistributionMode::ShardedCapacity,
+                ShardPolicy::Equal,
+                execution.world_size(),
+            ),
         }
     }
 

--- a/qdp/qdp-core/src/lib.rs
+++ b/qdp/qdp-core/src/lib.rs
@@ -60,7 +60,6 @@ use std::sync::Arc;
 
 use crate::dlpack::DLManagedTensor;
 use crate::gpu::distributed::runtime;
-use crate::gpu::get_encoder;
 use cudarc::driver::CudaDevice;
 
 #[cfg(target_os = "linux")]

--- a/qdp/qdp-core/src/lib.rs
+++ b/qdp/qdp-core/src/lib.rs
@@ -38,9 +38,10 @@ mod profiling;
 pub use error::{MahoutError, Result, cuda_error_to_string};
 pub use gpu::memory::Precision;
 pub use gpu::{
-    DeviceMesh, DistributedAmplitudePlan, DistributedStateLayout, DistributedStateVector,
-    DistributionMode, GpuTopology, LinkKind, PlacementPlan, PlacementPlanner, PlacementRequest,
-    PreparedDistributedAmplitudeEncode, ShardPlacement, ShardPolicy,
+    Communicator, DeviceMesh, DistributedAmplitudePlan, DistributedStateLayout,
+    DistributedStateVector, DistributionMode, GpuTopology, HostCommunicator, LinkKind,
+    PlacementPlan, PlacementPlanner, PlacementRequest, PreparedDistributedAmplitudeEncode,
+    ShardPlacement, ShardPolicy,
 };
 pub use reader::{FloatElem, NullHandling, handle_float32_nulls, handle_float64_nulls};
 pub use types::{Dtype, Encoding};
@@ -59,7 +60,6 @@ use std::ffi::c_void;
 use std::sync::Arc;
 
 use crate::dlpack::DLManagedTensor;
-use crate::gpu::HostCommunicator;
 use crate::gpu::distributed::runtime;
 use crate::gpu::get_encoder;
 use cudarc::driver::CudaDevice;
@@ -168,12 +168,35 @@ impl QdpEngine {
         precision: Precision,
         request: Option<PlacementRequest>,
     ) -> Result<PreparedDistributedAmplitudeEncode> {
+        let communicator = HostCommunicator;
+        Self::prepare_distributed_amplitude_with_communicator(
+            device_ids,
+            data,
+            num_qubits,
+            precision,
+            request,
+            &communicator,
+        )
+    }
+
+    /// Prepare a distributed amplitude encode with an injected collective
+    /// implementation. This keeps the execution path compatible with future
+    /// MPI-backed or NCCL-backed coordination without hard-coding a specific
+    /// transport into the engine surface.
+    #[doc(hidden)]
+    pub fn prepare_distributed_amplitude_with_communicator(
+        device_ids: Vec<usize>,
+        data: &[f64],
+        num_qubits: usize,
+        precision: Precision,
+        request: Option<PlacementRequest>,
+        communicator: &dyn Communicator,
+    ) -> Result<PreparedDistributedAmplitudeEncode> {
         let request = Self::resolve_distributed_request(num_qubits, request)?;
         runtime::validate_distributed_input(data, &request)?;
         let mesh = Self::new_distributed_mesh(device_ids)?;
-        let communicator = HostCommunicator;
         let (plan, inv_norm, layout) =
-            runtime::prepare_distributed_encode(&mesh, data, precision, request, &communicator)?;
+            runtime::prepare_distributed_encode(&mesh, data, precision, request, communicator)?;
 
         Ok(PreparedDistributedAmplitudeEncode {
             mesh,
@@ -197,11 +220,33 @@ impl QdpEngine {
         precision: Precision,
         request: Option<PlacementRequest>,
     ) -> Result<DistributedStateVector> {
+        let communicator = HostCommunicator;
+        Self::encode_distributed_amplitude_to_shards_with_communicator(
+            device_ids,
+            data,
+            num_qubits,
+            precision,
+            request,
+            &communicator,
+        )
+    }
+
+    /// Materialize a distributed amplitude state with an injected collective
+    /// implementation. This is the execution-oriented companion to
+    /// `prepare_distributed_amplitude_with_communicator`.
+    #[doc(hidden)]
+    pub fn encode_distributed_amplitude_to_shards_with_communicator(
+        device_ids: Vec<usize>,
+        data: &[f64],
+        num_qubits: usize,
+        precision: Precision,
+        request: Option<PlacementRequest>,
+        communicator: &dyn Communicator,
+    ) -> Result<DistributedStateVector> {
         let request = Self::resolve_distributed_request(num_qubits, request)?;
         runtime::validate_distributed_input(data, &request)?;
         let mesh = Self::new_distributed_mesh(device_ids)?;
-        let communicator = HostCommunicator;
-        runtime::encode_distributed_to_shards(&mesh, data, precision, request, &communicator)
+        runtime::encode_distributed_to_shards(&mesh, data, precision, request, communicator)
     }
 
     fn resolve_distributed_request(

--- a/qdp/qdp-core/tests/common/mod.rs
+++ b/qdp/qdp-core/tests/common/mod.rs
@@ -22,6 +22,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use arrow::record_batch::RecordBatch;
 use parquet::arrow::ArrowWriter;
 use parquet::file::properties::WriterProperties;
+use qdp_core::gpu::{CollectiveCommunicator, DeviceMesh, GpuTopology};
 
 #[cfg(target_os = "linux")]
 use cudarc::driver::{CudaDevice, CudaSlice};
@@ -29,6 +30,91 @@ use cudarc::driver::{CudaDevice, CudaSlice};
 use qdp_core::dlpack::DLManagedTensor;
 #[cfg(target_os = "linux")]
 use qdp_core::{Precision, QdpEngine};
+
+#[allow(dead_code)]
+pub fn placeholder_mesh(device_ids: Vec<usize>) -> DeviceMesh {
+    let topology = GpuTopology::placeholder(device_ids.len());
+    DeviceMesh {
+        device_ids,
+        devices: Vec::new(),
+        topology,
+    }
+}
+
+#[derive(Clone, Copy)]
+#[allow(dead_code)]
+pub struct TestCollective {
+    pub rank: usize,
+    pub world_size: usize,
+}
+
+impl TestCollective {
+    #[allow(dead_code)]
+    pub fn new(rank: usize, world_size: usize) -> Self {
+        Self { rank, world_size }
+    }
+}
+
+impl CollectiveCommunicator for TestCollective {
+    fn rank(&self) -> usize {
+        self.rank
+    }
+
+    fn world_size(&self) -> usize {
+        self.world_size
+    }
+
+    fn all_reduce_sum_f64(&self, local_value: f64) -> qdp_core::Result<f64> {
+        Ok(local_value)
+    }
+}
+
+#[derive(Clone)]
+#[allow(dead_code)]
+pub struct RecordingCollective {
+    pub rank: usize,
+    pub world_size: usize,
+    pub global_sum: f64,
+    pub seen: std::sync::Arc<std::sync::Mutex<Vec<f64>>>,
+}
+
+impl RecordingCollective {
+    #[allow(dead_code)]
+    pub fn new(
+        rank: usize,
+        world_size: usize,
+        global_sum: f64,
+    ) -> (Self, std::sync::Arc<std::sync::Mutex<Vec<f64>>>) {
+        let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        (
+            Self {
+                rank,
+                world_size,
+                global_sum,
+                seen: std::sync::Arc::clone(&seen),
+            },
+            seen,
+        )
+    }
+}
+
+impl CollectiveCommunicator for RecordingCollective {
+    fn rank(&self) -> usize {
+        self.rank
+    }
+
+    fn world_size(&self) -> usize {
+        self.world_size
+    }
+
+    fn all_reduce_sum_f64(&self, local_value: f64) -> qdp_core::Result<f64> {
+        self.seen
+            .lock()
+            .expect("recording collective observations mutex poisoned")
+            .push(local_value);
+        Ok(self.global_sum)
+    }
+}
 
 /// Creates normalized test data (f64)
 #[allow(dead_code)] // Used by multiple test modules
@@ -86,6 +172,23 @@ pub fn write_fixed_size_list_parquet(path: &str, data: &[f64], sample_size: usiz
 #[allow(dead_code)]
 pub fn cuda_device() -> Option<Arc<CudaDevice>> {
     CudaDevice::new(0).ok()
+}
+
+/// Returns one CUDA device handle by ordinal, or `None` when unavailable.
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+pub fn cuda_device_by_id(device_id: usize) -> Option<Arc<CudaDevice>> {
+    CudaDevice::new(device_id).ok()
+}
+
+/// Returns all requested CUDA device handles, or `None` if any device is unavailable.
+#[cfg(target_os = "linux")]
+#[allow(dead_code)]
+pub fn cuda_devices(device_ids: &[usize]) -> Option<Vec<Arc<CudaDevice>>> {
+    device_ids
+        .iter()
+        .map(|&device_id| cuda_device_by_id(device_id))
+        .collect()
 }
 
 /// Returns a QDP engine, or `None` when GPU-backed engine initialization is unavailable.

--- a/qdp/qdp-core/tests/gpu_api_workflow.rs
+++ b/qdp/qdp-core/tests/gpu_api_workflow.rs
@@ -274,8 +274,8 @@ fn test_distributed_amplitude_two_gpu_smoke() {
     .expect("Distributed amplitude shard encode should succeed");
 
     assert_eq!(distributed.num_shards(), 2, "Expected two shards");
-    assert_eq!(distributed.shards[0].device_id, 0);
-    assert_eq!(distributed.shards[1].device_id, 1);
+    assert_eq!(distributed.shards()[0].device_id, 0);
+    assert_eq!(distributed.shards()[1].device_id, 1);
 
     let shard0 = distributed.copy_shard_to_host_f64(0).unwrap();
     let shard1 = distributed.copy_shard_to_host_f64(1).unwrap();

--- a/qdp/qdp-core/tests/gpu_api_workflow.rs
+++ b/qdp/qdp-core/tests/gpu_api_workflow.rs
@@ -18,9 +18,9 @@
 
 #[cfg(target_os = "linux")]
 use qdp_core::MahoutError;
-use qdp_core::QdpEngine;
 #[cfg(target_os = "linux")]
 use qdp_core::gpu::pipeline::run_dual_stream_pipeline_aligned;
+use qdp_core::{Precision, QdpEngine};
 
 mod common;
 
@@ -246,6 +246,54 @@ fn test_single_encode_dlpack_2d_shape() {
 
         common::take_deleter_and_delete(dlpack_ptr);
     }
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn test_distributed_amplitude_two_gpu_smoke() {
+    println!("Testing distributed amplitude shard encode on two GPUs...");
+
+    if common::cuda_device().is_none() {
+        println!("SKIP: No GPU available");
+        return;
+    }
+
+    if cudarc::driver::CudaDevice::new(1).is_err() {
+        println!("SKIP: Second GPU unavailable");
+        return;
+    }
+
+    let data = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let distributed = QdpEngine::encode_distributed_amplitude_to_shards(
+        vec![0, 1],
+        &data,
+        3,
+        Precision::Float64,
+        None,
+    )
+    .expect("Distributed amplitude shard encode should succeed");
+
+    assert_eq!(distributed.num_shards(), 2, "Expected two shards");
+    assert_eq!(distributed.shards[0].device_id, 0);
+    assert_eq!(distributed.shards[1].device_id, 1);
+
+    let shard0 = distributed.copy_shard_to_host_f64(0).unwrap();
+    let shard1 = distributed.copy_shard_to_host_f64(1).unwrap();
+
+    assert_eq!(shard0.len(), 4);
+    assert_eq!(shard1.len(), 4);
+
+    let total_prob: f64 = shard0
+        .iter()
+        .chain(shard1.iter())
+        .map(|value| value.x * value.x + value.y * value.y)
+        .sum();
+    assert!(
+        (total_prob - 1.0).abs() < 1e-10,
+        "Distributed state should remain normalized"
+    );
+
+    println!("PASS: Distributed amplitude shard encode succeeded on two GPUs");
 }
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
@@ -1,3 +1,19 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use qdp_core::{
     DeviceMesh, DistributedAmplitudePlan, DistributedStateLayout, DistributionMode, GpuTopology,
     PlacementRequest, Precision, ShardPolicy,
@@ -48,19 +64,29 @@ fn distributed_amplitude_plan_allows_extra_global_qubit_when_shards_fit() {
 }
 
 #[test]
-fn distributed_amplitude_plan_rejects_global_qubits_when_local_shard_exceeds_single_gpu_limit() {
-    let topology = GpuTopology::placeholder(1);
+fn distributed_amplitude_plan_supports_q34_with_balanced_six_gpu_shards() {
+    let topology = GpuTopology::placeholder(6);
     let mesh = DeviceMesh {
-        device_ids: vec![0],
+        device_ids: vec![0, 1, 2, 3, 4, 5],
         devices: Vec::new(),
         topology,
     };
-    let request = PlacementRequest::new(31, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
-    let err = DistributedAmplitudePlan::for_request(&mesh, request).unwrap_err();
-    assert!(matches!(
-        err,
-        qdp_core::MahoutError::InvalidInput(msg) if msg.contains("per-device capacity")
-    ));
+    let request = PlacementRequest::new(
+        34,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::BalancedUneven,
+    );
+    let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
+
+    assert_eq!(plan.global_len, 1usize << 34);
+    assert_eq!(plan.num_devices, 6);
+    assert_eq!(plan.shard_bits, None);
+    assert_eq!(plan.uniform_shard_len, None);
+    assert_eq!(plan.shard_range(0).unwrap(), (0, 2_863_311_531));
+    assert_eq!(
+        plan.shard_range(5).unwrap(),
+        (14_316_557_654, 17_179_869_184)
+    );
 }
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
@@ -1,0 +1,140 @@
+use qdp_core::{
+    DeviceMesh, DistributedAmplitudePlan, DistributedStateLayout, DistributionMode, GpuTopology,
+    PlacementRequest, Precision, ShardPolicy,
+};
+
+#[test]
+fn distributed_amplitude_plan_has_expected_shard_math() {
+    let topology = GpuTopology::placeholder(4);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1, 2, 3],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(4, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
+    assert_eq!(plan.global_len, 16);
+    assert_eq!(plan.shard_bits, Some(2));
+    assert_eq!(plan.uniform_shard_len, Some(4));
+    assert_eq!(plan.shard_range(0).unwrap(), (0, 4));
+    assert_eq!(plan.shard_range(3).unwrap(), (12, 16));
+}
+
+#[test]
+fn distributed_amplitude_plan_rejects_too_many_devices_for_qubits() {
+    let topology = GpuTopology::placeholder(4);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1, 2, 3],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(1, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let err = DistributedAmplitudePlan::for_request(&mesh, request).unwrap_err();
+    assert!(matches!(err, qdp_core::MahoutError::InvalidInput(_)));
+}
+
+#[test]
+fn distributed_amplitude_plan_allows_extra_global_qubit_when_shards_fit() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(31, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
+    assert_eq!(plan.global_len, 1usize << 31);
+    assert_eq!(plan.uniform_shard_len, Some(1usize << 30));
+}
+
+#[test]
+fn distributed_amplitude_plan_rejects_global_qubits_when_local_shard_exceeds_single_gpu_limit() {
+    let topology = GpuTopology::placeholder(1);
+    let mesh = DeviceMesh {
+        device_ids: vec![0],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(31, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let err = DistributedAmplitudePlan::for_request(&mesh, request).unwrap_err();
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg) if msg.contains("per-device capacity")
+    ));
+}
+
+#[test]
+fn distributed_amplitude_plan_rejects_zero_qubits() {
+    let topology = GpuTopology::placeholder(1);
+    let mesh = DeviceMesh {
+        device_ids: vec![0],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(0, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let err = DistributedAmplitudePlan::for_request(&mesh, request).unwrap_err();
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("at least 1")
+    ));
+}
+
+#[test]
+fn distributed_amplitude_plan_reports_out_of_range_shard_ids() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(2, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
+    let err = plan.shard_range(2).unwrap_err();
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("out of range")
+    ));
+}
+
+#[test]
+fn balanced_uneven_distributed_amplitude_plan_omits_uniform_shard_metadata() {
+    let topology = GpuTopology::placeholder(3);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1, 2],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(
+        3,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::BalancedUneven,
+    );
+    let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
+    assert_eq!(plan.shard_bits, None);
+    assert_eq!(plan.uniform_shard_len, None);
+    assert_eq!(plan.shard_range(2).unwrap(), (6, 8));
+}
+
+#[test]
+fn distributed_state_layout_rejects_mesh_with_missing_device_handles() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(2, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
+
+    let err = match DistributedStateLayout::new(&mesh, &plan, Precision::Float64) {
+        Ok(_) => panic!("expected malformed mesh to be rejected"),
+        Err(err) => err,
+    };
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("device handles")
+    ));
+}

--- a/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
@@ -14,9 +14,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use qdp_core::{
+use qdp_core::Precision;
+use qdp_core::gpu::{
     DeviceMesh, DistributedAmplitudePlan, DistributedStateLayout, DistributionMode, GpuTopology,
-    PlacementRequest, Precision, ShardPolicy,
+    PlacementRequest, ShardPolicy,
 };
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
@@ -16,8 +16,8 @@
 
 use qdp_core::Precision;
 use qdp_core::gpu::{
-    DeviceMesh, DistributedAmplitudePlan, DistributedStateLayout, DistributionMode, GpuTopology,
-    PlacementRequest, ShardPolicy,
+    DeviceMesh, DistributedAmplitudePlan, DistributedStateLayout, DistributedStatePlan,
+    DistributionMode, GpuTopology, PlacementPlanner, PlacementRequest, ShardPolicy,
 };
 
 #[test]
@@ -35,6 +35,76 @@ fn distributed_amplitude_plan_has_expected_shard_math() {
     assert_eq!(plan.uniform_shard_len, Some(4));
     assert_eq!(plan.shard_range(0).unwrap(), (0, 4));
     assert_eq!(plan.shard_range(3).unwrap(), (12, 16));
+}
+
+#[test]
+fn distributed_state_plan_carries_workload_neutral_shard_math() {
+    let topology = GpuTopology::placeholder(4);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1, 2, 3],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(4, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let placement = PlacementPlanner::plan(&mesh, &request).unwrap();
+    let plan = DistributedStatePlan::from_placement(request, placement).unwrap();
+
+    assert_eq!(plan.request().num_qubits, 4);
+    assert_eq!(plan.placement().num_devices(), 4);
+    assert_eq!(plan.global_len, 16);
+    assert_eq!(plan.num_devices, 4);
+    assert_eq!(plan.shard_bits, Some(2));
+    assert_eq!(plan.uniform_shard_len, Some(4));
+    assert_eq!(plan.shard_range(2).unwrap(), (8, 12));
+    assert_eq!(
+        plan.estimated_max_shard_bytes(Precision::Float32).unwrap(),
+        32
+    );
+}
+
+#[test]
+fn distributed_state_plan_exposes_rank_local_placements() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new_with_world(
+        4,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::Equal,
+        2,
+    )
+    .unwrap();
+    let placement = PlacementPlanner::plan_rank_local(&mesh, &request).unwrap();
+    let plan = DistributedStatePlan::from_placement(request, placement).unwrap();
+
+    let rank_one = plan.placements_for_rank_iter(1).collect::<Vec<_>>();
+
+    assert_eq!(rank_one.len(), 2);
+    assert_eq!(rank_one[0].rank_id, 1);
+    assert_eq!(rank_one[0].device_id, 0);
+    assert_eq!((rank_one[0].start_idx, rank_one[0].end_idx), (4, 8));
+    assert_eq!(rank_one[1].rank_id, 1);
+    assert_eq!(rank_one[1].device_id, 1);
+    assert_eq!((rank_one[1].start_idx, rank_one[1].end_idx), (12, 16));
+}
+
+#[test]
+fn distributed_amplitude_plan_exposes_shared_state_plan() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(3, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
+
+    let shared: &DistributedStatePlan = plan.as_ref();
+    assert_eq!(shared.global_len, plan.global_len);
+    assert_eq!(shared.shard_range(1).unwrap(), plan.shard_range(1).unwrap());
 }
 
 #[test]
@@ -226,9 +296,11 @@ fn distributed_state_layout_can_be_rank_local() {
     assert_eq!(layout.rank_id, 1);
     assert_eq!(layout.world_size, 2);
     assert_eq!(layout.num_shards(), 1);
-    assert_eq!(layout.shards[0].rank_id, 1);
-    assert_eq!(layout.shards[0].device_id, 1);
-    assert_eq!(layout.shards[0].shard_id, 1);
+    assert_eq!(layout.shards().len(), 1);
+    assert_eq!(layout.iter_shards().count(), 1);
+    assert_eq!(layout.shards()[0].rank_id, 1);
+    assert_eq!(layout.shards()[0].device_id, 1);
+    assert_eq!(layout.shards()[0].shard_id, 1);
 }
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
@@ -167,6 +167,71 @@ fn distributed_state_layout_rejects_mesh_with_missing_device_handles() {
 }
 
 #[test]
+fn distributed_state_layout_rejects_rank_out_of_range_before_device_handles() {
+    let mesh = DeviceMesh {
+        device_ids: vec![1],
+        devices: Vec::new(),
+        topology: GpuTopology::placeholder(1),
+    };
+    let planning_mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology: GpuTopology::placeholder(2),
+    };
+    let request = PlacementRequest::new_with_world(
+        2,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::Equal,
+        2,
+    )
+    .unwrap();
+    let plan = DistributedAmplitudePlan::for_request(&planning_mesh, request).unwrap();
+
+    let err =
+        DistributedStateLayout::new_for_rank(&mesh, &plan, Precision::Float64, 2).unwrap_err();
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("rank") && msg.contains("world size")
+    ));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn distributed_state_layout_can_be_rank_local() {
+    let device1 = match cudarc::driver::CudaDevice::new(1) {
+        Ok(device) => device,
+        Err(_) => return,
+    };
+    let rank_mesh =
+        DeviceMesh::from_parts(vec![1], vec![device1], GpuTopology::placeholder(1)).unwrap();
+    let planning_mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology: GpuTopology::placeholder(2),
+    };
+    let request = PlacementRequest::new_with_world(
+        2,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::Equal,
+        2,
+    )
+    .unwrap();
+    let plan = DistributedAmplitudePlan::for_request(&planning_mesh, request).unwrap();
+
+    let layout =
+        DistributedStateLayout::new_for_rank(&rank_mesh, &plan, Precision::Float64, 1).unwrap();
+
+    assert_eq!(layout.rank_id, 1);
+    assert_eq!(layout.world_size, 2);
+    assert_eq!(layout.num_shards(), 1);
+    assert_eq!(layout.shards[0].rank_id, 1);
+    assert_eq!(layout.shards[0].device_id, 1);
+    assert_eq!(layout.shards[0].shard_id, 1);
+}
+
+#[test]
 fn distributed_amplitude_plan_reports_rank_local_ranges() {
     let topology = GpuTopology::placeholder(4);
     let mesh = DeviceMesh {

--- a/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
@@ -20,14 +20,11 @@ use qdp_core::gpu::{
     DistributionMode, GpuTopology, PlacementPlanner, PlacementRequest, ShardPolicy,
 };
 
+mod common;
+
 #[test]
 fn distributed_amplitude_plan_has_expected_shard_math() {
-    let topology = GpuTopology::placeholder(4);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1, 2, 3],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1, 2, 3]);
     let request = PlacementRequest::new(4, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
     assert_eq!(plan.global_len, 16);
@@ -39,12 +36,7 @@ fn distributed_amplitude_plan_has_expected_shard_math() {
 
 #[test]
 fn distributed_state_plan_carries_workload_neutral_shard_math() {
-    let topology = GpuTopology::placeholder(4);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1, 2, 3],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1, 2, 3]);
     let request = PlacementRequest::new(4, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let placement = PlacementPlanner::plan(&mesh, &request).unwrap();
     let plan = DistributedStatePlan::from_placement(request, placement).unwrap();
@@ -64,12 +56,7 @@ fn distributed_state_plan_carries_workload_neutral_shard_math() {
 
 #[test]
 fn distributed_state_plan_exposes_rank_local_placements() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest::new_with_world(
         4,
         DistributionMode::ShardedCapacity,
@@ -93,12 +80,7 @@ fn distributed_state_plan_exposes_rank_local_placements() {
 
 #[test]
 fn distributed_amplitude_plan_exposes_shared_state_plan() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest::new(3, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
 
@@ -109,12 +91,7 @@ fn distributed_amplitude_plan_exposes_shared_state_plan() {
 
 #[test]
 fn distributed_amplitude_plan_rejects_too_many_devices_for_qubits() {
-    let topology = GpuTopology::placeholder(4);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1, 2, 3],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1, 2, 3]);
     let request = PlacementRequest::new(1, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let err = DistributedAmplitudePlan::for_request(&mesh, request).unwrap_err();
     assert!(matches!(err, qdp_core::MahoutError::InvalidInput(_)));
@@ -122,12 +99,7 @@ fn distributed_amplitude_plan_rejects_too_many_devices_for_qubits() {
 
 #[test]
 fn distributed_amplitude_plan_allows_extra_global_qubit_when_shards_fit() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest::new(31, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
     assert_eq!(plan.global_len, 1usize << 31);
@@ -136,12 +108,7 @@ fn distributed_amplitude_plan_allows_extra_global_qubit_when_shards_fit() {
 
 #[test]
 fn distributed_amplitude_plan_supports_q34_with_balanced_six_gpu_shards() {
-    let topology = GpuTopology::placeholder(6);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1, 2, 3, 4, 5],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1, 2, 3, 4, 5]);
     let request = PlacementRequest::new(
         34,
         DistributionMode::ShardedCapacity,
@@ -162,12 +129,7 @@ fn distributed_amplitude_plan_supports_q34_with_balanced_six_gpu_shards() {
 
 #[test]
 fn distributed_amplitude_plan_rejects_zero_qubits() {
-    let topology = GpuTopology::placeholder(1);
-    let mesh = DeviceMesh {
-        device_ids: vec![0],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0]);
     let request = PlacementRequest::new(0, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let err = DistributedAmplitudePlan::for_request(&mesh, request).unwrap_err();
     assert!(matches!(
@@ -179,12 +141,7 @@ fn distributed_amplitude_plan_rejects_zero_qubits() {
 
 #[test]
 fn distributed_amplitude_plan_reports_out_of_range_shard_ids() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest::new(2, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
     let err = plan.shard_range(2).unwrap_err();
@@ -197,12 +154,7 @@ fn distributed_amplitude_plan_reports_out_of_range_shard_ids() {
 
 #[test]
 fn balanced_uneven_distributed_amplitude_plan_omits_uniform_shard_metadata() {
-    let topology = GpuTopology::placeholder(3);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1, 2],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1, 2]);
     let request = PlacementRequest::new(
         3,
         DistributionMode::ShardedCapacity,
@@ -216,12 +168,7 @@ fn balanced_uneven_distributed_amplitude_plan_omits_uniform_shard_metadata() {
 
 #[test]
 fn distributed_state_layout_rejects_mesh_with_missing_device_handles() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest::new(2, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
 
@@ -238,16 +185,8 @@ fn distributed_state_layout_rejects_mesh_with_missing_device_handles() {
 
 #[test]
 fn distributed_state_layout_rejects_rank_out_of_range_before_device_handles() {
-    let mesh = DeviceMesh {
-        device_ids: vec![1],
-        devices: Vec::new(),
-        topology: GpuTopology::placeholder(1),
-    };
-    let planning_mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology: GpuTopology::placeholder(2),
-    };
+    let mesh = common::placeholder_mesh(vec![1]);
+    let planning_mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest::new_with_world(
         2,
         DistributionMode::ShardedCapacity,
@@ -270,17 +209,12 @@ fn distributed_state_layout_rejects_rank_out_of_range_before_device_handles() {
 #[test]
 #[cfg(target_os = "linux")]
 fn distributed_state_layout_can_be_rank_local() {
-    let device1 = match cudarc::driver::CudaDevice::new(1) {
-        Ok(device) => device,
-        Err(_) => return,
+    let Some(device1) = common::cuda_device_by_id(1) else {
+        return;
     };
     let rank_mesh =
         DeviceMesh::from_parts(vec![1], vec![device1], GpuTopology::placeholder(1)).unwrap();
-    let planning_mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology: GpuTopology::placeholder(2),
-    };
+    let planning_mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest::new_with_world(
         2,
         DistributionMode::ShardedCapacity,
@@ -305,12 +239,7 @@ fn distributed_state_layout_can_be_rank_local() {
 
 #[test]
 fn distributed_amplitude_plan_reports_rank_local_ranges() {
-    let topology = GpuTopology::placeholder(4);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1, 2, 3],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1, 2, 3]);
     let request = PlacementRequest::new_with_world(
         4,
         DistributionMode::ShardedCapacity,

--- a/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
@@ -225,7 +225,7 @@ fn distributed_state_layout_rejects_mesh_with_missing_device_handles() {
     let request = PlacementRequest::new(2, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
 
-    let err = match DistributedStateLayout::new(&mesh, &plan, Precision::Float64) {
+    let err = match DistributedStateLayout::new_for_rank(&mesh, &plan, Precision::Float64, 0) {
         Ok(_) => panic!("expected malformed mesh to be rejected"),
         Err(err) => err,
     };

--- a/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_amplitude_plan.rs
@@ -165,3 +165,25 @@ fn distributed_state_layout_rejects_mesh_with_missing_device_handles() {
         if msg.contains("device handles")
     ));
 }
+
+#[test]
+fn distributed_amplitude_plan_reports_rank_local_ranges() {
+    let topology = GpuTopology::placeholder(4);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1, 2, 3],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new_with_world(
+        4,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::Equal,
+        2,
+    )
+    .unwrap();
+    let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
+
+    assert_eq!(plan.num_local_shards(0), 2);
+    assert_eq!(plan.num_local_shards(1), 2);
+    assert_eq!(plan.rank_shard_ranges(1), vec![(4, 8), (12, 16)]);
+}

--- a/qdp/qdp-core/tests/gpu_distributed_communicator.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_communicator.rs
@@ -1,0 +1,19 @@
+use qdp_core::gpu::{Communicator, HostCommunicator};
+
+#[test]
+fn host_communicator_reduce_sum_returns_total() {
+    let comm = HostCommunicator;
+    let values = vec![1.0, 2.0, 3.0];
+    assert_eq!(comm.reduce_sum_f64(&values).unwrap(), 6.0);
+}
+
+#[test]
+fn host_communicator_reduce_sum_rejects_empty_inputs() {
+    let comm = HostCommunicator;
+    let err = comm.reduce_sum_f64(&[]).unwrap_err();
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("at least one value")
+    ));
+}

--- a/qdp/qdp-core/tests/gpu_distributed_communicator.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_communicator.rs
@@ -1,19 +1,35 @@
-use qdp_core::gpu::{Communicator, HostCommunicator};
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use qdp_core::gpu::{CollectiveCommunicator, LocalCollectiveCommunicator};
 
 #[test]
-fn host_communicator_reduce_sum_returns_total() {
-    let comm = HostCommunicator;
+fn local_collective_reduce_sum_returns_total() {
+    let comm = LocalCollectiveCommunicator;
     let values = vec![1.0, 2.0, 3.0];
-    assert_eq!(comm.reduce_sum_f64(&values).unwrap(), 6.0);
+    assert_eq!(comm.all_reduce_sum_f64(&values).unwrap(), 6.0);
 }
 
 #[test]
-fn host_communicator_reduce_sum_rejects_empty_inputs() {
-    let comm = HostCommunicator;
-    let err = comm.reduce_sum_f64(&[]).unwrap_err();
+fn local_collective_reduce_sum_rejects_empty_inputs() {
+    let comm = LocalCollectiveCommunicator;
+    let err = comm.all_reduce_sum_f64(&[]).unwrap_err();
     assert!(matches!(
         err,
         qdp_core::MahoutError::InvalidInput(msg)
-        if msg.contains("at least one value")
+        if msg.contains("at least one partial contribution")
     ));
 }

--- a/qdp/qdp-core/tests/gpu_distributed_communicator.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_communicator.rs
@@ -14,22 +14,67 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use qdp_core::gpu::{CollectiveCommunicator, LocalCollectiveCommunicator};
+use std::ffi::c_void;
+
+use qdp_core::gpu::{
+    CollectiveCommunicator, DeviceCollectiveBackend, DeviceCollectiveCommunicator,
+    LocalCollectiveCommunicator, MpiDeviceCollectiveCommunicator, NcclDeviceCollectiveCommunicator,
+};
 
 #[test]
-fn local_collective_reduce_sum_returns_total() {
+fn local_collective_reports_single_rank_identity() {
     let comm = LocalCollectiveCommunicator;
-    let values = vec![1.0, 2.0, 3.0];
-    assert_eq!(comm.all_reduce_sum_f64(&values).unwrap(), 6.0);
+
+    assert_eq!(comm.rank(), 0);
+    assert_eq!(comm.world_size(), 1);
+    assert_eq!(comm.all_reduce_sum_f64(12.5).unwrap(), 12.5);
 }
 
 #[test]
-fn local_collective_reduce_sum_rejects_empty_inputs() {
-    let comm = LocalCollectiveCommunicator;
-    let err = comm.all_reduce_sum_f64(&[]).unwrap_err();
+fn placeholder_mpi_device_collective_is_explicitly_unavailable() {
+    let backend = MpiDeviceCollectiveCommunicator;
+    assert_eq!(
+        backend.backend_kind(),
+        DeviceCollectiveBackend::CudaAwareMpi
+    );
+
+    let err = unsafe {
+        backend.all_reduce_sum_f32_device(
+            std::ptr::null::<c_void>(),
+            std::ptr::null_mut::<c_void>(),
+            0,
+            0,
+            std::ptr::null_mut::<c_void>(),
+        )
+    }
+    .unwrap_err();
+
     assert!(matches!(
         err,
-        qdp_core::MahoutError::InvalidInput(msg)
-        if msg.contains("at least one partial contribution")
+        qdp_core::MahoutError::NotImplemented(msg)
+        if msg.contains("CUDA-aware MPI device collectives")
+    ));
+}
+
+#[test]
+fn placeholder_nccl_device_collective_is_explicitly_unavailable() {
+    let backend = NcclDeviceCollectiveCommunicator;
+    assert_eq!(backend.backend_kind(), DeviceCollectiveBackend::Nccl);
+
+    let err = unsafe {
+        backend.all_reduce_sum_f32_device(
+            std::ptr::null::<c_void>(),
+            std::ptr::null_mut::<c_void>(),
+            0,
+            0,
+            std::ptr::null_mut::<c_void>(),
+        )
+    }
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::NotImplemented(msg)
+        if msg.contains("NCCL device collectives")
     ));
 }

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -14,8 +14,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use qdp_core::gpu::QuantumEncoder;
-use qdp_core::{HostCommunicator, Precision, QdpEngine};
+use qdp_core::gpu::{
+    DeviceMesh, DistributedAmplitudePlan, DistributedExecutionContext, DistributedStateLayout,
+    DistributionMode, GpuTopology, LinkKind, LocalCollectiveCommunicator, PlacementRequest,
+    QuantumEncoder, ShardPolicy,
+};
+use qdp_core::{Precision, QdpEngine};
 
 mod common;
 
@@ -45,20 +49,20 @@ fn prepare_distributed_amplitude_returns_expected_metadata() {
 }
 
 #[test]
-fn prepare_distributed_amplitude_with_explicit_communicator_returns_expected_metadata() {
+fn prepare_distributed_amplitude_on_execution_context_returns_expected_metadata() {
     #[cfg(target_os = "linux")]
     if cudarc::driver::CudaDevice::new(1).is_err() {
         return;
     }
 
-    let communicator = HostCommunicator;
-    let prepared = QdpEngine::prepare_distributed_amplitude_with_communicator(
-        vec![0, 1],
+    let collectives = LocalCollectiveCommunicator;
+    let execution = DistributedExecutionContext::single_process(vec![0, 1], &collectives).unwrap();
+    let prepared = QdpEngine::prepare_distributed_amplitude_on(
+        &execution,
         &[1.0, 2.0, 3.0],
         2,
         Precision::Float32,
         None,
-        &communicator,
     )
     .unwrap();
 
@@ -66,6 +70,106 @@ fn prepare_distributed_amplitude_with_explicit_communicator_returns_expected_met
     assert_eq!(prepared.plan.uniform_shard_len, Some(2));
     assert_eq!(prepared.layout.num_shards(), 2);
     assert_eq!(prepared.layout.global_len, 4);
+}
+
+#[cfg(target_os = "linux")]
+fn reordered_three_device_mesh() -> Option<DeviceMesh> {
+    let device0 = cudarc::driver::CudaDevice::new(0).ok()?;
+    let device1 = cudarc::driver::CudaDevice::new(1).ok()?;
+    let device2 = cudarc::driver::CudaDevice::new(2).ok()?;
+    let topology = GpuTopology {
+        peer_access: vec![
+            vec![true, true, false],
+            vec![true, true, true],
+            vec![false, true, true],
+        ],
+        links: vec![
+            vec![LinkKind::SameDevice, LinkKind::Pix, LinkKind::Unknown],
+            vec![LinkKind::Pix, LinkKind::SameDevice, LinkKind::Node],
+            vec![LinkKind::Unknown, LinkKind::Node, LinkKind::SameDevice],
+        ],
+    };
+
+    DeviceMesh::from_parts(vec![0, 1, 2], vec![device0, device1, device2], topology).ok()
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn distributed_layout_uses_device_handles_for_reordered_placements() {
+    let Some(mesh) = reordered_three_device_mesh() else {
+        return;
+    };
+
+    let request = PlacementRequest::new(
+        2,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::BalancedUneven,
+    );
+    let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
+    assert_eq!(plan.placement.placements[0].device_id, 1);
+
+    let layout = DistributedStateLayout::new(&mesh, &plan, Precision::Float32).unwrap();
+    assert_eq!(layout.shards[0].device_id, 1);
+    assert_eq!(layout.shards[0].device.ordinal(), 1);
+    assert_eq!(layout.shards[1].device_id, 0);
+    assert_eq!(layout.shards[1].device.ordinal(), 0);
+    assert_eq!(layout.shards[2].device_id, 2);
+    assert_eq!(layout.shards[2].device.ordinal(), 2);
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn distributed_encoding_uses_device_handles_for_reordered_placements() {
+    let Some(mesh) = reordered_three_device_mesh() else {
+        return;
+    };
+    let device0 = mesh.device_for_id(0).unwrap();
+
+    let collectives = LocalCollectiveCommunicator;
+    let execution = DistributedExecutionContext::new(mesh, &collectives);
+    let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let single_state = qdp_core::gpu::AmplitudeEncoder
+        .encode(&device0, &input, 3)
+        .unwrap();
+    let single_host = single_state
+        .copy_to_host_f64(&device0)
+        .unwrap()
+        .into_iter()
+        .map(|value| value.x)
+        .collect::<Vec<_>>();
+
+    let state = QdpEngine::encode_distributed_amplitude_to_shards_on(
+        &execution,
+        &input,
+        3,
+        Precision::Float64,
+        Some(PlacementRequest::new(
+            3,
+            DistributionMode::ShardedCapacity,
+            ShardPolicy::BalancedUneven,
+        )),
+    )
+    .unwrap();
+
+    assert_eq!(state.shards[0].device_id, 1);
+    assert_eq!(state.shards[0].device.ordinal(), 1);
+    assert_eq!(state.shards[1].device_id, 0);
+    assert_eq!(state.shards[1].device.ordinal(), 0);
+    assert_eq!(state.shards[2].device_id, 2);
+    assert_eq!(state.shards[2].device.ordinal(), 2);
+
+    let mut distributed_host = Vec::new();
+    for shard_id in 0..state.num_shards() {
+        distributed_host.extend(
+            state
+                .copy_shard_to_host_f64(shard_id)
+                .unwrap()
+                .into_iter()
+                .map(|value| value.x),
+        );
+    }
+
+    assert_eq!(distributed_host, single_host);
 }
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -1,0 +1,219 @@
+use qdp_core::gpu::QuantumEncoder;
+use qdp_core::{Precision, QdpEngine};
+
+mod common;
+
+#[test]
+fn prepare_distributed_amplitude_returns_expected_metadata() {
+    #[cfg(target_os = "linux")]
+    if cudarc::driver::CudaDevice::new(1).is_err() {
+        return;
+    }
+
+    let prepared = QdpEngine::prepare_distributed_amplitude(
+        vec![0, 1],
+        &[1.0, 2.0, 3.0],
+        2,
+        Precision::Float32,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(prepared.mesh.num_devices(), 2);
+    assert_eq!(prepared.plan.uniform_shard_len, Some(2));
+    assert_eq!(prepared.layout.num_shards(), 2);
+    assert_eq!(prepared.layout.global_len, 4);
+
+    let expected = 1.0 / 14.0f64.sqrt();
+    assert!((prepared.inv_norm - expected).abs() < 1e-12);
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn encode_distributed_amplitude_to_shards_returns_real_buffers() {
+    let Some(device0) = common::cuda_device() else {
+        return;
+    };
+    let device1 = match cudarc::driver::CudaDevice::new(1) {
+        Ok(device) => device,
+        Err(_) => return,
+    };
+
+    let _ = device1;
+
+    let state = QdpEngine::encode_distributed_amplitude_to_shards(
+        vec![0, 1],
+        &[1.0, 2.0, 3.0],
+        2,
+        Precision::Float64,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(state.num_shards(), 2);
+
+    let shard0 = state.copy_shard_to_host_f64(0).unwrap();
+    let shard1 = state.copy_shard_to_host_f64(1).unwrap();
+
+    let expected = 1.0 / 14.0f64.sqrt();
+    let shard0 = shard0.iter().map(|value| value.x).collect::<Vec<_>>();
+    let shard1 = shard1.iter().map(|value| value.x).collect::<Vec<_>>();
+
+    assert!((shard0[0] - expected).abs() < 1e-12);
+    assert!((shard0[1] - (2.0 * expected)).abs() < 1e-12);
+    assert!((shard1[0] - (3.0 * expected)).abs() < 1e-12);
+    assert_eq!(shard1[1], 0.0);
+
+    let _ = device0;
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn distributed_amplitude_matches_single_gpu_reference_on_two_gpus() {
+    let device0 = match cudarc::driver::CudaDevice::new(0) {
+        Ok(device) => device,
+        Err(_) => return,
+    };
+    let device1 = match cudarc::driver::CudaDevice::new(1) {
+        Ok(device) => device,
+        Err(_) => return,
+    };
+
+    let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
+    let encoder = qdp_core::gpu::AmplitudeEncoder;
+    let single_state = encoder.encode(&device0, &input, 3).unwrap();
+    let single_host = single_state
+        .copy_to_host_f64(&device0)
+        .unwrap()
+        .into_iter()
+        .map(|value| value.x)
+        .collect::<Vec<_>>();
+
+    let distributed = QdpEngine::encode_distributed_amplitude_to_shards(
+        vec![0, 1],
+        &input,
+        3,
+        Precision::Float64,
+        None,
+    )
+    .unwrap();
+
+    let mut distributed_host = Vec::new();
+    distributed_host.extend(
+        distributed
+            .copy_shard_to_host_f64(0)
+            .unwrap()
+            .into_iter()
+            .map(|value| value.x),
+    );
+    distributed_host.extend(
+        distributed
+            .copy_shard_to_host_f64(1)
+            .unwrap()
+            .into_iter()
+            .map(|value| value.x),
+    );
+
+    assert_eq!(distributed_host.len(), single_host.len());
+    for (idx, (distributed_value, single_value)) in
+        distributed_host.iter().zip(single_host.iter()).enumerate()
+    {
+        assert!(
+            (*distributed_value - *single_value).abs() < 1e-12,
+            "Mismatch at amplitude {}: distributed={} single={}",
+            idx,
+            distributed_value,
+            single_value
+        );
+    }
+
+    let _ = device1;
+}
+
+#[test]
+fn prepare_distributed_amplitude_rejects_oversized_inputs() {
+    let err = match QdpEngine::prepare_distributed_amplitude(
+        vec![0],
+        &[1.0, 2.0, 3.0],
+        1,
+        Precision::Float64,
+        None,
+    ) {
+        Ok(_) => panic!("expected oversized input to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("exceeds state vector size")
+    ));
+}
+
+#[test]
+fn prepare_distributed_amplitude_validates_input_before_building_mesh() {
+    let err = match QdpEngine::prepare_distributed_amplitude(
+        vec![9999],
+        &[],
+        1,
+        Precision::Float64,
+        None,
+    ) {
+        Ok(_) => panic!("expected empty input to be rejected before mesh creation"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("cannot be empty")
+    ));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn distributed_state_rejects_out_of_range_shard_reads() {
+    let Some(_device0) = common::cuda_device() else {
+        return;
+    };
+
+    let state = QdpEngine::encode_distributed_amplitude_to_shards(
+        vec![0],
+        &[1.0, 2.0],
+        1,
+        Precision::Float64,
+        None,
+    )
+    .unwrap();
+
+    let err = state.copy_shard_to_host_f64(1).unwrap_err();
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("out of range")
+    ));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn distributed_state_rejects_precision_mismatched_host_reads() {
+    let Some(_device0) = common::cuda_device() else {
+        return;
+    };
+
+    let state = QdpEngine::encode_distributed_amplitude_to_shards(
+        vec![0],
+        &[1.0, 2.0],
+        1,
+        Precision::Float32,
+        None,
+    )
+    .unwrap();
+
+    let err = state.copy_shard_to_host_f64(0).unwrap_err();
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("float32 data, not float64")
+    ));
+}

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -1,5 +1,21 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use qdp_core::gpu::QuantumEncoder;
-use qdp_core::{Precision, QdpEngine};
+use qdp_core::{HostCommunicator, Precision, QdpEngine};
 
 mod common;
 
@@ -26,6 +42,30 @@ fn prepare_distributed_amplitude_returns_expected_metadata() {
 
     let expected = 1.0 / 14.0f64.sqrt();
     assert!((prepared.inv_norm - expected).abs() < 1e-12);
+}
+
+#[test]
+fn prepare_distributed_amplitude_with_explicit_communicator_returns_expected_metadata() {
+    #[cfg(target_os = "linux")]
+    if cudarc::driver::CudaDevice::new(1).is_err() {
+        return;
+    }
+
+    let communicator = HostCommunicator;
+    let prepared = QdpEngine::prepare_distributed_amplitude_with_communicator(
+        vec![0, 1],
+        &[1.0, 2.0, 3.0],
+        2,
+        Precision::Float32,
+        None,
+        &communicator,
+    )
+    .unwrap();
+
+    assert_eq!(prepared.mesh.num_devices(), 2);
+    assert_eq!(prepared.plan.uniform_shard_len, Some(2));
+    assert_eq!(prepared.layout.num_shards(), 2);
+    assert_eq!(prepared.layout.global_len, 4);
 }
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -369,3 +369,31 @@ fn distributed_state_rejects_precision_mismatched_host_reads() {
         if msg.contains("float32 data, not float64")
     ));
 }
+
+#[test]
+#[cfg(target_os = "linux")]
+fn distributed_state_exposes_local_zero_copy_shard_views() {
+    let Some(_device0) = common::cuda_device() else {
+        return;
+    };
+
+    let state = QdpEngine::encode_distributed_amplitude_to_shards(
+        vec![0],
+        &[1.0, 2.0],
+        1,
+        Precision::Float32,
+        None,
+    )
+    .unwrap();
+
+    let views = state.local_shard_views();
+    assert_eq!(views.len(), 1);
+    assert_eq!(views[0].rank_id, 0);
+    assert_eq!(views[0].device_id, 0);
+    assert_eq!(views[0].shard_id, 0);
+    assert_eq!(views[0].start_idx, 0);
+    assert_eq!(views[0].end_idx, 2);
+    assert_eq!(views[0].precision, Precision::Float32);
+    assert_eq!(views[0].local_len, 2);
+    assert!(!views[0].ptr.is_null());
+}

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -26,11 +26,7 @@ mod common;
 #[test]
 fn prepare_distributed_amplitude_returns_expected_metadata() {
     #[cfg(target_os = "linux")]
-    if cudarc::driver::CudaDevice::new(0).is_err() {
-        return;
-    }
-    #[cfg(target_os = "linux")]
-    if cudarc::driver::CudaDevice::new(1).is_err() {
+    if common::cuda_devices(&[0, 1]).is_none() {
         return;
     }
 
@@ -55,11 +51,7 @@ fn prepare_distributed_amplitude_returns_expected_metadata() {
 #[test]
 fn prepare_distributed_amplitude_on_execution_context_returns_expected_metadata() {
     #[cfg(target_os = "linux")]
-    if cudarc::driver::CudaDevice::new(0).is_err() {
-        return;
-    }
-    #[cfg(target_os = "linux")]
-    if cudarc::driver::CudaDevice::new(1).is_err() {
+    if common::cuda_devices(&[0, 1]).is_none() {
         return;
     }
 
@@ -82,9 +74,7 @@ fn prepare_distributed_amplitude_on_execution_context_returns_expected_metadata(
 
 #[cfg(target_os = "linux")]
 fn reordered_three_device_mesh() -> Option<DeviceMesh> {
-    let device0 = cudarc::driver::CudaDevice::new(0).ok()?;
-    let device1 = cudarc::driver::CudaDevice::new(1).ok()?;
-    let device2 = cudarc::driver::CudaDevice::new(2).ok()?;
+    let devices = common::cuda_devices(&[0, 1, 2])?;
     let topology = GpuTopology {
         peer_access: vec![
             vec![true, true, false],
@@ -98,7 +88,22 @@ fn reordered_three_device_mesh() -> Option<DeviceMesh> {
         ],
     };
 
-    DeviceMesh::from_parts(vec![0, 1, 2], vec![device0, device1, device2], topology).ok()
+    DeviceMesh::from_parts(vec![0, 1, 2], devices, topology).ok()
+}
+
+#[cfg(target_os = "linux")]
+fn copy_all_shards_to_host_f64(state: &qdp_core::gpu::DistributedStateVector) -> Vec<f64> {
+    let mut host = Vec::new();
+    for shard_id in 0..state.num_shards() {
+        host.extend(
+            state
+                .copy_shard_to_host_f64(shard_id)
+                .unwrap()
+                .into_iter()
+                .map(|value| value.x),
+        );
+    }
+    host
 }
 
 #[test]
@@ -172,16 +177,7 @@ fn distributed_encoding_uses_device_handles_for_reordered_placements() {
     assert_eq!(state.shards()[2].device_id, 2);
     assert_eq!(state.shards()[2].device.ordinal(), 2);
 
-    let mut distributed_host = Vec::new();
-    for shard_id in 0..state.num_shards() {
-        distributed_host.extend(
-            state
-                .copy_shard_to_host_f64(shard_id)
-                .unwrap()
-                .into_iter()
-                .map(|value| value.x),
-        );
-    }
+    let distributed_host = copy_all_shards_to_host_f64(&state);
 
     assert_eq!(distributed_host, single_host);
 }
@@ -192,12 +188,9 @@ fn encode_distributed_amplitude_to_shards_returns_real_buffers() {
     let Some(device0) = common::cuda_device() else {
         return;
     };
-    let device1 = match cudarc::driver::CudaDevice::new(1) {
-        Ok(device) => device,
-        Err(_) => return,
-    };
-
-    let _ = device1;
+    if common::cuda_device_by_id(1).is_none() {
+        return;
+    }
 
     let state = QdpEngine::encode_distributed_amplitude_to_shards(
         vec![0, 1],
@@ -228,14 +221,12 @@ fn encode_distributed_amplitude_to_shards_returns_real_buffers() {
 #[test]
 #[cfg(target_os = "linux")]
 fn distributed_amplitude_matches_single_gpu_reference_on_two_gpus() {
-    let device0 = match cudarc::driver::CudaDevice::new(0) {
-        Ok(device) => device,
-        Err(_) => return,
+    let Some(device0) = common::cuda_device() else {
+        return;
     };
-    let device1 = match cudarc::driver::CudaDevice::new(1) {
-        Ok(device) => device,
-        Err(_) => return,
-    };
+    if common::cuda_device_by_id(1).is_none() {
+        return;
+    }
 
     let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let encoder = qdp_core::gpu::AmplitudeEncoder;
@@ -256,21 +247,7 @@ fn distributed_amplitude_matches_single_gpu_reference_on_two_gpus() {
     )
     .unwrap();
 
-    let mut distributed_host = Vec::new();
-    distributed_host.extend(
-        distributed
-            .copy_shard_to_host_f64(0)
-            .unwrap()
-            .into_iter()
-            .map(|value| value.x),
-    );
-    distributed_host.extend(
-        distributed
-            .copy_shard_to_host_f64(1)
-            .unwrap()
-            .into_iter()
-            .map(|value| value.x),
-    );
+    let distributed_host = copy_all_shards_to_host_f64(&distributed);
 
     assert_eq!(distributed_host.len(), single_host.len());
     for (idx, (distributed_value, single_value)) in
@@ -284,8 +261,6 @@ fn distributed_amplitude_matches_single_gpu_reference_on_two_gpus() {
             single_value
         );
     }
-
-    let _ = device1;
 }
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -139,7 +139,8 @@ fn distributed_encoding_uses_device_handles_for_reordered_placements() {
     let device0 = mesh.device_for_id(0).unwrap();
 
     let collectives = LocalCollectiveCommunicator;
-    let execution = DistributedExecutionContext::new(mesh, &collectives);
+    let execution =
+        DistributedExecutionContext::rank_local_with_mesh(0, 1, mesh, &collectives).unwrap();
     let input = vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0];
     let single_state = qdp_core::gpu::AmplitudeEncoder
         .encode(&device0, &input, 3)

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -121,7 +121,7 @@ fn distributed_layout_uses_device_handles_for_reordered_placements() {
         Some(1)
     );
 
-    let layout = DistributedStateLayout::new(&mesh, &plan, Precision::Float32).unwrap();
+    let layout = DistributedStateLayout::new_for_rank(&mesh, &plan, Precision::Float32, 0).unwrap();
     assert_eq!(layout.shards()[0].device_id, 1);
     assert_eq!(layout.shards()[0].device.ordinal(), 1);
     assert_eq!(layout.shards()[1].device_id, 0);

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -387,6 +387,8 @@ fn distributed_state_exposes_local_zero_copy_shard_views() {
     .unwrap();
 
     let views = state.local_shard_views();
+    let iter_views = state.iter_local_shard_views().collect::<Vec<_>>();
+    assert_eq!(iter_views, views);
     assert_eq!(views.len(), 1);
     assert_eq!(views[0].rank_id, 0);
     assert_eq!(views[0].device_id, 0);

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -26,6 +26,10 @@ mod common;
 #[test]
 fn prepare_distributed_amplitude_returns_expected_metadata() {
     #[cfg(target_os = "linux")]
+    if cudarc::driver::CudaDevice::new(0).is_err() {
+        return;
+    }
+    #[cfg(target_os = "linux")]
     if cudarc::driver::CudaDevice::new(1).is_err() {
         return;
     }
@@ -50,6 +54,10 @@ fn prepare_distributed_amplitude_returns_expected_metadata() {
 
 #[test]
 fn prepare_distributed_amplitude_on_execution_context_returns_expected_metadata() {
+    #[cfg(target_os = "linux")]
+    if cudarc::driver::CudaDevice::new(0).is_err() {
+        return;
+    }
     #[cfg(target_os = "linux")]
     if cudarc::driver::CudaDevice::new(1).is_err() {
         return;

--- a/qdp/qdp-core/tests/gpu_distributed_engine.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_engine.rs
@@ -114,15 +114,20 @@ fn distributed_layout_uses_device_handles_for_reordered_placements() {
         ShardPolicy::BalancedUneven,
     );
     let plan = DistributedAmplitudePlan::for_request(&mesh, request).unwrap();
-    assert_eq!(plan.placement.placements[0].device_id, 1);
+    assert_eq!(
+        plan.placements_for_rank_iter(0)
+            .next()
+            .map(|placement| placement.device_id),
+        Some(1)
+    );
 
     let layout = DistributedStateLayout::new(&mesh, &plan, Precision::Float32).unwrap();
-    assert_eq!(layout.shards[0].device_id, 1);
-    assert_eq!(layout.shards[0].device.ordinal(), 1);
-    assert_eq!(layout.shards[1].device_id, 0);
-    assert_eq!(layout.shards[1].device.ordinal(), 0);
-    assert_eq!(layout.shards[2].device_id, 2);
-    assert_eq!(layout.shards[2].device.ordinal(), 2);
+    assert_eq!(layout.shards()[0].device_id, 1);
+    assert_eq!(layout.shards()[0].device.ordinal(), 1);
+    assert_eq!(layout.shards()[1].device_id, 0);
+    assert_eq!(layout.shards()[1].device.ordinal(), 0);
+    assert_eq!(layout.shards()[2].device_id, 2);
+    assert_eq!(layout.shards()[2].device.ordinal(), 2);
 }
 
 #[test]
@@ -159,12 +164,12 @@ fn distributed_encoding_uses_device_handles_for_reordered_placements() {
     )
     .unwrap();
 
-    assert_eq!(state.shards[0].device_id, 1);
-    assert_eq!(state.shards[0].device.ordinal(), 1);
-    assert_eq!(state.shards[1].device_id, 0);
-    assert_eq!(state.shards[1].device.ordinal(), 0);
-    assert_eq!(state.shards[2].device_id, 2);
-    assert_eq!(state.shards[2].device.ordinal(), 2);
+    assert_eq!(state.shards()[0].device_id, 1);
+    assert_eq!(state.shards()[0].device.ordinal(), 1);
+    assert_eq!(state.shards()[1].device_id, 0);
+    assert_eq!(state.shards()[1].device.ordinal(), 0);
+    assert_eq!(state.shards()[2].device_id, 2);
+    assert_eq!(state.shards()[2].device.ordinal(), 2);
 
     let mut distributed_host = Vec::new();
     for shard_id in 0..state.num_shards() {
@@ -390,6 +395,8 @@ fn distributed_state_exposes_local_zero_copy_shard_views() {
     let iter_views = state.iter_local_shard_views().collect::<Vec<_>>();
     assert_eq!(iter_views, views);
     assert_eq!(views.len(), 1);
+    assert_eq!(state.shards().len(), 1);
+    assert_eq!(state.iter_shards().count(), 1);
     assert_eq!(views[0].rank_id, 0);
     assert_eq!(views[0].device_id, 0);
     assert_eq!(views[0].shard_id, 0);

--- a/qdp/qdp-core/tests/gpu_distributed_planner.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_planner.rs
@@ -1,3 +1,19 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use qdp_core::gpu::{
     DeviceMesh, DistributionMode, GpuTopology, LinkKind, PlacementPlanner, PlacementRequest,
     ShardPolicy,

--- a/qdp/qdp-core/tests/gpu_distributed_planner.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_planner.rs
@@ -1,0 +1,139 @@
+use qdp_core::{
+    DeviceMesh, DistributionMode, GpuTopology, LinkKind, PlacementPlanner, PlacementRequest,
+    ShardPolicy,
+};
+
+#[test]
+fn placement_planner_emits_contiguous_ranges() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![3, 7],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(3, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let plan = PlacementPlanner::plan(&mesh, &request).unwrap();
+    assert_eq!(plan.gather_device_id, Some(3));
+    assert_eq!(plan.placements.len(), 2);
+    assert_eq!(plan.placements[0].device_id, 3);
+    assert_eq!(
+        (plan.placements[0].start_idx, plan.placements[0].end_idx),
+        (0, 4)
+    );
+    assert_eq!(plan.placements[1].device_id, 7);
+    assert_eq!(
+        (plan.placements[1].start_idx, plan.placements[1].end_idx),
+        (4, 8)
+    );
+}
+
+#[test]
+fn balanced_uneven_policy_supports_non_power_of_two_device_counts() {
+    let topology = GpuTopology::placeholder(3);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1, 2],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(
+        3,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::BalancedUneven,
+    );
+    let plan = PlacementPlanner::plan(&mesh, &request).unwrap();
+    assert_eq!(plan.placements.len(), 3);
+    assert_eq!(
+        (plan.placements[0].start_idx, plan.placements[0].end_idx),
+        (0, 3)
+    );
+    assert_eq!(
+        (plan.placements[1].start_idx, plan.placements[1].end_idx),
+        (3, 6)
+    );
+    assert_eq!(
+        (plan.placements[2].start_idx, plan.placements[2].end_idx),
+        (6, 8)
+    );
+}
+
+#[test]
+fn equal_policy_rejects_non_power_of_two_device_counts() {
+    let topology = GpuTopology::placeholder(3);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1, 2],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(3, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+    let err = PlacementPlanner::plan(&mesh, &request).unwrap_err();
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("power-of-two")
+    ));
+}
+
+#[test]
+fn single_mode_uses_only_first_device() {
+    let topology = GpuTopology::placeholder(3);
+    let mesh = DeviceMesh {
+        device_ids: vec![4, 8, 15],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(3, DistributionMode::Single, ShardPolicy::Equal);
+    let plan = PlacementPlanner::plan(&mesh, &request).unwrap();
+    assert_eq!(plan.placements.len(), 1);
+    assert_eq!(plan.gather_device_id, Some(4));
+    assert_eq!(plan.placements[0].device_id, 4);
+    assert_eq!((plan.placements[0].start_idx, plan.placements[0].end_idx), (0, 8));
+}
+
+#[test]
+fn replicated_mode_is_not_implemented() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(2, DistributionMode::Replicated, ShardPolicy::Equal);
+    let err = PlacementPlanner::plan(&mesh, &request).unwrap_err();
+    assert!(matches!(err, qdp_core::MahoutError::NotImplemented(_)));
+}
+
+#[test]
+fn sharded_capacity_prefers_topology_recommended_device_order() {
+    let topology = GpuTopology {
+        peer_access: vec![
+            vec![true, true, false],
+            vec![true, true, true],
+            vec![false, true, true],
+        ],
+        links: vec![
+            vec![LinkKind::SameDevice, LinkKind::Pix, LinkKind::Unknown],
+            vec![LinkKind::Pix, LinkKind::SameDevice, LinkKind::Node],
+            vec![LinkKind::Unknown, LinkKind::Node, LinkKind::SameDevice],
+        ],
+    };
+    let mesh = DeviceMesh {
+        device_ids: vec![10, 11, 12],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(
+        3,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::BalancedUneven,
+    );
+
+    let plan = PlacementPlanner::plan(&mesh, &request).unwrap();
+    let ordered_ids = plan
+        .placements
+        .iter()
+        .map(|placement| placement.device_id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(plan.gather_device_id, Some(11));
+    assert_eq!(ordered_ids, vec![11, 10, 12]);
+}

--- a/qdp/qdp-core/tests/gpu_distributed_planner.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_planner.rs
@@ -1,4 +1,4 @@
-use qdp_core::{
+use qdp_core::gpu::{
     DeviceMesh, DistributionMode, GpuTopology, LinkKind, PlacementPlanner, PlacementRequest,
     ShardPolicy,
 };
@@ -86,7 +86,10 @@ fn single_mode_uses_only_first_device() {
     assert_eq!(plan.placements.len(), 1);
     assert_eq!(plan.gather_device_id, Some(4));
     assert_eq!(plan.placements[0].device_id, 4);
-    assert_eq!((plan.placements[0].start_idx, plan.placements[0].end_idx), (0, 8));
+    assert_eq!(
+        (plan.placements[0].start_idx, plan.placements[0].end_idx),
+        (0, 8)
+    );
 }
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_planner.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_planner.rs
@@ -245,3 +245,37 @@ fn single_rank_request_preserves_rank_zero_ownership() {
     );
     assert_eq!(plan.num_local_shards(0), 2);
 }
+
+#[test]
+fn rank_local_planner_expands_local_devices_across_world() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new_with_world(
+        2,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::Equal,
+        2,
+    )
+    .unwrap();
+
+    let plan = PlacementPlanner::plan_rank_local(&mesh, &request).unwrap();
+    let rank_device_pairs = plan
+        .placements
+        .iter()
+        .map(|placement| (placement.rank_id, placement.device_id))
+        .collect::<Vec<_>>();
+    let ranges = plan
+        .placements
+        .iter()
+        .map(|placement| (placement.start_idx, placement.end_idx))
+        .collect::<Vec<_>>();
+
+    assert_eq!(rank_device_pairs, vec![(0, 0), (1, 0), (0, 1), (1, 1)]);
+    assert_eq!(ranges, vec![(0, 1), (1, 2), (2, 3), (3, 4)]);
+    assert_eq!(plan.placements_for_rank(0).len(), 2);
+    assert_eq!(plan.placements_for_rank(1).len(), 2);
+}

--- a/qdp/qdp-core/tests/gpu_distributed_planner.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_planner.rs
@@ -181,9 +181,8 @@ fn sharded_plan_assigns_ranks_round_robin() {
         .collect::<Vec<_>>();
 
     assert_eq!(ranks, vec![0, 1, 0, 1]);
-    assert_eq!(plan.placements_for_rank(0).len(), 2);
-    assert_eq!(plan.placements_for_rank(1).len(), 2);
-    assert_eq!(plan.num_local_shards(0), 2);
+    assert_eq!(plan.placements_for_rank_iter(0).count(), 2);
+    assert_eq!(plan.placements_for_rank_iter(1).count(), 2);
     assert_eq!(plan.local_max_len(0), 4);
 }
 
@@ -243,7 +242,7 @@ fn single_rank_request_preserves_rank_zero_ownership() {
             .iter()
             .all(|placement| placement.rank_id == 0)
     );
-    assert_eq!(plan.num_local_shards(0), 2);
+    assert_eq!(plan.placements_for_rank_iter(0).count(), 2);
 }
 
 #[test]
@@ -276,6 +275,6 @@ fn rank_local_planner_expands_local_devices_across_world() {
 
     assert_eq!(rank_device_pairs, vec![(0, 0), (1, 0), (0, 1), (1, 1)]);
     assert_eq!(ranges, vec![(0, 1), (1, 2), (2, 3), (3, 4)]);
-    assert_eq!(plan.placements_for_rank(0).len(), 2);
-    assert_eq!(plan.placements_for_rank(1).len(), 2);
+    assert_eq!(plan.placements_for_rank_iter(0).count(), 2);
+    assert_eq!(plan.placements_for_rank_iter(1).count(), 2);
 }

--- a/qdp/qdp-core/tests/gpu_distributed_planner.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_planner.rs
@@ -205,6 +205,29 @@ fn placement_request_rejects_zero_world_size() {
 }
 
 #[test]
+fn placement_planner_rejects_public_request_with_zero_world_size() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest {
+        num_qubits: 2,
+        mode: DistributionMode::ShardedCapacity,
+        shard_policy: ShardPolicy::Equal,
+        world_size: 0,
+    };
+
+    let err = PlacementPlanner::plan(&mesh, &request).unwrap_err();
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("world size")
+    ));
+}
+
+#[test]
 fn single_rank_request_preserves_rank_zero_ownership() {
     let topology = GpuTopology::placeholder(2);
     let mesh = DeviceMesh {

--- a/qdp/qdp-core/tests/gpu_distributed_planner.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_planner.rs
@@ -156,3 +156,69 @@ fn sharded_capacity_prefers_topology_recommended_device_order() {
     assert_eq!(plan.gather_device_id, Some(11));
     assert_eq!(ordered_ids, vec![11, 10, 12]);
 }
+
+#[test]
+fn sharded_plan_assigns_ranks_round_robin() {
+    let topology = GpuTopology::placeholder(4);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1, 2, 3],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new_with_world(
+        4,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::Equal,
+        2,
+    )
+    .unwrap();
+
+    let plan = PlacementPlanner::plan(&mesh, &request).unwrap();
+    let ranks = plan
+        .placements
+        .iter()
+        .map(|placement| placement.rank_id)
+        .collect::<Vec<_>>();
+
+    assert_eq!(ranks, vec![0, 1, 0, 1]);
+    assert_eq!(plan.placements_for_rank(0).len(), 2);
+    assert_eq!(plan.placements_for_rank(1).len(), 2);
+    assert_eq!(plan.num_local_shards(0), 2);
+    assert_eq!(plan.local_max_len(0), 4);
+}
+
+#[test]
+fn placement_request_rejects_zero_world_size() {
+    let err = PlacementRequest::new_with_world(
+        2,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::Equal,
+        0,
+    )
+    .unwrap_err();
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("world size")
+    ));
+}
+
+#[test]
+fn single_rank_request_preserves_rank_zero_ownership() {
+    let topology = GpuTopology::placeholder(2);
+    let mesh = DeviceMesh {
+        device_ids: vec![3, 7],
+        devices: Vec::new(),
+        topology,
+    };
+    let request = PlacementRequest::new(3, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+
+    let plan = PlacementPlanner::plan(&mesh, &request).unwrap();
+    assert!(
+        plan.placements
+            .iter()
+            .all(|placement| placement.rank_id == 0)
+    );
+    assert_eq!(plan.num_local_shards(0), 2);
+}

--- a/qdp/qdp-core/tests/gpu_distributed_planner.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_planner.rs
@@ -19,14 +19,11 @@ use qdp_core::gpu::{
     ShardPolicy,
 };
 
+mod common;
+
 #[test]
 fn placement_planner_emits_contiguous_ranges() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![3, 7],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![3, 7]);
     let request = PlacementRequest::new(3, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let plan = PlacementPlanner::plan(&mesh, &request).unwrap();
     assert_eq!(plan.gather_device_id, Some(3));
@@ -45,12 +42,7 @@ fn placement_planner_emits_contiguous_ranges() {
 
 #[test]
 fn balanced_uneven_policy_supports_non_power_of_two_device_counts() {
-    let topology = GpuTopology::placeholder(3);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1, 2],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1, 2]);
     let request = PlacementRequest::new(
         3,
         DistributionMode::ShardedCapacity,
@@ -74,12 +66,7 @@ fn balanced_uneven_policy_supports_non_power_of_two_device_counts() {
 
 #[test]
 fn equal_policy_rejects_non_power_of_two_device_counts() {
-    let topology = GpuTopology::placeholder(3);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1, 2],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1, 2]);
     let request = PlacementRequest::new(3, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
     let err = PlacementPlanner::plan(&mesh, &request).unwrap_err();
     assert!(matches!(
@@ -91,12 +78,7 @@ fn equal_policy_rejects_non_power_of_two_device_counts() {
 
 #[test]
 fn single_mode_uses_only_first_device() {
-    let topology = GpuTopology::placeholder(3);
-    let mesh = DeviceMesh {
-        device_ids: vec![4, 8, 15],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![4, 8, 15]);
     let request = PlacementRequest::new(3, DistributionMode::Single, ShardPolicy::Equal);
     let plan = PlacementPlanner::plan(&mesh, &request).unwrap();
     assert_eq!(plan.placements.len(), 1);
@@ -110,12 +92,7 @@ fn single_mode_uses_only_first_device() {
 
 #[test]
 fn replicated_mode_is_not_implemented() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest::new(2, DistributionMode::Replicated, ShardPolicy::Equal);
     let err = PlacementPlanner::plan(&mesh, &request).unwrap_err();
     assert!(matches!(err, qdp_core::MahoutError::NotImplemented(_)));
@@ -159,12 +136,7 @@ fn sharded_capacity_prefers_topology_recommended_device_order() {
 
 #[test]
 fn sharded_plan_assigns_ranks_round_robin() {
-    let topology = GpuTopology::placeholder(4);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1, 2, 3],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1, 2, 3]);
     let request = PlacementRequest::new_with_world(
         4,
         DistributionMode::ShardedCapacity,
@@ -205,12 +177,7 @@ fn placement_request_rejects_zero_world_size() {
 
 #[test]
 fn placement_planner_rejects_public_request_with_zero_world_size() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest {
         num_qubits: 2,
         mode: DistributionMode::ShardedCapacity,
@@ -228,12 +195,7 @@ fn placement_planner_rejects_public_request_with_zero_world_size() {
 
 #[test]
 fn single_rank_request_preserves_rank_zero_ownership() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![3, 7],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![3, 7]);
     let request = PlacementRequest::new(3, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
 
     let plan = PlacementPlanner::plan(&mesh, &request).unwrap();
@@ -247,12 +209,7 @@ fn single_rank_request_preserves_rank_zero_ownership() {
 
 #[test]
 fn rank_local_planner_expands_local_devices_across_world() {
-    let topology = GpuTopology::placeholder(2);
-    let mesh = DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology,
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1]);
     let request = PlacementRequest::new_with_world(
         2,
         DistributionMode::ShardedCapacity,

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -1,0 +1,144 @@
+use qdp_core::{DistributionMode, PlacementRequest, Precision, QdpEngine, ShardPolicy};
+
+#[test]
+fn prepare_distributed_amplitude_handles_padding_tail_in_norm() {
+    let prepared = QdpEngine::prepare_distributed_amplitude(
+        vec![0],
+        &[1.0, 2.0, 3.0],
+        2,
+        Precision::Float64,
+        None,
+    )
+    .unwrap();
+
+    let expected = 1.0 / 14.0f64.sqrt();
+    assert!((prepared.inv_norm - expected).abs() < 1e-12);
+}
+
+#[test]
+fn prepare_distributed_amplitude_accepts_custom_request() {
+    #[cfg(target_os = "linux")]
+    if cudarc::driver::CudaDevice::new(1).is_err() {
+        return;
+    }
+
+    let prepared = QdpEngine::prepare_distributed_amplitude(
+        vec![0, 1],
+        &[1.0, 2.0, 3.0],
+        2,
+        Precision::Float32,
+        Some(PlacementRequest::new(
+            2,
+            DistributionMode::ShardedCapacity,
+            ShardPolicy::Equal,
+        )),
+    )
+    .unwrap();
+
+    assert_eq!(prepared.plan.num_qubits, 2);
+    assert_eq!(prepared.plan.placement.num_devices(), 2);
+}
+
+#[test]
+fn prepare_distributed_amplitude_rejects_request_qubit_mismatch() {
+    let err = match QdpEngine::prepare_distributed_amplitude(
+        vec![0],
+        &[1.0, 2.0],
+        2,
+        Precision::Float64,
+        Some(PlacementRequest::new(
+            3,
+            DistributionMode::ShardedCapacity,
+            ShardPolicy::Equal,
+        )),
+    ) {
+        Ok(_) => panic!("expected qubit mismatch to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("qubit mismatch")
+    ));
+}
+
+#[test]
+fn prepare_distributed_amplitude_rejects_empty_input() {
+    let err = match QdpEngine::prepare_distributed_amplitude(
+        vec![0],
+        &[],
+        1,
+        Precision::Float64,
+        None,
+    ) {
+        Ok(_) => panic!("expected empty input to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("cannot be empty")
+    ));
+}
+
+#[test]
+fn prepare_distributed_amplitude_rejects_zero_norm_input() {
+    let err = match QdpEngine::prepare_distributed_amplitude(
+        vec![0],
+        &[0.0, 0.0],
+        1,
+        Precision::Float64,
+        None,
+    ) {
+        Ok(_) => panic!("expected zero-norm input to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("zero or non-finite norm")
+    ));
+}
+
+#[test]
+fn prepare_distributed_amplitude_rejects_non_finite_input() {
+    let err = match QdpEngine::prepare_distributed_amplitude(
+        vec![0],
+        &[1.0, f64::NAN],
+        1,
+        Precision::Float64,
+        None,
+    ) {
+        Ok(_) => panic!("expected non-finite input to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("NaN or Inf")
+    ));
+}
+
+#[test]
+fn prepare_distributed_amplitude_validates_input_before_building_mesh() {
+    let err = match QdpEngine::prepare_distributed_amplitude(
+        vec![9999],
+        &[],
+        1,
+        Precision::Float64,
+        None,
+    ) {
+        Ok(_) => panic!("expected invalid input to be rejected before mesh creation"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("cannot be empty")
+    ));
+}

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -1,3 +1,19 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 use qdp_core::{DistributionMode, PlacementRequest, Precision, QdpEngine, ShardPolicy};
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -65,16 +65,11 @@ fn prepare_distributed_amplitude_rejects_request_qubit_mismatch() {
 
 #[test]
 fn prepare_distributed_amplitude_rejects_empty_input() {
-    let err = match QdpEngine::prepare_distributed_amplitude(
-        vec![0],
-        &[],
-        1,
-        Precision::Float64,
-        None,
-    ) {
-        Ok(_) => panic!("expected empty input to be rejected"),
-        Err(err) => err,
-    };
+    let err =
+        match QdpEngine::prepare_distributed_amplitude(vec![0], &[], 1, Precision::Float64, None) {
+            Ok(_) => panic!("expected empty input to be rejected"),
+            Err(err) => err,
+        };
 
     assert!(matches!(
         err,

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -179,7 +179,7 @@ fn prepare_distributed_amplitude_accepts_custom_request() {
     .unwrap();
 
     assert_eq!(prepared.plan.num_qubits, 2);
-    assert_eq!(prepared.plan.placement.num_devices(), 2);
+    assert_eq!(prepared.plan.num_devices, 2);
 }
 
 #[test]
@@ -388,8 +388,8 @@ fn prepare_distributed_amplitude_uses_only_rank_local_norm_contribution() {
     assert!((prepared.inv_norm - (1.0 / 30.0f64.sqrt())).abs() < 1e-12);
     assert_eq!(prepared.layout.rank_id, 1);
     assert_eq!(prepared.layout.num_shards(), 2);
-    assert_eq!(prepared.layout.shards[0].shard_id, 1);
-    assert_eq!(prepared.layout.shards[1].shard_id, 3);
+    assert_eq!(prepared.layout.shards()[0].shard_id, 1);
+    assert_eq!(prepared.layout.shards()[1].shard_id, 3);
 }
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -343,11 +343,12 @@ fn prepare_distributed_amplitude_uses_only_rank_local_norm_contribution() {
     )
     .unwrap();
 
-    assert_eq!(*seen.lock().unwrap(), vec![25.0]);
+    assert_eq!(*seen.lock().unwrap(), vec![20.0]);
     assert!((prepared.inv_norm - (1.0 / 30.0f64.sqrt())).abs() < 1e-12);
     assert_eq!(prepared.layout.rank_id, 1);
-    assert_eq!(prepared.layout.num_shards(), 1);
+    assert_eq!(prepared.layout.num_shards(), 2);
     assert_eq!(prepared.layout.shards[0].shard_id, 1);
+    assert_eq!(prepared.layout.shards[1].shard_id, 3);
 }
 
 #[test]
@@ -408,6 +409,49 @@ fn prepare_distributed_amplitude_on_defaults_request_world_to_execution_world() 
         None,
     ) {
         Ok(_) => panic!("expected handle-less mesh to fail after request resolution"),
+        Err(err) => err,
+    };
+
+    assert_eq!(*seen.lock().unwrap(), vec![20.0]);
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("Device mesh / device handles mismatch")
+    ));
+}
+
+#[test]
+fn prepare_distributed_amplitude_on_plans_from_rank_local_mesh() {
+    let mesh = qdp_core::gpu::DeviceMesh {
+        device_ids: vec![0],
+        devices: Vec::new(),
+        topology: qdp_core::gpu::GpuTopology::placeholder(1),
+    };
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let collectives = RecordingCollective {
+        rank: 1,
+        world_size: 2,
+        global_sum: 30.0,
+        seen: Arc::clone(&seen),
+    };
+    let execution =
+        DistributedExecutionContext::rank_local_with_mesh(1, 2, mesh, &collectives).unwrap();
+    let request = PlacementRequest::new_with_world(
+        2,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::Equal,
+        2,
+    )
+    .unwrap();
+
+    let err = match QdpEngine::prepare_distributed_amplitude_on(
+        &execution,
+        &[1.0, 2.0, 3.0, 4.0],
+        2,
+        Precision::Float64,
+        Some(request),
+    ) {
+        Ok(_) => panic!("expected handle-less mesh to fail after rank-local planning"),
         Err(err) => err,
     };
 

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -14,6 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::{Arc, Mutex};
+
 use qdp_core::gpu::{
     CollectiveCommunicator, DeviceMesh, DistributedExecutionContext, GpuTopology,
     LocalCollectiveCommunicator,
@@ -37,6 +39,29 @@ impl CollectiveCommunicator for TestCollective {
 
     fn all_reduce_sum_f64(&self, local_value: f64) -> qdp_core::Result<f64> {
         Ok(local_value)
+    }
+}
+
+#[derive(Clone)]
+struct RecordingCollective {
+    rank: usize,
+    world_size: usize,
+    global_sum: f64,
+    seen: Arc<Mutex<Vec<f64>>>,
+}
+
+impl CollectiveCommunicator for RecordingCollective {
+    fn rank(&self) -> usize {
+        self.rank
+    }
+
+    fn world_size(&self) -> usize {
+        self.world_size
+    }
+
+    fn all_reduce_sum_f64(&self, local_value: f64) -> qdp_core::Result<f64> {
+        self.seen.lock().unwrap().push(local_value);
+        Ok(self.global_sum)
     }
 }
 
@@ -108,6 +133,11 @@ fn single_process_rejects_collective_metadata_mismatch_before_cuda_init() {
 
 #[test]
 fn prepare_distributed_amplitude_handles_padding_tail_in_norm() {
+    #[cfg(target_os = "linux")]
+    if cudarc::driver::CudaDevice::new(0).is_err() {
+        return;
+    }
+
     let prepared = QdpEngine::prepare_distributed_amplitude(
         vec![0],
         &[1.0, 2.0, 3.0],
@@ -123,6 +153,10 @@ fn prepare_distributed_amplitude_handles_padding_tail_in_norm() {
 
 #[test]
 fn prepare_distributed_amplitude_accepts_custom_request() {
+    #[cfg(target_os = "linux")]
+    if cudarc::driver::CudaDevice::new(0).is_err() {
+        return;
+    }
     #[cfg(target_os = "linux")]
     if cudarc::driver::CudaDevice::new(1).is_err() {
         return;
@@ -186,8 +220,19 @@ fn prepare_distributed_amplitude_rejects_empty_input() {
 
 #[test]
 fn prepare_distributed_amplitude_rejects_zero_norm_input() {
-    let err = match QdpEngine::prepare_distributed_amplitude(
-        vec![0],
+    let mesh = DeviceMesh {
+        device_ids: vec![0],
+        devices: Vec::new(),
+        topology: GpuTopology::placeholder(1),
+    };
+    let collectives = TestCollective {
+        rank: 0,
+        world_size: 1,
+    };
+    let execution =
+        DistributedExecutionContext::rank_local_with_mesh(0, 1, mesh, &collectives).unwrap();
+    let err = match QdpEngine::prepare_distributed_amplitude_on(
+        &execution,
         &[0.0, 0.0],
         1,
         Precision::Float64,
@@ -206,8 +251,19 @@ fn prepare_distributed_amplitude_rejects_zero_norm_input() {
 
 #[test]
 fn prepare_distributed_amplitude_rejects_non_finite_input() {
-    let err = match QdpEngine::prepare_distributed_amplitude(
-        vec![0],
+    let mesh = DeviceMesh {
+        device_ids: vec![0],
+        devices: Vec::new(),
+        topology: GpuTopology::placeholder(1),
+    };
+    let collectives = TestCollective {
+        rank: 0,
+        world_size: 1,
+    };
+    let execution =
+        DistributedExecutionContext::rank_local_with_mesh(0, 1, mesh, &collectives).unwrap();
+    let err = match QdpEngine::prepare_distributed_amplitude_on(
+        &execution,
         &[1.0, f64::NAN],
         1,
         Precision::Float64,
@@ -241,5 +297,124 @@ fn prepare_distributed_amplitude_validates_input_before_building_mesh() {
         err,
         qdp_core::MahoutError::InvalidInput(msg)
         if msg.contains("cannot be empty")
+    ));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn prepare_distributed_amplitude_uses_only_rank_local_norm_contribution() {
+    let device0 = match cudarc::driver::CudaDevice::new(0) {
+        Ok(device) => device,
+        Err(_) => return,
+    };
+    let device1 = match cudarc::driver::CudaDevice::new(1) {
+        Ok(device) => device,
+        Err(_) => return,
+    };
+    let mesh = qdp_core::gpu::DeviceMesh::from_parts(
+        vec![0, 1],
+        vec![device0, device1],
+        qdp_core::gpu::GpuTopology::placeholder(2),
+    )
+    .unwrap();
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let collectives = RecordingCollective {
+        rank: 1,
+        world_size: 2,
+        global_sum: 30.0,
+        seen: Arc::clone(&seen),
+    };
+    let execution =
+        DistributedExecutionContext::rank_local_with_mesh(1, 2, mesh, &collectives).unwrap();
+    let request = PlacementRequest::new_with_world(
+        2,
+        DistributionMode::ShardedCapacity,
+        ShardPolicy::Equal,
+        2,
+    )
+    .unwrap();
+
+    let prepared = QdpEngine::prepare_distributed_amplitude_on(
+        &execution,
+        &[1.0, 2.0, 3.0, 4.0],
+        2,
+        Precision::Float64,
+        Some(request),
+    )
+    .unwrap();
+
+    assert_eq!(*seen.lock().unwrap(), vec![25.0]);
+    assert!((prepared.inv_norm - (1.0 / 30.0f64.sqrt())).abs() < 1e-12);
+    assert_eq!(prepared.layout.rank_id, 1);
+    assert_eq!(prepared.layout.num_shards(), 1);
+    assert_eq!(prepared.layout.shards[0].shard_id, 1);
+}
+
+#[test]
+fn prepare_distributed_amplitude_on_rejects_request_world_mismatch() {
+    let mesh = qdp_core::gpu::DeviceMesh {
+        device_ids: vec![0],
+        devices: Vec::new(),
+        topology: qdp_core::gpu::GpuTopology::placeholder(1),
+    };
+    let collectives = TestCollective {
+        rank: 0,
+        world_size: 2,
+    };
+    let execution =
+        DistributedExecutionContext::rank_local_with_mesh(0, 2, mesh, &collectives).unwrap();
+    let request = PlacementRequest::new(2, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
+
+    let err = match QdpEngine::prepare_distributed_amplitude_on(
+        &execution,
+        &[1.0, 2.0],
+        2,
+        Precision::Float64,
+        Some(request),
+    ) {
+        Ok(_) => panic!("expected request world mismatch to be rejected"),
+        Err(err) => err,
+    };
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("world size")
+    ));
+}
+
+#[test]
+fn prepare_distributed_amplitude_on_defaults_request_world_to_execution_world() {
+    let mesh = qdp_core::gpu::DeviceMesh {
+        device_ids: vec![0, 1],
+        devices: Vec::new(),
+        topology: qdp_core::gpu::GpuTopology::placeholder(2),
+    };
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let collectives = RecordingCollective {
+        rank: 1,
+        world_size: 2,
+        global_sum: 30.0,
+        seen: Arc::clone(&seen),
+    };
+    let execution =
+        DistributedExecutionContext::rank_local_with_mesh(1, 2, mesh, &collectives).unwrap();
+
+    let err = match QdpEngine::prepare_distributed_amplitude_on(
+        &execution,
+        &[1.0, 2.0, 3.0, 4.0],
+        2,
+        Precision::Float64,
+        None,
+    ) {
+        Ok(_) => panic!("expected handle-less mesh to fail after request resolution"),
+        Err(err) => err,
+    };
+
+    assert_eq!(*seen.lock().unwrap(), vec![25.0]);
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("Device mesh / device handles mismatch")
     ));
 }

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -14,13 +14,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use qdp_core::gpu::{DistributedExecutionContext, LocalCollectiveCommunicator};
+use qdp_core::gpu::{
+    DeviceMesh, DistributedExecutionContext, GpuTopology, LocalCollectiveCommunicator,
+};
 use qdp_core::{DistributionMode, PlacementRequest, Precision, QdpEngine, ShardPolicy};
 
 #[test]
 fn rank_local_execution_context_reports_rank_metadata() {
     let collectives = LocalCollectiveCommunicator;
-    let execution = DistributedExecutionContext::rank_local(1, 3, vec![0], &collectives).unwrap();
+    let mesh = DeviceMesh {
+        device_ids: vec![0],
+        devices: Vec::new(),
+        topology: GpuTopology::placeholder(1),
+    };
+    let execution =
+        DistributedExecutionContext::rank_local_with_mesh(1, 3, mesh, &collectives).unwrap();
 
     assert_eq!(execution.rank(), 1);
     assert_eq!(execution.world_size(), 3);

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -60,7 +60,10 @@ impl CollectiveCommunicator for RecordingCollective {
     }
 
     fn all_reduce_sum_f64(&self, local_value: f64) -> qdp_core::Result<f64> {
-        self.seen.lock().unwrap().push(local_value);
+        self.seen
+            .lock()
+            .expect("recording collective observations mutex poisoned")
+            .push(local_value);
         Ok(self.global_sum)
     }
 }

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -14,7 +14,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use qdp_core::gpu::{DistributedExecutionContext, LocalCollectiveCommunicator};
 use qdp_core::{DistributionMode, PlacementRequest, Precision, QdpEngine, ShardPolicy};
+
+#[test]
+fn rank_local_execution_context_reports_rank_metadata() {
+    let collectives = LocalCollectiveCommunicator;
+    let execution = DistributedExecutionContext::rank_local(1, 3, vec![0], &collectives).unwrap();
+
+    assert_eq!(execution.rank(), 1);
+    assert_eq!(execution.world_size(), 3);
+    assert_eq!(execution.mesh().num_devices(), 1);
+    assert!(execution.device_collectives().is_none());
+}
+
+#[test]
+fn rank_local_execution_context_rejects_rank_out_of_range() {
+    let collectives = LocalCollectiveCommunicator;
+    let err = DistributedExecutionContext::rank_local(2, 2, vec![0], &collectives).unwrap_err();
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("rank") && msg.contains("world size")
+    ));
+}
 
 #[test]
 fn prepare_distributed_amplitude_handles_padding_tail_in_norm() {

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -15,13 +15,37 @@
 // limitations under the License.
 
 use qdp_core::gpu::{
-    DeviceMesh, DistributedExecutionContext, GpuTopology, LocalCollectiveCommunicator,
+    CollectiveCommunicator, DeviceMesh, DistributedExecutionContext, GpuTopology,
+    LocalCollectiveCommunicator,
 };
 use qdp_core::{DistributionMode, PlacementRequest, Precision, QdpEngine, ShardPolicy};
 
+#[derive(Clone, Copy)]
+struct TestCollective {
+    rank: usize,
+    world_size: usize,
+}
+
+impl CollectiveCommunicator for TestCollective {
+    fn rank(&self) -> usize {
+        self.rank
+    }
+
+    fn world_size(&self) -> usize {
+        self.world_size
+    }
+
+    fn all_reduce_sum_f64(&self, local_value: f64) -> qdp_core::Result<f64> {
+        Ok(local_value)
+    }
+}
+
 #[test]
 fn rank_local_execution_context_reports_rank_metadata() {
-    let collectives = LocalCollectiveCommunicator;
+    let collectives = TestCollective {
+        rank: 1,
+        world_size: 3,
+    };
     let mesh = DeviceMesh {
         device_ids: vec![0],
         devices: Vec::new(),
@@ -34,6 +58,25 @@ fn rank_local_execution_context_reports_rank_metadata() {
     assert_eq!(execution.world_size(), 3);
     assert_eq!(execution.mesh().num_devices(), 1);
     assert!(execution.device_collectives().is_none());
+}
+
+#[test]
+fn rank_local_execution_context_rejects_collective_metadata_mismatch() {
+    let collectives = LocalCollectiveCommunicator;
+    let mesh = DeviceMesh {
+        device_ids: vec![0],
+        devices: Vec::new(),
+        topology: GpuTopology::placeholder(1),
+    };
+
+    let err =
+        DistributedExecutionContext::rank_local_with_mesh(1, 3, mesh, &collectives).unwrap_err();
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("collective") && msg.contains("rank")
+    ));
 }
 
 #[test]

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -14,71 +14,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::{Arc, Mutex};
-
-use qdp_core::gpu::{
-    CollectiveCommunicator, DeviceMesh, DistributedExecutionContext, GpuTopology,
-    LocalCollectiveCommunicator,
-};
+use qdp_core::gpu::{DistributedExecutionContext, LocalCollectiveCommunicator};
 use qdp_core::{DistributionMode, PlacementRequest, Precision, QdpEngine, ShardPolicy};
 
-#[derive(Clone, Copy)]
-struct TestCollective {
-    rank: usize,
-    world_size: usize,
-}
+mod common;
 
-impl CollectiveCommunicator for TestCollective {
-    fn rank(&self) -> usize {
-        self.rank
-    }
-
-    fn world_size(&self) -> usize {
-        self.world_size
-    }
-
-    fn all_reduce_sum_f64(&self, local_value: f64) -> qdp_core::Result<f64> {
-        Ok(local_value)
-    }
-}
-
-#[derive(Clone)]
-struct RecordingCollective {
-    rank: usize,
-    world_size: usize,
-    global_sum: f64,
-    seen: Arc<Mutex<Vec<f64>>>,
-}
-
-impl CollectiveCommunicator for RecordingCollective {
-    fn rank(&self) -> usize {
-        self.rank
-    }
-
-    fn world_size(&self) -> usize {
-        self.world_size
-    }
-
-    fn all_reduce_sum_f64(&self, local_value: f64) -> qdp_core::Result<f64> {
-        self.seen
-            .lock()
-            .expect("recording collective observations mutex poisoned")
-            .push(local_value);
-        Ok(self.global_sum)
-    }
-}
+use common::{RecordingCollective, TestCollective};
 
 #[test]
 fn rank_local_execution_context_reports_rank_metadata() {
-    let collectives = TestCollective {
-        rank: 1,
-        world_size: 3,
-    };
-    let mesh = DeviceMesh {
-        device_ids: vec![0],
-        devices: Vec::new(),
-        topology: GpuTopology::placeholder(1),
-    };
+    let collectives = TestCollective::new(1, 3);
+    let mesh = common::placeholder_mesh(vec![0]);
     let execution =
         DistributedExecutionContext::rank_local_with_mesh(1, 3, mesh, &collectives).unwrap();
 
@@ -91,11 +37,7 @@ fn rank_local_execution_context_reports_rank_metadata() {
 #[test]
 fn rank_local_execution_context_rejects_collective_metadata_mismatch() {
     let collectives = LocalCollectiveCommunicator;
-    let mesh = DeviceMesh {
-        device_ids: vec![0],
-        devices: Vec::new(),
-        topology: GpuTopology::placeholder(1),
-    };
+    let mesh = common::placeholder_mesh(vec![0]);
 
     let err =
         DistributedExecutionContext::rank_local_with_mesh(1, 3, mesh, &collectives).unwrap_err();
@@ -121,10 +63,7 @@ fn rank_local_execution_context_rejects_rank_out_of_range() {
 
 #[test]
 fn single_process_rejects_collective_metadata_mismatch_before_cuda_init() {
-    let collectives = TestCollective {
-        rank: 1,
-        world_size: 3,
-    };
+    let collectives = TestCollective::new(1, 3);
     let err = DistributedExecutionContext::single_process(vec![0], &collectives).unwrap_err();
 
     assert!(matches!(
@@ -137,7 +76,7 @@ fn single_process_rejects_collective_metadata_mismatch_before_cuda_init() {
 #[test]
 fn prepare_distributed_amplitude_handles_padding_tail_in_norm() {
     #[cfg(target_os = "linux")]
-    if cudarc::driver::CudaDevice::new(0).is_err() {
+    if common::cuda_device_by_id(0).is_none() {
         return;
     }
 
@@ -157,11 +96,7 @@ fn prepare_distributed_amplitude_handles_padding_tail_in_norm() {
 #[test]
 fn prepare_distributed_amplitude_accepts_custom_request() {
     #[cfg(target_os = "linux")]
-    if cudarc::driver::CudaDevice::new(0).is_err() {
-        return;
-    }
-    #[cfg(target_os = "linux")]
-    if cudarc::driver::CudaDevice::new(1).is_err() {
+    if common::cuda_devices(&[0, 1]).is_none() {
         return;
     }
 
@@ -223,15 +158,8 @@ fn prepare_distributed_amplitude_rejects_empty_input() {
 
 #[test]
 fn prepare_distributed_amplitude_rejects_zero_norm_input() {
-    let mesh = DeviceMesh {
-        device_ids: vec![0],
-        devices: Vec::new(),
-        topology: GpuTopology::placeholder(1),
-    };
-    let collectives = TestCollective {
-        rank: 0,
-        world_size: 1,
-    };
+    let mesh = common::placeholder_mesh(vec![0]);
+    let collectives = TestCollective::new(0, 1);
     let execution =
         DistributedExecutionContext::rank_local_with_mesh(0, 1, mesh, &collectives).unwrap();
     let err = match QdpEngine::prepare_distributed_amplitude_on(
@@ -254,15 +182,8 @@ fn prepare_distributed_amplitude_rejects_zero_norm_input() {
 
 #[test]
 fn prepare_distributed_amplitude_rejects_non_finite_input() {
-    let mesh = DeviceMesh {
-        device_ids: vec![0],
-        devices: Vec::new(),
-        topology: GpuTopology::placeholder(1),
-    };
-    let collectives = TestCollective {
-        rank: 0,
-        world_size: 1,
-    };
+    let mesh = common::placeholder_mesh(vec![0]);
+    let collectives = TestCollective::new(0, 1);
     let execution =
         DistributedExecutionContext::rank_local_with_mesh(0, 1, mesh, &collectives).unwrap();
     let err = match QdpEngine::prepare_distributed_amplitude_on(
@@ -285,18 +206,8 @@ fn prepare_distributed_amplitude_rejects_non_finite_input() {
 
 #[test]
 fn prepare_distributed_amplitude_reduces_before_rejecting_non_finite_input() {
-    let mesh = DeviceMesh {
-        device_ids: vec![0],
-        devices: Vec::new(),
-        topology: GpuTopology::placeholder(1),
-    };
-    let seen = Arc::new(Mutex::new(Vec::new()));
-    let collectives = RecordingCollective {
-        rank: 0,
-        world_size: 1,
-        global_sum: f64::NAN,
-        seen: Arc::clone(&seen),
-    };
+    let mesh = common::placeholder_mesh(vec![0]);
+    let (collectives, seen) = RecordingCollective::new(0, 1, f64::NAN);
     let execution =
         DistributedExecutionContext::rank_local_with_mesh(0, 1, mesh, &collectives).unwrap();
 
@@ -344,27 +255,16 @@ fn prepare_distributed_amplitude_validates_input_before_building_mesh() {
 #[test]
 #[cfg(target_os = "linux")]
 fn prepare_distributed_amplitude_uses_only_rank_local_norm_contribution() {
-    let device0 = match cudarc::driver::CudaDevice::new(0) {
-        Ok(device) => device,
-        Err(_) => return,
-    };
-    let device1 = match cudarc::driver::CudaDevice::new(1) {
-        Ok(device) => device,
-        Err(_) => return,
+    let Some(devices) = common::cuda_devices(&[0, 1]) else {
+        return;
     };
     let mesh = qdp_core::gpu::DeviceMesh::from_parts(
         vec![0, 1],
-        vec![device0, device1],
+        devices,
         qdp_core::gpu::GpuTopology::placeholder(2),
     )
     .unwrap();
-    let seen = Arc::new(Mutex::new(Vec::new()));
-    let collectives = RecordingCollective {
-        rank: 1,
-        world_size: 2,
-        global_sum: 30.0,
-        seen: Arc::clone(&seen),
-    };
+    let (collectives, seen) = RecordingCollective::new(1, 2, 30.0);
     let execution =
         DistributedExecutionContext::rank_local_with_mesh(1, 2, mesh, &collectives).unwrap();
     let request = PlacementRequest::new_with_world(
@@ -394,15 +294,8 @@ fn prepare_distributed_amplitude_uses_only_rank_local_norm_contribution() {
 
 #[test]
 fn prepare_distributed_amplitude_on_rejects_request_world_mismatch() {
-    let mesh = qdp_core::gpu::DeviceMesh {
-        device_ids: vec![0],
-        devices: Vec::new(),
-        topology: qdp_core::gpu::GpuTopology::placeholder(1),
-    };
-    let collectives = TestCollective {
-        rank: 0,
-        world_size: 2,
-    };
+    let mesh = common::placeholder_mesh(vec![0]);
+    let collectives = TestCollective::new(0, 2);
     let execution =
         DistributedExecutionContext::rank_local_with_mesh(0, 2, mesh, &collectives).unwrap();
     let request = PlacementRequest::new(2, DistributionMode::ShardedCapacity, ShardPolicy::Equal);
@@ -427,18 +320,8 @@ fn prepare_distributed_amplitude_on_rejects_request_world_mismatch() {
 
 #[test]
 fn prepare_distributed_amplitude_on_defaults_request_world_to_execution_world() {
-    let mesh = qdp_core::gpu::DeviceMesh {
-        device_ids: vec![0, 1],
-        devices: Vec::new(),
-        topology: qdp_core::gpu::GpuTopology::placeholder(2),
-    };
-    let seen = Arc::new(Mutex::new(Vec::new()));
-    let collectives = RecordingCollective {
-        rank: 1,
-        world_size: 2,
-        global_sum: 30.0,
-        seen: Arc::clone(&seen),
-    };
+    let mesh = common::placeholder_mesh(vec![0, 1]);
+    let (collectives, seen) = RecordingCollective::new(1, 2, 30.0);
     let execution =
         DistributedExecutionContext::rank_local_with_mesh(1, 2, mesh, &collectives).unwrap();
 
@@ -463,18 +346,8 @@ fn prepare_distributed_amplitude_on_defaults_request_world_to_execution_world() 
 
 #[test]
 fn prepare_distributed_amplitude_on_plans_from_rank_local_mesh() {
-    let mesh = qdp_core::gpu::DeviceMesh {
-        device_ids: vec![0],
-        devices: Vec::new(),
-        topology: qdp_core::gpu::GpuTopology::placeholder(1),
-    };
-    let seen = Arc::new(Mutex::new(Vec::new()));
-    let collectives = RecordingCollective {
-        rank: 1,
-        world_size: 2,
-        global_sum: 30.0,
-        seen: Arc::clone(&seen),
-    };
+    let mesh = common::placeholder_mesh(vec![0]);
+    let (collectives, seen) = RecordingCollective::new(1, 2, 30.0);
     let execution =
         DistributedExecutionContext::rank_local_with_mesh(1, 2, mesh, &collectives).unwrap();
     let request = PlacementRequest::new_with_world(

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -92,6 +92,21 @@ fn rank_local_execution_context_rejects_rank_out_of_range() {
 }
 
 #[test]
+fn single_process_rejects_collective_metadata_mismatch_before_cuda_init() {
+    let collectives = TestCollective {
+        rank: 1,
+        world_size: 3,
+    };
+    let err = DistributedExecutionContext::single_process(vec![0], &collectives).unwrap_err();
+
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("collective") && msg.contains("rank")
+    ));
+}
+
+#[test]
 fn prepare_distributed_amplitude_handles_padding_tail_in_norm() {
     let prepared = QdpEngine::prepare_distributed_amplitude(
         vec![0],

--- a/qdp/qdp-core/tests/gpu_distributed_runtime.rs
+++ b/qdp/qdp-core/tests/gpu_distributed_runtime.rs
@@ -276,7 +276,45 @@ fn prepare_distributed_amplitude_rejects_non_finite_input() {
     assert!(matches!(
         err,
         qdp_core::MahoutError::InvalidInput(msg)
-        if msg.contains("NaN or Inf")
+        if msg.contains("zero or non-finite norm")
+    ));
+}
+
+#[test]
+fn prepare_distributed_amplitude_reduces_before_rejecting_non_finite_input() {
+    let mesh = DeviceMesh {
+        device_ids: vec![0],
+        devices: Vec::new(),
+        topology: GpuTopology::placeholder(1),
+    };
+    let seen = Arc::new(Mutex::new(Vec::new()));
+    let collectives = RecordingCollective {
+        rank: 0,
+        world_size: 1,
+        global_sum: f64::NAN,
+        seen: Arc::clone(&seen),
+    };
+    let execution =
+        DistributedExecutionContext::rank_local_with_mesh(0, 1, mesh, &collectives).unwrap();
+
+    let err = match QdpEngine::prepare_distributed_amplitude_on(
+        &execution,
+        &[1.0, f64::NAN],
+        1,
+        Precision::Float64,
+        None,
+    ) {
+        Ok(_) => panic!("expected non-finite input to be rejected after reduction"),
+        Err(err) => err,
+    };
+
+    let seen = seen.lock().unwrap();
+    assert_eq!(seen.len(), 1);
+    assert!(!seen[0].is_finite());
+    assert!(matches!(
+        err,
+        qdp_core::MahoutError::InvalidInput(msg)
+        if msg.contains("zero or non-finite norm")
     ));
 }
 

--- a/qdp/qdp-core/tests/gpu_topology.rs
+++ b/qdp/qdp-core/tests/gpu_topology.rs
@@ -1,0 +1,79 @@
+//
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use qdp_core::{DeviceMesh, GpuTopology, LinkKind};
+
+#[test]
+fn placeholder_topology_marks_self_edges() {
+    let topology = GpuTopology::placeholder(2);
+    assert!(topology.peer_access[0][0]);
+    assert!(topology.peer_access[1][1]);
+    assert_eq!(topology.links[0][0], LinkKind::SameDevice);
+    assert_eq!(topology.links[1][1], LinkKind::SameDevice);
+    assert!(!topology.peer_access[0][1]);
+    assert_eq!(topology.links[0][1], LinkKind::Unknown);
+}
+
+#[test]
+fn duplicate_device_ids_are_rejected() {
+    let err = DeviceMesh::new(vec![0, 0]).err().unwrap();
+    assert!(matches!(err, qdp_core::MahoutError::InvalidInput(_)));
+}
+
+#[test]
+fn power_of_two_validation_rejects_three_devices() {
+    let topology = GpuTopology::placeholder(3);
+    let mesh = DeviceMesh {
+        device_ids: vec![0, 1, 2],
+        devices: Vec::new(),
+        topology,
+    };
+    let err = mesh.validate_power_of_two().unwrap_err();
+    assert!(matches!(err, qdp_core::MahoutError::InvalidInput(_)));
+}
+
+#[test]
+#[cfg(target_os = "linux")]
+fn from_parts_rejects_device_handle_mismatch() {
+    let device = match cudarc::driver::CudaDevice::new(0) {
+        Ok(device) => device,
+        Err(_) => return,
+    };
+    let topology = GpuTopology::placeholder(1);
+    let err = DeviceMesh::from_parts(vec![1], vec![device], topology)
+        .err()
+        .unwrap();
+    assert!(matches!(err, qdp_core::MahoutError::InvalidInput(_)));
+}
+
+#[test]
+fn preferred_gather_index_prefers_best_connected_device() {
+    let topology = GpuTopology {
+        peer_access: vec![
+            vec![true, true, false],
+            vec![true, true, true],
+            vec![false, true, true],
+        ],
+        links: vec![
+            vec![LinkKind::SameDevice, LinkKind::Pix, LinkKind::Unknown],
+            vec![LinkKind::Pix, LinkKind::SameDevice, LinkKind::Node],
+            vec![LinkKind::Unknown, LinkKind::Node, LinkKind::SameDevice],
+        ],
+    };
+
+    assert_eq!(topology.preferred_gather_index(), Some(1));
+    assert_eq!(topology.recommended_placement_order(), vec![1, 0, 2]);
+}

--- a/qdp/qdp-core/tests/gpu_topology.rs
+++ b/qdp/qdp-core/tests/gpu_topology.rs
@@ -14,7 +14,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use qdp_core::{DeviceMesh, GpuTopology, LinkKind};
+use qdp_core::DeviceMesh;
+use qdp_core::gpu::{GpuTopology, LinkKind};
 
 #[test]
 fn placeholder_topology_marks_self_edges() {


### PR DESCRIPTION
### Related Issues

Closes #1295
Part of #1297

### Summary

This PR adds the first QDP-native distributed GPU state execution foundation, with amplitude state construction as the first workload.

The implementation is intentionally **MPI-ready** but does **not** require MPI or NCCL as mandatory dependencies. The executable path in this PR is a real single-process fallback that runs through the same rank-local planning, runtime, transport, and state boundaries that a future MPI-backed execution path should use.

In other words, this PR is not claiming full `mpirun -n N` support yet. It establishes the architecture and a testable fallback boundary that future MPI, CUDA-aware MPI, and NCCL backends can replace or extend.

The main architecture boundary is intentionally split into four layers:

- **Planning** decides where shards should live.
- **Runtime** decides what work the current rank performs.
- **Transport** owns scalar and future GPU-resident collectives.
- **State** owns local GPU shard buffers and exposes local zero-copy views.

## Current Capability

This PR currently supports:

- rank/world execution metadata through `DistributedExecutionContext`
- rank-local device meshes and placement planning
- shared distributed state planning through `DistributedStatePlan`
- amplitude-specific execution through `DistributedAmplitudePlan`
- local GPU shard materialization for shards owned by the current rank
- scalar rank-level reduction through `CollectiveCommunicator`
- single-process fallback through `LocalCollectiveCommunicator`
- zero-copy **local** shard metadata through `DistributedStateVector::local_shard_views()`
- planned `device_id` to CUDA handle resolution, so shard metadata, active CUDA device context, and allocated buffers stay aligned
- placeholder CUDA-aware MPI / NCCL device collective types that identify their backend but return `NotImplemented` for GPU-resident collectives

### Architecture Shape

```mermaid
sequenceDiagram
    participant Caller as QdpEngine caller
    participant Engine as QdpEngine
    participant Ctx as DistributedExecutionContext
    participant Planner as PlacementPlanner
    participant StatePlan as DistributedStatePlan
    participant AmpPlan as DistributedAmplitudePlan
    participant Runtime as distributed runtime
    participant Comm as CollectiveCommunicator
    participant State as DistributedStateVector

    Caller->>Engine: submit distributed amplitude request
    Engine->>Engine: validate input and resolve request
    Engine->>Ctx: construct rank-local execution context
    Engine->>Planner: build rank-local placement plan
    Planner-->>Engine: placement + shard ranges
    Engine->>StatePlan: build shared shard/rank contract
    StatePlan-->>AmpPlan: wrap for amplitude workload
    AmpPlan->>Runtime: execute local-rank shard work
    Runtime->>Runtime: compute local norm contribution
    Runtime->>Comm: all_reduce_sum_f64(local_norm_sq)
    Comm-->>Runtime: global norm
    Runtime->>Runtime: allocate and encode local GPU shards
    Runtime-->>State: local distributed state
    State-->>Caller: zero-copy local shard views available
```

This PR does not yet support:

- true MPI multi-rank launch
- CUDA-aware MPI collective execution
- NCCL collective execution
- multi-node execution
- cross-rank zero-copy transport

### Follow-up Work

- Implement a true MPI scalar communicator for `CollectiveCommunicator`.
- Add a documented `mpirun -n N` launch path.
- Add multi-rank smoke tests gated behind an MPI feature or CI environment.
- Implement CUDA-aware MPI and/or NCCL `DeviceCollectiveCommunicator` backends.
- Define gather/export and downstream consumer contracts for distributed state.
