### PR TITLE
Add QuMat neutrosophic foundation docs

### DIFF
--- a/docs/academic/implementation-to-citation-map.md
+++ b/docs/academic/implementation-to-citation-map.md
@@ -1,0 +1,75 @@
+---
+title: Implementation to Citation Map
+sidebar_label: Implementation to Citation Map
+---
+
+# Implementation to Citation Map
+
+Status: phase-1 citation gate  
+Related issue: [apache/mahout#1372](https://github.com/apache/mahout/issues/1372)
+
+## Rule
+
+Every planned implementation should be in one of three states:
+
+1. `source-backed`
+2. `local design extension`
+3. `unsupported`
+
+Anything still marked `unsupported` should not be presented as if it were ready for implementation.
+
+## Mapping
+
+### NeutroBit carrier over `|0>`, `|1>`, `|I>`
+
+- Status: `source-backed`
+- Primary source:
+  - `Neutrosophic Logic Based Quantum Computing`
+
+### Neutrosophic `W` gate
+
+- Status: `source-backed`
+- Primary source:
+  - `Neutrosophic Logic Based Quantum Computing`
+
+### Neutrosophic `X/Y/Z` family
+
+- Status: `source-backed`
+- Primary source:
+  - `Neutrosophic Logic Based Quantum Computing`
+- Note:
+  - software class shape remains an implementation choice
+
+### Neutrosophic Hadamard
+
+- Status: `source-backed`
+- Primary source:
+  - `Neutrosophic Logic Based Quantum Computing`
+
+### `NeutroGate` software abstraction
+
+- Status: `local design extension`
+- Grounding:
+  - justified by QuMat's gate-oriented API
+- Note:
+  - this is a software abstraction, not a paper-defined class contract
+
+### Projection and comparison harness
+
+- Status: `local design extension`
+- Grounding:
+  - needed to compare a `3`-state reference model against current QuMat qubit semantics
+
+### Direct execution on `qiskit` / `cirq` / `amazon_braket` as neutrobit backends
+
+- Status: `unsupported`
+- Reason:
+  - current repo and current published sources do not justify claiming native `3`-state execution on existing QuMat backends
+
+### Kernel-method bridge into Mahout
+
+- Status: `local design extension`
+- Grounding:
+  - `MAHOUT-2200` confirms kernel-method direction exists
+- Missing:
+  - exact technical bridge remains unproven and should be treated as tentative, not oversold

--- a/docs/academic/neutrosophic-operator-layer-bibliography.md
+++ b/docs/academic/neutrosophic-operator-layer-bibliography.md
@@ -1,0 +1,104 @@
+---
+title: Neutrosophic Operator Layer Bibliography
+sidebar_label: Neutrosophic Bibliography
+---
+
+# Neutrosophic Operator Layer Bibliography
+
+Status: phase-1 foundation bibliography  
+Related issue: [apache/mahout#1372](https://github.com/apache/mahout/issues/1372)
+
+## Source Selection Rules
+
+Use this precedence:
+
+1. primary papers and journal pages
+2. official project documentation
+3. maintainer-owned issue trackers and talks
+
+This document is intentionally public-safe. It does not rely on unpublished local manuscripts.
+
+## Primary Neutrosophic Sources
+
+### Direct operator and carrier foundation
+
+- Florentin Smarandache et al.  
+  **Neutrosophic Logic Based Quantum Computing**  
+  <https://fs.unm.edu/neut/NeutrosophicLogicBasedQuantum.pdf>
+
+Use in this case:
+
+- neutrobit carrier concept
+- neutrosophic `W`
+- neutrosophic Pauli-style operators
+- neutrosophic Hadamard direction
+
+### Structural neutrosophic foundation
+
+- Florentin Smarandache  
+  **(t, i, f)-Neutrosophic Structures & I-Neutrosophic Structures (Revisited)**  
+  <https://fs.unm.edu/nss8/index.php/111/article/view/484>
+
+Use in this case:
+
+- indeterminacy-bearing structures
+- separation between carrier structure and binary-state assumptions
+
+### Quantum-facing indeterminacy foundation
+
+- Florentin Smarandache  
+  **Neutrosophic Quantum Theory: Partial Entanglement, Partial Effect of the Observer, and Teleportation**  
+  <https://fs.unm.edu/nss8/index.php/111/article/view/6355>
+
+Use in this case:
+
+- quantum-facing indeterminacy language
+- observer and partial-state framing
+
+### Geometry and fractal bridge
+
+- Erick Gonzalez-Caballero, Maikel Y. Leyva-Vazquez, Noel Batista-Hernandez, Florentin Smarandache  
+  **NeutroGeometry and Fractal Geometry**  
+  <https://fs.unm.edu/nss8/index.php/111/article/view/4836>
+
+Use in this case:
+
+- geometric irregularity as a carrier discussion
+- fractal relevance for multi-scale indeterminacy
+
+### Measurement foundation
+
+- Florentin Smarandache  
+  **Neutrosophic Measure and Neutrosophic Integral**  
+  <https://fs.unm.edu/nss8/index.php/111/article/view/3893>
+
+Use in this case:
+
+- explicit measurement rules
+- distinction between indeterminacy and ad hoc scoring
+
+## Official Mahout and QuMat Context
+
+- Apache Mahout  
+  **QuMat**  
+  <https://mahout.apache.org/qumat/>
+
+- Apache Mahout  
+  **Getting Started with QuMat**  
+  <https://mahout.apache.org/docs/qumat/getting-started/>
+
+- Apache JIRA  
+  **MAHOUT-2200 Quantum Kernel Methods research spike**  
+  <https://issues.apache.org/jira/browse/MAHOUT-2200>
+
+- FOSSY 2024  
+  **QuMat: Apache Mahout's Quantum Computing Interface**  
+  <https://2024.fossy.us/schedule/presentation/265/>
+
+## Exclusion Rule
+
+Do not mark an implementation claim as academically grounded if the source provides only:
+
+- general philosophy without operator relevance
+- project marketing without technical surface
+- private or unpublished design intent

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,11 @@ anywhere.'
 - [Parameterized Quantum Circuits: Developer's Guide](./advanced/pqc) - In-depth guide to PQCs
 - [Qumat Gap Analysis for PQC](./advanced/gap-analysis) - Analysis of PQC capabilities
 
+### Research and RFC Notes
+- [Experimental Neutrosophic Operator Layer for QuMat](./rfcs/experimental-neutrosophic-operator-layer) - Phase-1 RFC for a conservative experimental operator-extension discussion
+- [Neutrosophic Operator Layer Bibliography](./academic/neutrosophic-operator-layer-bibliography) - Published sources used to ground the RFC
+- [Implementation to Citation Map](./academic/implementation-to-citation-map) - Citation gate for distinguishing source-backed items from local design extensions
+
 ### Qumat Components
 - [Qumat (Circuits)](./qumat) - Quantum circuit abstraction layer
 - [QDP (Quantum Data Plane)](./qdp) - GPU-accelerated data encoding

--- a/docs/rfcs/experimental-neutrosophic-operator-layer.md
+++ b/docs/rfcs/experimental-neutrosophic-operator-layer.md
@@ -1,0 +1,152 @@
+---
+title: Experimental Neutrosophic Operator Layer for QuMat
+sidebar_label: Experimental Neutrosophic Operator Layer
+---
+
+# RFC: Experimental Neutrosophic Operator Layer for QuMat
+
+Status: phase-1 foundation draft  
+Related issue: [apache/mahout#1372](https://github.com/apache/mahout/issues/1372)
+
+## Context and Motivation
+
+QuMat already provides a meaningful operator surface for standard quantum-circuit work:
+
+- unified circuit construction
+- standard gate application
+- backend dispatch across `qiskit`, `cirq`, and `amazon_braket`
+- public-facing positioning as Mahout's quantum-computing layer
+
+At the same time, some research directions require a state carrier that is not reducible to a standard qubit. A conservative first step is to treat that need as a reference-model problem, not a backend-rewrite problem.
+
+The immediate goal is therefore modest:
+
+- define a narrow experimental direction
+- keep it separate from production backend semantics
+- anchor it in published sources before any broader implementation claims are made
+
+## Problem Statement
+
+Current QuMat supports standard qubit-oriented gates and backend execution, but it does not provide:
+
+- a non-binary state carrier for indeterminacy-bearing operators
+- an experimental namespace for non-standard operator families
+- a structured comparison surface between standard qubit execution and a richer reference-state model
+
+Without that, the following cannot be explored in a disciplined way:
+
+- neutrobit semantics
+- neutrosophic `W/X/Y/Z/H` gates over a `3x3` carrier
+- comparison studies that preserve the distinction between:
+  - qubit-compatible subspace behavior
+  - genuinely `3`-state neutrosophic behavior
+
+## Proposed Direction
+
+The first increment should remain conservative and local-first.
+
+Suggested shape:
+
+- a `NeutroBit` reference carrier over `|0>`, `|1>`, and `|I>`
+- a `NeutroGate` abstraction for named `3x3` operators
+- a first operator family:
+  - `W`
+  - `X`
+  - `Y`
+  - `Z`
+  - `H`
+- local normalization and measurement utilities
+- a projection and comparison harness against standard QuMat qubit circuits where comparison is mathematically valid
+
+The first goal is observability and reference semantics, not backend replacement.
+
+## Why QuMat Is a Good Candidate
+
+QuMat is a reasonable host for this discussion because it already has:
+
+- a unified operator-facing API
+- documented standard gate semantics
+- explicit backend modularity
+- a live kernel-method direction under `MAHOUT-2200`
+
+The fit is real at the level of:
+
+- experimental operator abstraction
+- comparison harnesses
+- future data-encoding and kernel-method bridges
+- non-breaking extension points
+
+The fit is not yet direct at the level of:
+
+- native `3`-state execution on existing QuMat backends
+- immediate upstream implementation
+- claims that Mahout already supports neutrosophic carriers
+
+## Academic and Technical Foundation
+
+The direct source pack for this direction is documented in:
+
+- [Neutrosophic operator-layer bibliography](../academic/neutrosophic-operator-layer-bibliography.md)
+- [Implementation-to-citation map](../academic/implementation-to-citation-map.md)
+
+Those documents define what is:
+
+- source-backed
+- local design extension
+- unsupported
+
+## Proposed Phased Implementation
+
+### Phase 1 - Reference kernel
+
+Define a local reference-state kernel with:
+
+- carrier semantics
+- operator semantics
+- normalization rules
+- deterministic tests
+
+### Phase 2 - Gate family
+
+Add the first experimental operator family:
+
+- `W`
+- `X`
+- `Y`
+- `Z`
+- `H`
+
+### Phase 3 - Comparison harness
+
+Add a constrained comparison surface between:
+
+- standard QuMat qubit execution
+- projected behavior from the experimental reference carrier
+
+### Phase 4 - Kernel and data-encoding fit analysis
+
+Only after the reference layer is stable, evaluate whether the direction can connect conservatively to Mahout's kernel-method and data-encoding work.
+
+## Explicit Constraints
+
+This RFC does not propose:
+
+- rewriting QuMat backend modules in the first pass
+- changing current production backend semantics
+- claiming native neutrobit execution on `qiskit`, `cirq`, or `amazon_braket`
+- replacing Mahout's current architecture with a new theory-first model
+
+## Open Questions
+
+1. Should a future public proposal stay strictly at the operator-abstraction level?
+2. Should the first comparison harness stay basis-state only?
+3. If kernel-method work becomes the strongest fit, should the operator layer remain purely experimental while only the encoding bridge is discussed publicly?
+
+## Maintainer-Safe Ask
+
+Would QuMat accept a narrowly scoped experimental operator-extension discussion that is:
+
+- explicitly separate from production backend semantics
+- local-reference-first
+- comparison-oriented before implementation-oriented
+- grounded in published academic sources


### PR DESCRIPTION
## Summary
- add the phase-1 documentation foundation for an experimental neutrosophic operator layer in QuMat
- ground the proposal in published sources and official Mahout context
- add a citation gate so future implementation slices stay explicit about what is source-backed, what is a local design extension, and what is still unsupported
- link the RFC pack from the QuMat docs index so the discussion has a stable public entrypoint

## Details
This PR is the single public Phase 1 anchor for the experimental neutrosophic discussion tied to [apache/mahout#1372](https://github.com/apache/mahout/issues/1372).

Its scope is intentionally documentation-only. It does not change QuMat runtime behavior, backend dispatch, or production circuit semantics. Its purpose is to make the discussion reviewable in public while the implementation branches remain protected on the case-study side.

This branch adds:
- an RFC for a conservative experimental neutrosophic operator-layer discussion
- an academic bibliography restricted to published sources and official Mahout context
- an implementation-to-citation map that separates source-backed items from local design extensions
- docs index links so the RFC pack is reachable from the QuMat docs surface

Current implementation posture:
- this PR is the only upstream PR in scope
- the RFC issue remains the only upstream discussion thread: https://github.com/apache/mahout/issues/1372
- the six engineering branches are protected on the local case-study repo side:
  - https://github.com/SeCuReDmE-main-dev/Apache_Mahoot_case_study/tree/docs/mahout-neutro-case-foundation
  - https://github.com/SeCuReDmE-main-dev/Apache_Mahoot_case_study/tree/feature/qumat-neutrobit-reference-kernel
  - https://github.com/SeCuReDmE-main-dev/Apache_Mahoot_case_study/tree/feature/qumat-neutro-gates-wxyz-h
  - https://github.com/SeCuReDmE-main-dev/Apache_Mahoot_case_study/tree/feature/qumat-fractal-carrier-df-df-ifractal
  - https://github.com/SeCuReDmE-main-dev/Apache_Mahoot_case_study/tree/feature/qumat-projection-comparison-harness
  - https://github.com/SeCuReDmE-main-dev/Apache_Mahoot_case_study/tree/docs/mahout-rfc-neutro-layer

Conservative constraints for the public Mahout surface:
- no production backend rewrite in the first pass
- no public API break for current QuMat users
- no claim that `qiskit`, `cirq`, or `amazon_braket` natively execute a 3-state neutrosophic carrier
- no additional upstream implementation PRs unless maintainers indicate interest in that direction

## Validation
- reviewed rendered-style link targets and relative doc paths
- verified the docs are linked from `docs/index.md`
- confirmed this branch changes documentation only and does not alter QuMat runtime behavior

## RFC
- refs apache/mahout#1372
