### PR TITLE
ci: pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -7,7 +7,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: github/issue-labeler@v3.4
+      - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/labeler.yml

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       issues: write # required for Broken Links Report
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Link Checker
         id: lychee
@@ -27,7 +27,7 @@ jobs:
 
       - name: Broken Links Report
         if: steps.lychee.outputs.exit_code != 0 && github.event_name == 'schedule'
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/notebook-testing.yml
+++ b/.github/workflows/notebook-testing.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python with uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           python-version: "3.12"
           enable-cache: true

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -30,10 +30,10 @@ jobs:
         python-version: ["3.10"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -46,10 +46,10 @@ jobs:
     # during the slower maturin build below.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Cargo check (no-CUDA stubs)
         working-directory: qdp
@@ -65,10 +65,10 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -29,10 +29,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -31,12 +31,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -30,9 +30,9 @@ jobs:
   build-qumat:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
 
@@ -41,7 +41,7 @@ jobs:
           pip install uv
           uv build
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: qumat
           path: dist/*
@@ -54,7 +54,7 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -83,7 +83,7 @@ jobs:
             fi
           sccache: true
 
-      - uses: actions/upload-artifact@v5
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: qumat-qdp-cp${{ matrix.python-version }}
           path: qdp/qdp-python/dist/*.whl


### PR DESCRIPTION
## Summary

- Pins all third-party GitHub Actions to their full 40-character commit SHA per [ASF GitHub Actions Policy](https://infra.apache.org/github-actions-policy.html), resolving #1368
- `actions/*` and `github/*` are exempt from the allowlist check but are pinned anyway for supply-chain security
- All pinned SHAs verified against the [Apache infrastructure-actions allowlist](https://github.com/apache/infrastructure-actions/blob/main/approved_patterns.yml)
- `PyO3/maturin-action` kept at `@v1` tag (approved via `@*` wildcard with no expiry — no SHA required)

| Action | Pinned to |
|---|---|
| `actions/checkout` | `de0fac2e` (v6) |
| `actions/github-script` | `ed597411` (v8) |
| `actions/setup-python` | `a309ff8b` (v6) |
| `actions/setup-node` | `49933ea5` (v4) |
| `actions/upload-artifact` | `330a01c4` (v5) |
| `github/issue-labeler` | `c1b0f9f5` (v3.4) |
| `astral-sh/setup-uv` | `08807647` (v8.1.0) |
| `dtolnay/rust-toolchain` | `29eef336` (stable) |
| `lycheeverse/lychee-action` | already pinned |

## Test plan

- [x] Verify all CI workflows pass on this PR