### PR TITLE
docs: fix stale links on the How to Contribute pages (#1301)

### DIFF
--- a/docs/about/how-to-contribute.md
+++ b/docs/about/how-to-contribute.md
@@ -12,7 +12,7 @@ of ways to contribute!
 <a name="HowToContribute-BeInvolved"></a>
 ## Get Involved
 
-Discussions at Apache happen on the mailing list. To get involved, you should join the [Mahout mailing lists](../community/mailing-lists).  In particular:
+Discussions at Apache happen on the mailing list. To get involved, you should join the [Mahout mailing lists](../community/mailing-lists.md).  In particular:
 
 * The **user list** (to help others)
 * The **development list** (to join discussions of changes)  -- This is the best place
@@ -46,9 +46,7 @@ where people are working.
 Also, documentation is a great way to familiarize yourself with the code
 and is always a welcome addition to the codebase and this website. Feel free
 to contribute texts and tutorials! Committers will make sure they are added
-to this website, and we have a [guide for making website updates][2].
-We also have a [wide variety of books and slides][3] for learning more about
-machine learning algorithms.
+to this website.
 
 If you are interested in working towards being a committer, general guidelines are available in the [Apache Community documentation](https://community.apache.org/contributors/).
 
@@ -82,7 +80,7 @@ First of all, you need to get the Mahout source code from [GitHub](https://githu
 <a name="HowToContribute-MakingChanges"></a>
 ## Making Changes
 
-Before you start, you should send a message to the [Mahout developer mailing list](../community/mailing-lists)
+Before you start, you should send a message to the [Mahout developer mailing list](../community/mailing-lists.md)
 (note: you have to subscribe before you can post), or file a ticket in our [issue tracker](https://github.com/apache/mahout/issues).
 Describe your proposed changes and check that they fit in with what others are doing and have planned for the project.  Be patient, it may take folks a while to understand your requirements.
 
@@ -143,9 +141,7 @@ for improvement (more tests, better javadocs, etc...) then make the changes on y
 thumbs up, that's a good sign for committers when deciding if it's worth spending time to review it -- and if other people have already put in
 effort to improve the docs/tests for an issue, that helps even more.
 
-For more information see [Handling GitHub PRs](http://mahout.apache.org/documentation/developers/github).
+For more information see the [PR policy and review guidelines](../community/pr-policy-and-review-guidelines.md).
 
 
   [1]: http://www.apache.org/dev/contrib-email-tips
-  [2]: http://mahout.apache.org/documentation/developers/how-to-update-the-website.html
-  [3]: http://mahout.apache.org/general/books-tutorials-and-talks.html

--- a/docs/qumat/getting-started.md
+++ b/docs/qumat/getting-started.md
@@ -72,4 +72,4 @@ Refer to repository examples:
 
 - [Basic Gates](./basic-gates)
 - [API Reference](./api)
-- [QDP Getting Started](../qdp/getting-started)
+- [QDP Getting Started](../qdp/getting-started.md)

--- a/docs/qumat/index.md
+++ b/docs/qumat/index.md
@@ -21,6 +21,6 @@ Qumat is a high-level Python library for quantum computing that provides:
 
 ## Related
 
-- [QDP (Quantum Data Plane)](../qdp)
-- [Quantum Computing Primer](../learning/quantum-computing-primer)
-- [Research Papers](../learning/papers)
+- [QDP (Quantum Data Plane)](../qdp/index.md)
+- [Quantum Computing Primer](../learning/quantum-computing-primer/index.md)
+- [Research Papers](../learning/papers/index.md)

--- a/lychee.toml
+++ b/lychee.toml
@@ -4,7 +4,6 @@ exclude_path = [
     "./website/versioned*", # Focus on next version
     "./website/static/download/downloads.html", # Should we fix in the future?
     "./dev/rc-email-template.md", # Should we fix in the future?
-    "./docs/about/how-to-contribute.md", # TODO: fix the links in this file
     "./qdp/docs/readers/README.md", # TODO: fix the links in this file
 ]
 fallback_extensions = ["md"]

--- a/website/scripts/sync-docs.js
+++ b/website/scripts/sync-docs.js
@@ -165,12 +165,6 @@ function transformLinks(content) {
       return match;
     }
 
-    // Handle .md file references
-    if (url.endsWith('.md')) {
-      // Remove .md extension for Docusaurus
-      url = url.slice(0, -3);
-    }
-
     return `[${text}](${url})`;
   });
 }

--- a/website/versioned_docs/version-0.4/about/how-to-contribute.md
+++ b/website/versioned_docs/version-0.4/about/how-to-contribute.md
@@ -21,7 +21,7 @@ to understand where the project is headed.
 
 Please keep discussions about Mahout on list so that everyone benefits.
 Emailing individual committers with questions about specific Mahout issues
-is discouraged.  See [http://people.apache.org/~hossman/#private_q](http://people.apache.org/~hossman/#private_q)
+is discouraged.  See [https://www.apache.org/theapacheway/](https://www.apache.org/theapacheway/)
 .  Apache  has a number of [email tips for contributors][1] as well.
 
 <a name="HowToContribute-WhattoWorkOn?"></a>
@@ -46,9 +46,7 @@ where people are working.
 Also, documentation is a great way to familiarize yourself with the code
 and is always a welcome addition to the codebase and this website. Feel free
 to contribute texts and tutorials! Committers will make sure they are added
-to this website, and we have a [guide for making website updates][2].
-We also have a [wide variety of books and slides][3] for learning more about
-machine learning algorithms.
+to this website.
 
 If you are interested in working towards being a committer, general guidelines are available in the [Apache Community documentation](https://community.apache.org/contributors/).
 
@@ -143,9 +141,7 @@ for improvement (more tests, better javadocs, etc...) then make the changes on y
 thumbs up, that's a good sign for committers when deciding if it's worth spending time to review it -- and if other people have already put in
 effort to improve the docs/tests for an issue, that helps even more.
 
-For more information see [Handling GitHub PRs](http://mahout.apache.org/documentation/developers/github).
+For more information see the [PR policy and review guidelines](https://github.com/apache/mahout/blob/main/docs/community/pr-policy-and-review-guidelines.md).
 
 
   [1]: http://www.apache.org/dev/contrib-email-tips
-  [2]: http://mahout.apache.org/documentation/developers/how-to-update-the-website.html
-  [3]: http://mahout.apache.org/general/books-tutorials-and-talks.html

--- a/website/versioned_docs/version-0.5/about/how-to-contribute.md
+++ b/website/versioned_docs/version-0.5/about/how-to-contribute.md
@@ -46,9 +46,7 @@ where people are working.
 Also, documentation is a great way to familiarize yourself with the code
 and is always a welcome addition to the codebase and this website. Feel free
 to contribute texts and tutorials! Committers will make sure they are added
-to this website, and we have a [guide for making website updates][2].
-We also have a [wide variety of books and slides][3] for learning more about
-machine learning algorithms.
+to this website.
 
 If you are interested in working towards being a committer, general guidelines are available in the [Apache Community documentation](https://community.apache.org/contributors/).
 
@@ -143,9 +141,7 @@ for improvement (more tests, better javadocs, etc...) then make the changes on y
 thumbs up, that's a good sign for committers when deciding if it's worth spending time to review it -- and if other people have already put in
 effort to improve the docs/tests for an issue, that helps even more.
 
-For more information see [Handling GitHub PRs](http://mahout.apache.org/documentation/developers/github).
+For more information see the [PR policy and review guidelines](https://github.com/apache/mahout/blob/main/docs/community/pr-policy-and-review-guidelines.md).
 
 
   [1]: http://www.apache.org/dev/contrib-email-tips
-  [2]: http://mahout.apache.org/documentation/developers/how-to-update-the-website.html
-  [3]: http://mahout.apache.org/general/books-tutorials-and-talks.html


### PR DESCRIPTION
### Related Issues

Closes #1301

### Changes

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

The `How to Contribute` page contained three stale `mahout.apache.org` targets (all `404`) on every published variant (`/docs/`, `/docs/next/`, `/docs/0.4/`):

| Link text | Old target |
|---|---|
| `guide for making website updates` | `http://mahout.apache.org/documentation/developers/how-to-update-the-website.html` |
| `wide variety of books and slides` | `http://mahout.apache.org/general/books-tutorials-and-talks.html` |
| `Handling GitHub PRs` | `http://mahout.apache.org/documentation/developers/github` |

Reviewer @viiccwen also surfaced (a) several `../community/...` and `../qdp/...` relative links in source `/docs/` that render as `404` on the built Docusaurus site, and (b) another stale `http://people.apache.org/~hossman/#private_q` `404` on the v0.4 page.

**Root cause for the relative-link bug:** `website/docusaurus.config.ts` doesn't set `trailingSlash`, so Docusaurus serves URLs with a trailing slash. Browser resolution of `../community/mailing-lists` from `/docs/next/about/how-to-contribute/` lands at `/docs/next/about/community/mailing-lists` (404). The proper Docusaurus fix is to write `[label](../community/mailing-lists.md)` so Docusaurus does version-aware static resolution at build time — but `website/scripts/sync-docs.js` was stripping the `.md` extension before Docusaurus saw the file, defeating that resolution. The pattern was introduced by #948 (`5901b9ab1`, *docs: use relative links in docs*) and bit several files.

### How

- `website/scripts/sync-docs.js` — stop stripping `.md` from internal links in `transformLinks()`; let Docusaurus do its own version-aware resolution.
- `docs/about/how-to-contribute.md` — switch `../community/mailing-lists` and `../community/pr-policy-and-review-guidelines` to `.md` extensions on lines 15, 85, 144. Drop the `guide for making website updates` sentence and `[2]` reference: `website/README.md` is never published to `mahout.apache.org` (lives outside `/docs/`, not in the Docusaurus sidebar), so per #1301 the sentence is removed rather than relinked.
- `docs/qumat/index.md`, `docs/qumat/getting-started.md` — same `../...` → `../....md` fix (lines 24/25/26 and 75) for the same latent bug.
- `Handling GitHub PRs` → repointed to `docs/community/pr-policy-and-review-guidelines.md`. The `next` doc uses a `.md`-suffixed Docusaurus-relative link; v0.4 and v0.5 use the absolute GitHub URL because that doc was added after those snapshots.
- `wide variety of books and slides` — sentence removed on all 3 routes (no equivalent page exists).
- `website/versioned_docs/version-0.4/about/how-to-contribute.md` — replace the stale `http://people.apache.org/~hossman/#private_q` (404) with `https://www.apache.org/theapacheway/` (already used in `next`/v0.5).
- `lychee.toml` — drop the `./docs/about/how-to-contribute.md` exclusion now that the file is clean.

Fix is applied consistently across all three affected routes:
- `docs/about/how-to-contribute.md` (current / `next`)
- `website/versioned_docs/version-0.5/about/how-to-contribute.md`
- `website/versioned_docs/version-0.4/about/how-to-contribute.md`

### Verification

**Docusaurus build (`cd website && npm ci && npm run build`):** succeeds; **no broken-link warnings on the previously broken paths**. Inspecting the built HTML for `/docs/next/about/how-to-contribute/index.html`:

- `href=` on the *Mahout mailing lists* link is now `/docs/next/community/mailing-lists` (was `/docs/next/about/community/mailing-lists` → 404).
- `href=` on the *PR policy and review guidelines* link is now `/docs/next/community/pr-policy-and-review-guidelines` (was `/docs/next/about/community/pr-policy-and-review-guidelines` → 404).
- The `guide for making website updates` text is no longer present in any rendered page.

**lychee (lychee 0.24.2 --config lychee.toml .):** `95 → 94` total errors. The single removed error is the v0.4 `hossman` 404. No new errors introduced. Remaining errors (KaTeX font references, root-relative `/docs/...` paths in `v0.4/download/quickstart`, etc.) all pre-date this PR.

**lychee (lychee --config lychee.toml docs/about/how-to-contribute.md):**
```
🔍 14 Total ✅ 14 OK 🚫 0 Errors
```

**pre-commit:** `end-of-file-fixer` and `trailing-whitespace` pass on the changed files. (Environment-only `cargo clippy` / `cargo fmt` / `ty` hooks were skipped — no Rust or Python files modified.)

## Checklist

- [x] Added or updated unit tests for all changes (N/A — docs/script change, manual build + lychee verification)
- [x] Added or updated documentation for all changes