### PR TITLE
fix(examples): correct backend_name in quantum_teleportation.py

### DIFF
--- a/examples/qumat/quantum_teleportation.py
+++ b/examples/qumat/quantum_teleportation.py
@@ -19,7 +19,7 @@ from qumat import QuMat
 
 # Initialize your QuMat quantum computer with the chosen backend
 backend_config = {
-    "backend_name": "qiskit_simulator",
+    "backend_name": "qiskit",
     "backend_options": {
         "simulator_type": "qasm_simulator",
         "shots": 1,  # Set to 1 for teleportation


### PR DESCRIPTION
## Summary

- `examples/qumat/quantum_teleportation.py:22` used `"qiskit_simulator"` which is not a registered Qumat backend module, causing an immediate `ModuleNotFoundError` when running the example.
- Changed to `"qiskit"`, the valid backend name used by `simple_example.py` and documented in `QuMat.__init__`.

Fixes #1317.

## Test plan

- [ ] `python examples/qumat/quantum_teleportation.py` runs without `ModuleNotFoundError`
- [ ] CI green