### PR TITLE
test(qdp_python): match actual ValueError from QuantumDataLoader.backend()

### DIFF
--- a/testing/qdp_python/test_fallback.py
+++ b/testing/qdp_python/test_fallback.py
@@ -273,7 +273,10 @@ class TestLoaderPytorchBackend:
     def test_invalid_backend_raises(self):
         from qumat_qdp.loader import QuantumDataLoader
 
-        with pytest.raises(ValueError, match="'rust', 'pytorch', or 'auto'"):
+        with pytest.raises(
+            ValueError,
+            match=r"backend must be one of \['auto', 'pytorch', 'rust'\], got 'invalid'",
+        ):
             QuantumDataLoader(device_id=0).backend("invalid")
 
 


### PR DESCRIPTION
## Summary

- `testing/qdp_python/test_fallback.py::TestLoaderPytorchBackend::test_invalid_backend_raises` was asserting an older error message format (`'rust', 'pytorch', or 'auto'`). The current implementation in `qdp/qdp-python/qumat_qdp/loader.py:355` raises `backend must be one of ['auto', 'pytorch', 'rust'], got 'invalid'` instead, so the test was failing whenever it actually ran the assertion path.
- Update the regex to match the current sorted-list format. Functional behavior is unchanged; this is purely a stale-test fix.

## How it slipped through

The drift is between two validation paths in the package: `qumat_qdp/api.py:128` still raises the older `'rust' or 'pytorch'` form, while `qumat_qdp/loader.py:355` raises the newer sorted-set form. The test happens to exercise the loader path, which had been refactored without the test being updated.

## Test plan

- [ ] CI green
- [x] Verified locally against the `qumat-qdp 0.2.0rc1` wheel installed from TestPyPI: this single test now passes