### PR TITLE
feat(qdp): add Backend enum for compute-target classification

### DIFF
--- a/qdp/qdp-core/src/lib.rs
+++ b/qdp/qdp-core/src/lib.rs
@@ -38,7 +38,7 @@ mod profiling;
 pub use error::{MahoutError, Result, cuda_error_to_string};
 pub use gpu::memory::Precision;
 pub use reader::{NullHandling, handle_float64_nulls};
-pub use types::{Dtype, Encoding};
+pub use types::{Backend, Dtype, Encoding};
 
 // Throughput/latency pipeline runner: single path using QdpEngine and encode_batch in Rust.
 #[cfg(target_os = "linux")]

--- a/qdp/qdp-core/src/types.rs
+++ b/qdp/qdp-core/src/types.rs
@@ -158,3 +158,99 @@ impl Encoding {
         }
     }
 }
+
+/// Compute backend used for the Rust-side encoding pipeline.
+///
+/// Today this is a thin, 1-D classification used by callers (Python bindings,
+/// benchmarks, future planning layers) to ask "what compute target is the
+/// Rust pipeline running against?". It is intentionally **not** plumbed through
+/// [`crate::pipeline_runner::PipelineConfig`] as a dispatch axis: there is
+/// currently only one Rust-side encoder implementation (CUDA / nvcc), so a 2-D
+/// `(Encoding, Backend) → &'static dyn QuantumEncoder` table would have nothing
+/// extra to dispatch to.
+///
+/// The AMD / Triton path that exists upstream (`qumat_qdp/backends/amd.py`,
+/// added in #1158) lives entirely on the Python side. It does not have a
+/// matching Rust-level [`crate::QuantumEncoder`] implementation, so it is
+/// **not** modelled here as a `Backend` variant. When (and if) a Rust-AMD
+/// path is proposed, add the variant and grow the dispatch table at the same
+/// time — not before.
+///
+/// `TorchRef` represents the pure-PyTorch reference implementations
+/// (`torch_ref.py`, added in #1189) used by CI machines without a CUDA GPU.
+/// It is included so callers can distinguish "running on CUDA" from "running
+/// the pure-PyTorch fallback" without sniffing the engine state.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum Backend {
+    /// NVIDIA CUDA via the in-tree CUDA kernels (the historical default).
+    CudaNvidia,
+    /// Pure-PyTorch reference implementation for CPU / non-CUDA CI lanes.
+    TorchRef,
+}
+
+impl Backend {
+    /// Stable lower-case name suitable for logging and user-facing error messages.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::CudaNvidia => "cuda-nvidia",
+            Self::TorchRef => "torch-ref",
+        }
+    }
+
+    /// Parse a backend name (case-insensitive, ASCII).
+    ///
+    /// Accepts the canonical names returned by [`as_str`](Self::as_str) plus a few
+    /// convenience aliases (`cuda`, `nvidia`, `torch`, `cpu`). Unknown names that
+    /// resemble unsupported backends (notably `amd` / `triton`) get a dedicated
+    /// error message pointing to the Python-side AMD path so users don't think
+    /// the Rust core silently ignores them.
+    pub fn from_str_ci(s: &str) -> Result<Self> {
+        let t = s.trim();
+        if t.eq_ignore_ascii_case("cuda-nvidia")
+            || t.eq_ignore_ascii_case("cuda")
+            || t.eq_ignore_ascii_case("nvidia")
+        {
+            Ok(Self::CudaNvidia)
+        } else if t.eq_ignore_ascii_case("torch-ref")
+            || t.eq_ignore_ascii_case("torch")
+            || t.eq_ignore_ascii_case("torchref")
+            || t.eq_ignore_ascii_case("cpu")
+        {
+            Ok(Self::TorchRef)
+        } else if t.eq_ignore_ascii_case("amd")
+            || t.eq_ignore_ascii_case("triton")
+            || t.eq_ignore_ascii_case("triton-amd")
+        {
+            Err(MahoutError::InvalidInput(
+                "AMD / Triton backend is not selectable from the Rust core; use the \
+                 Python-side `qumat_qdp.backends.amd` path instead. The Rust `Backend` \
+                 enum will gain an `AMD` variant once a Rust-side AMD encoder lands."
+                    .to_string(),
+            ))
+        } else {
+            Err(MahoutError::InvalidInput(format!(
+                "Unknown backend: {s}. Available: cuda-nvidia (alias: cuda), torch-ref (alias: torch, cpu)."
+            )))
+        }
+    }
+
+    /// Best-guess backend for the current build / host.
+    ///
+    /// Returns [`Backend::CudaNvidia`] on Linux (the platform that compiles the
+    /// CUDA kernels) and [`Backend::TorchRef`] elsewhere. This does **not** probe
+    /// for a working CUDA runtime — it is a compile-time classification, not a
+    /// runtime capability check. Use [`QdpEngine::new`](crate::QdpEngine::new) to
+    /// fail with a clear error when a CUDA device is unavailable at runtime.
+    #[must_use]
+    pub fn detect() -> Self {
+        #[cfg(target_os = "linux")]
+        {
+            Self::CudaNvidia
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            Self::TorchRef
+        }
+    }
+}

--- a/qdp/qdp-core/tests/types.rs
+++ b/qdp/qdp-core/tests/types.rs
@@ -16,7 +16,7 @@
 
 //! Tests for [`qdp_core::Encoding`] and [`qdp_core::Dtype`].
 
