### PR TITLE
docs: fix broken blog link to the quantum computing primer (#1300)

### DIFF
--- a/docs/blog/2025-01-24-Meeting-Minutes.md
+++ b/docs/blog/2025-01-24-Meeting-Minutes.md
@@ -39,4 +39,4 @@ authors: [mahout-team]
 ### New Business
 * [#470 Add Qumat to PyPi](https://github.com/apache/mahout/issues/470)
 * Slides for FOSDEM
-* [New quantum computing primer](https://mahout.apache.org/quantum-computing-primer) on web site
+* [New quantum computing primer](https://mahout.apache.org/docs/learning/quantum-computing-primer/) on web site

--- a/docs/blog/2025-02-14-Meeting-Minutes.md
+++ b/docs/blog/2025-02-14-Meeting-Minutes.md
@@ -36,7 +36,7 @@ authors: [mahout-team]
 * [#478 Post-processing](https://github.com/apache/mahout/issues/478)
 * [#475 Add open in colab button to Optimization Example](https://github.com/apache/mahout/issues/475) (to Andrew)
 * [#474 Add angle definitions to Optimization Example](https://github.com/apache/mahout/issues/474)
-* [New quantum computing primer](https://mahout.apache.org/quantum-computing-primer) on web site
+* [New quantum computing primer](https://mahout.apache.org/docs/learning/quantum-computing-primer/) on web site
 
 ### New Business
 * [#470 Add Qumat to PyPi](https://github.com/apache/mahout/issues/470)

--- a/docs/blog/2025-03-13-Meeting-Minutes.md
+++ b/docs/blog/2025-03-13-Meeting-Minutes.md
@@ -36,7 +36,7 @@ authors: [mahout-team]
 * [#478 Post-processing](https://github.com/apache/mahout/issues/478)
 * [#475 Add open in colab button to Optimization Example](https://github.com/apache/mahout/issues/475) (to Andrew)
 * [#474 Add angle definitions to Optimization Example](https://github.com/apache/mahout/issues/474)
-* [New quantum computing primer](https://mahout.apache.org/quantum-computing-primer) on web site
+* [New quantum computing primer](https://mahout.apache.org/docs/learning/quantum-computing-primer/) on web site
 
 ### New Business
 * Word back from PyPi about qumat ownership, they are going to contact the owner of the current package  [#470 Add Qumat to PyPi](https://github.com/apache/mahout/issues/470)


### PR DESCRIPTION
## What

Fix the broken `New quantum computing primer` link surfaced from `https://mahout.apache.org/blog/` (issue #1300). The link points at `https://mahout.apache.org/quantum-computing-primer`, which now returns `404 Not Found`. The primer was moved into the docs structure and is currently published at `https://mahout.apache.org/docs/learning/quantum-computing-primer/` (live, returns `200 OK`).

The same broken target appears in three meeting-minutes blog entries that all show up under `/blog/`:

- `docs/blog/2025-01-24-Meeting-Minutes.md`
- `docs/blog/2025-02-14-Meeting-Minutes.md`
- `docs/blog/2025-03-13-Meeting-Minutes.md`

## Why

This is a user-facing broken internal link on the public Mahout site. Readers browsing the blog index get sent to a dead page instead of the intended primer.

## How

Replace the stale URL with the current published location in each affected file:

``````
- https://mahout.apache.org/quantum-computing-primer
+ https://mahout.apache.org/docs/learning/quantum-computing-primer/
``````

(Source page exists at `docs/learning/quantum-computing-primer/index.md`.) The link text and surrounding bullet are unchanged.

## Verification

Reproduced and verified locally with `lychee 0.24.2`.

**Before:**

``````
$ lychee docs/blog/2025-01-24-Meeting-Minutes.md docs/blog/2025-02-14-Meeting-Minutes.md docs/blog/2025-03-13-Meeting-Minutes.md
[404] https://mahout.apache.org/quantum-computing-primer (at 42:3)
[404] https://mahout.apache.org/quantum-computing-primer (at 39:3)
[404] https://mahout.apache.org/quantum-computing-primer (at 39:3)
🔍 54 Total ✅ 48 OK 🚫 3 Errors
``````

**After:**

``````
$ lychee docs/blog/2025-01-24-Meeting-Minutes.md docs/blog/2025-02-14-Meeting-Minutes.md docs/blog/2025-03-13-Meeting-Minutes.md
🔍 54 Total ✅ 51 OK 🚫 0 Errors
``````

`HEAD https://mahout.apache.org/docs/learning/quantum-computing-primer/` returns `HTTP/1.1 200 OK`. Pre-commit (`end-of-file-fixer`, `trailing-whitespace`) passes on the changed files.

> Note: `docs/blog/` is in `lychee.toml`'s `exclude_path`, so this isn't caught by CI link-checking, but the link is rendered to the live site at `/blog/` and is user-visible.

Closes #1300
