### PR TITLE
fix(qdp): guard batch size multiplication against overflow

### DIFF
--- a/qdp/qdp-core/src/gpu/encodings/amplitude.rs
+++ b/qdp/qdp-core/src/gpu/encodings/amplitude.rs
@@ -482,12 +482,18 @@ impl QuantumEncoder for AmplitudeEncoder {
                 sample_size, state_len, num_qubits
             )));
         }
-        if batch_data.len() != num_samples * sample_size {
+        let expected_len = num_samples.checked_mul(sample_size).ok_or_else(|| {
+            MahoutError::InvalidInput(format!(
+                "Batch size overflow: num_samples {} * sample_size {}",
+                num_samples, sample_size
+            ))
+        })?;
+        if batch_data.len() != expected_len {
             return Err(MahoutError::InvalidInput(format!(
                 "batch_data length mismatch (expected {} * {} = {}, got {})",
                 num_samples,
                 sample_size,
-                num_samples * sample_size,
+                expected_len,
                 batch_data.len()
             )));
         }

--- a/qdp/qdp-core/src/preprocessing.rs
+++ b/qdp/qdp-core/src/preprocessing.rs
@@ -98,7 +98,13 @@ impl Preprocessor {
             ));
         }
 
-        if batch_data.len() != num_samples * sample_size {
+        let expected_len = num_samples.checked_mul(sample_size).ok_or_else(|| {
+            MahoutError::InvalidInput(format!(
+                "Batch size overflow: num_samples {} * sample_size {}",
+                num_samples, sample_size
+            ))
+        })?;
+        if batch_data.len() != expected_len {
             return Err(MahoutError::InvalidInput(format!(
                 "Batch data length {} doesn't match num_samples {} * sample_size {}",
                 batch_data.len(),
@@ -158,5 +164,27 @@ impl Preprocessor {
                 Ok(norm)
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validate_batch_rejects_size_overflow() {
+        let data = [0.0_f64; 4];
+        let err = Preprocessor::validate_batch(&data, usize::MAX, 2, 1)
+            .expect_err("expected overflow error");
+        match err {
+            MahoutError::InvalidInput(msg) => {
+                assert!(
+                    msg.contains("overflow"),
+                    "unexpected error message: {}",
+                    msg
+                );
+            }
+            other => panic!("expected InvalidInput, got {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
## Summary

- `Preprocessor::validate_batch` and `AmplitudeEncoder::encode_batch_f32` computed `num_samples * sample_size` without overflow checks. The angle encoder paths already use `checked_mul` (angle.rs:87, :143, :327, :405, :528) — these two sites were missed.
- On 64-bit hosts the product can wrap, letting an undersized buffer pass the length check and causing out-of-bounds reads downstream in the encoder.
- This PR mirrors the angle.rs pattern: `checked_mul` returning `MahoutError::InvalidInput` on overflow.

## Changes

- `qdp/qdp-core/src/preprocessing.rs`: guard `num_samples * sample_size` in `validate_batch`.
- `qdp/qdp-core/src/gpu/encodings/amplitude.rs`: guard the same multiplication in `encode_batch_f32` (the f64 path already routes through `Preprocessor::validate_batch`).
- Added a unit test in `preprocessing.rs` covering the overflow path.

## Test plan

- [x] `cargo test --manifest-path qdp/qdp-core/Cargo.toml --lib` — 77 passed, 0 failed
- [x] pre-commit (clippy, rustfmt, license headers) — all pass
- [x] New test `validate_batch_rejects_size_overflow` exercises the `checked_mul` failure branch