-use qdp_core::{Dtype, Encoding};
+use qdp_core::{Backend, Dtype, Encoding};
 
 #[test]
 fn encoding_case_insensitive() {
@@ -72,4 +72,73 @@ fn dtype_from_str_ci() {
     assert_eq!(Dtype::from_str_ci("f32").unwrap(), Dtype::Float32);
     assert_eq!(Dtype::from_str_ci("Float64").unwrap(), Dtype::Float64);
     assert!(Dtype::from_str_ci("bf16").is_err());
+}
+
+// ---- `Backend` enum (PR 1.5) ----
+
+#[test]
+fn backend_case_insensitive_and_aliases() {
+    // Canonical names.
+    assert_eq!(
+        Backend::from_str_ci("cuda-nvidia").unwrap(),
+        Backend::CudaNvidia
+    );
+    assert_eq!(
+        Backend::from_str_ci("torch-ref").unwrap(),
+        Backend::TorchRef
+    );
+    // Aliases.
+    assert_eq!(Backend::from_str_ci("cuda").unwrap(), Backend::CudaNvidia);
+    assert_eq!(Backend::from_str_ci("nvidia").unwrap(), Backend::CudaNvidia);
+    assert_eq!(Backend::from_str_ci("CUDA").unwrap(), Backend::CudaNvidia);
+    assert_eq!(Backend::from_str_ci("torch").unwrap(), Backend::TorchRef);
+    assert_eq!(Backend::from_str_ci("torchref").unwrap(), Backend::TorchRef);
+    assert_eq!(Backend::from_str_ci("cpu").unwrap(), Backend::TorchRef);
+    // Whitespace tolerance.
+    assert_eq!(
+        Backend::from_str_ci("  cuda  ").unwrap(),
+        Backend::CudaNvidia
+    );
+}
+
+#[test]
+fn backend_amd_rejected_with_helpful_message() {
+    // AMD/Triton is the Python-side backend (#1158); the Rust core must reject
+    // it explicitly so users don't think the Rust path silently ignored the flag.
+    for name in ["amd", "AMD", "triton", "Triton", "triton-amd"] {
+        let err = Backend::from_str_ci(name)
+            .expect_err(&format!("backend '{}' should be rejected", name))
+            .to_string();
+        assert!(
+            err.contains("AMD") && err.contains("Python"),
+            "error for '{}' must mention AMD + the Python path, got: {}",
+            name,
+            err
+        );
+    }
+}
+
+#[test]
+fn backend_unknown_rejected() {
+    assert!(Backend::from_str_ci("metal").is_err());
+    assert!(Backend::from_str_ci("opencl").is_err());
+}
+
+#[test]
+fn backend_as_str_roundtrips() {
+    assert_eq!(Backend::CudaNvidia.as_str(), "cuda-nvidia");
+    assert_eq!(Backend::TorchRef.as_str(), "torch-ref");
+    // Round-trip through `as_str` -> `from_str_ci` for every variant.
+    for b in [Backend::CudaNvidia, Backend::TorchRef] {
+        assert_eq!(Backend::from_str_ci(b.as_str()).unwrap(), b);
+    }
+}
+
+#[test]
+fn backend_detect_is_platform_appropriate() {
+    let b = Backend::detect();
+    #[cfg(target_os = "linux")]
+    assert_eq!(b, Backend::CudaNvidia);
+    #[cfg(not(target_os = "linux"))]
+    assert_eq!(b, Backend::TorchRef);
 }


### PR DESCRIPTION
### Related Issues

<!-- Closes #123 -->

### Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [ ] Documentation
- [x] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

Callers (Python bindings, benchmarks, future planning layers) currently have no first-class way to ask "what compute target is the Rust pipeline running against?". They either sniff engine state or rely on string-based feature detection.

This adds a small `Backend` enum so that question has a typed answer.

It is **not** a dispatch axis: there is currently only one Rust-side encoder implementation (CUDA / nvcc), so a 2-D `(Encoding, Backend) -> &'static dyn QuantumEncoder` table would have nothing extra to dispatch to. The AMD / Triton path that already exists lives entirely on the Python side (`qumat_qdp/backends/amd.py`) and does not have a matching Rust-level `QuantumEncoder` implementation — so it is **not** modelled here as a variant. Grow the enum and the dispatch table at the same time when a Rust-side AMD path is proposed, not before.

### How

**Variants** (`qdp-core/src/types.rs`)

- `CudaNvidia` — in-tree CUDA kernels (the historical default)
- `TorchRef`   — pure-PyTorch reference, used by CPU / non-CUDA CI lanes

**API**

- `Backend::as_str()`      — stable lower-case name for logging (`"cuda-nvidia"` / `"torch-ref"`)
- `Backend::from_str_ci()` — case-insensitive parse with convenience aliases (`cuda` / `nvidia` map to `CudaNvidia`; `torch` / `torchref` / `cpu` map to `TorchRef`). Names that look like AMD (`amd`, `triton`, `triton-amd`) get a dedicated error message pointing at the Python-side path so users don't think the Rust core silently dropped the flag.
- `Backend::detect()`      — compile-time best guess (Linux → `CudaNvidia`, else `TorchRef`). Does **not** probe runtime CUDA availability; that remains the engine's responsibility.

`Backend` is re-exported from `qdp_core::` next to `Encoding` / `Dtype` so callers can `use qdp_core::Backend;`.

**Tests** (`qdp-core/tests/types.rs`) — 5 new

- case-insensitive parse + aliases + whitespace tolerance
- AMD names rejected with a message mentioning both "AMD" and "Python"
- unknown names rejected
- `as_str` round-trips through `from_str_ci` for every variant
- `detect()` returns the platform-appropriate variant

### Local verification

- `cargo test --tests` on `qdp-core`: all passing (11 type tests including the 5 new ones)
- Clippy / fmt / license-header: clean
- No call sites touched — this is a new public type, not a dispatch change

## Checklist

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
