### PR TITLE
fix(qdp): drop invalid PyPI classifiers from qumat-qdp

### DIFF
--- a/qdp/qdp-python/pyproject.toml
+++ b/qdp/qdp-python/pyproject.toml
@@ -25,9 +25,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Software Development :: Libraries :: Python Modules",
-    "Framework :: PyTorch",
-    "Framework :: TensorFlow",
-
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
## Summary

- Remove `Framework :: PyTorch` and `Framework :: TensorFlow` from `qdp/qdp-python/pyproject.toml`. Neither is in PyPI's official trove of valid classifiers, so PyPI/TestPyPI rejects every `qumat-qdp` upload with HTTP 400 (`'Framework :: PyTorch' is not a valid classifier`).
- Discovered while uploading the 0.6.0rc1 release candidate to TestPyPI; this fix unblocks the RC pipeline.
- Verified the remaining classifiers in both `pyproject.toml` (qumat) and `qdp/qdp-python/pyproject.toml` (qumat-qdp) against PyPI's live trove (891 entries) — 0 invalid after this change.

## Test plan

- [ ] CI green
- [ ] After merge, rebuild qumat-qdp wheels + sdist on `v0.6-stable` and confirm `twine upload --repository testpypi` succeeds for `qumat_qdp-*`