### PR TITLE
fix(qdp): add dtype support to QdpBenchmark; default f64

### DIFF
--- a/qdp/qdp-python/qumat_qdp/api.py
+++ b/qdp/qdp-python/qumat_qdp/api.py
@@ -100,6 +100,7 @@ class QdpBenchmark:
         self._batch_size: int = 64
         self._warmup_batches: int = 0
         self._backend_name: str = "rust"
+        self._dtype: str = "f64"
 
     def qubits(self, n: int) -> QdpBenchmark:
         """Set the number of qubits for benchmarked encodings.
@@ -151,6 +152,18 @@ class QdpBenchmark:
         self._backend_name = name
         return self
 
+    def dtype(self, dtype: str) -> QdpBenchmark:
+        """Set pipeline element dtype: ``'f64'`` (default) or ``'f32'``.
+
+        ``'f32'`` activates the zero-copy float32 batch path where the encoding
+        supports it; encodings without an f32 kernel automatically fall back to
+        f64 inside the Rust pipeline.
+        """
+        if dtype not in ("f32", "f64"):
+            raise ValueError(f"dtype must be 'f32' or 'f64', got {dtype!r}")
+        self._dtype = dtype
+        return self
+
     def _validate(self) -> None:
         if self._num_qubits is None or self._total_batches is None:
             raise ValueError(
@@ -183,7 +196,7 @@ class QdpBenchmark:
             encoding_method=self._encoding_method,
             warmup_batches=self._warmup_batches,
             seed=None,
-            dtype="f32",
+            dtype=self._dtype,
         )
         return ThroughputResult(
             duration_sec=duration_sec, vectors_per_sec=vectors_per_sec
@@ -199,7 +212,7 @@ class QdpBenchmark:
             encoding_method=self._encoding_method,
             warmup_batches=self._warmup_batches,
             seed=None,
-            dtype="f32",
+            dtype=self._dtype,
         )
         return LatencyResult(
             duration_sec=duration_sec,


### PR DESCRIPTION
## Problem

`QdpBenchmark.run_latency()` and `run_throughput()` raised `TypeError` on any call because `api.py` was unconditionally passing `dtype="f32"` to `run_throughput_pipeline_py()` — but `QdpBenchmark` had no `_dtype` field and no `.dtype()` builder method. The Rust binding already accepted `dtype` (defaulting to `"f64"`) but the Python layer never wired it up.

## Changes

- Add `_dtype: str = "f64"` to `QdpBenchmark.__init__`
- Add `.dtype("f32" | "f64")` builder method with validation
  - `"f32"` activates the zero-copy float32 batch path where the encoding supports it; encodings without an f32 kernel fall back to f64 inside the Rust pipeline automatically
  - `"f64"` is the default, matching the Rust binding default and the PyTorch reference path
- Pass `dtype=self._dtype` to both Rust call sites (`_run_throughput_rust`, `_run_latency_rust`)

## Test

```python
from qumat_qdp import QdpBenchmark
for dt in ("f64", "f32"):
    r = QdpBenchmark(device_id=0).qubits(4).encoding("amplitude").batches(4, size=8).warmup(1).dtype(dt).run_latency()
    print(f"dtype={dt}: {r.latency_ms_per_vector:.3f} ms/vector")
# dtype=f64: 0.019 ms/vector
# dtype=f32: 0.013 ms/vector
```