### PR TITLE
chore: bump versions to 0.7.0.dev0 / 0.3.0-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
 
 [project]
 name = "qumat"
-version = "0.6.0"
+version = "0.7.0.dev0"
 description = "A library for composing quantum machine learning."
 authors = [{ name = "Apache Mahout", email = "dev@mahout.apache.org" }]
 license = "Apache-2.0"

--- a/qdp/Cargo.lock
+++ b/qdp/Cargo.lock
@@ -2144,7 +2144,7 @@ dependencies = [
 
 [[package]]
 name = "qdp-core"
-version = "0.2.0"
+version = "0.3.0-dev"
 dependencies = [
  "approx",
  "arrow",
@@ -2171,7 +2171,7 @@ dependencies = [
 
 [[package]]
 name = "qdp-kernels"
-version = "0.2.0"
+version = "0.3.0-dev"
 dependencies = [
  "cc",
  "cudarc",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "qdp-python"
-version = "0.2.0"
+version = "0.3.0-dev"
 dependencies = [
  "env_logger",
  "numpy",

--- a/qdp/Cargo.toml
+++ b/qdp/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0-dev"
 edition = "2024"
 rust-version = "1.85"
 authors = ["Apache Mahout Contributors"]

--- a/uv.lock
+++ b/uv.lock
@@ -2015,7 +2015,7 @@ wheels = [
 
 [[package]]
 name = "qumat"
-version = "0.6.0"
+version = "0.7.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "amazon-braket-sdk" },


### PR DESCRIPTION
## Summary

Post-release version bump on `main` following the 0.6.0 / 0.2.0 release.

- `qumat`: `0.6.0` → `0.7.0.dev0`
- `qumat-qdp`: `0.2.0` → `0.3.0-dev`
- Regenerates `qdp/Cargo.lock` and updates the `qumat` entry in `uv.lock` accordingly.

## Why `.dev0` / `-dev`?

PEP 440 / Cargo semver ordering: `0.7.0.dev0` < `0.7.0rc1` < `0.7.0`. Keeping `main` at a development pre-release lets the next RC tag (`0.7.0rc1`) sort above main builds without introducing a version regression.

## Test plan

- [ ] CI passes (build + tests + ruff + ty)
- [ ] No unintended lockfile churn beyond the workspace package version