### PR TITLE
Add experimental neutrobit reference kernel

### DIFF
--- a/qumat/neutrosophic/__init__.py
+++ b/qumat/neutrosophic/__init__.py
@@ -13,9 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+"""Experimental local neutrosophic reference layer for QuMat."""
 
-from . import qdp
-from . import neutrosophic
-from .qumat import QuMat
+from .reference import NeutroBit
 
-__all__: list[str] = ["QuMat", "neutrosophic", "qdp"]
+__all__: list[str] = ["NeutroBit"]

--- a/qumat/neutrosophic/reference.py
+++ b/qumat/neutrosophic/reference.py
@@ -1,0 +1,72 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+
+def _as_complex_vector(state: Any) -> np.ndarray:
+    return np.asarray(state, dtype=complex).reshape(3)
+
+
+@dataclass(frozen=True)
+class NeutroBit:
+    """Three-state experimental carrier over |0>, |1>, and |I>."""
+
+    alpha: complex
+    beta: complex
+    gamma: complex
+
+    def vector(self) -> np.ndarray:
+        return np.array([self.alpha, self.beta, self.gamma], dtype=complex)
+
+    def norm_squared(self) -> float:
+        return float(np.sum(np.abs(self.vector()) ** 2).real)
+
+    def normalize(self) -> "NeutroBit":
+        norm = np.sqrt(self.norm_squared())
+        if np.isclose(norm, 0.0):
+            raise ValueError("Cannot normalize the zero neutrobit.")
+        normalized = self.vector() / norm
+        return NeutroBit(*normalized.tolist())
+
+    def measurement_probabilities(self) -> dict[str, float]:
+        normalized = self.normalize().vector()
+        probabilities = np.abs(normalized) ** 2
+        return {
+            "|0>": float(probabilities[0].real),
+            "|1>": float(probabilities[1].real),
+            "|I>": float(probabilities[2].real),
+        }
+
+    def project_to_qubit_subspace(self, normalize: bool = True) -> np.ndarray:
+        vector = self.vector()[:2].astype(complex)
+        if not normalize:
+            return vector
+        norm = np.sqrt(float(np.sum(np.abs(vector) ** 2).real))
+        if np.isclose(norm, 0.0):
+            raise ValueError("Cannot normalize an empty qubit projection.")
+        return vector / norm
+
+    @classmethod
+    def from_vector(cls, state: Any, normalize: bool = False) -> "NeutroBit":
+        vector = _as_complex_vector(state)
+        bit = cls(*vector.tolist())
+        return bit.normalize() if normalize else bit

--- a/testing/qumat/test_neutrobit_reference_kernel.py
+++ b/testing/qumat/test_neutrobit_reference_kernel.py
@@ -1,0 +1,49 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import numpy as np
+import pytest
+
+from qumat.neutrosophic import NeutroBit
+
+
+def test_neutrobit_normalization_and_measurement_sum_to_one():
+    bit = NeutroBit(1 + 0j, 1 + 0j, 1 + 0j).normalize()
+    probabilities = bit.measurement_probabilities()
+    assert pytest.approx(sum(probabilities.values())) == 1.0
+
+
+def test_zero_vector_normalization_is_rejected():
+    with pytest.raises(ValueError):
+        NeutroBit(0j, 0j, 0j).normalize()
+
+
+def test_projection_to_qubit_subspace_matches_expected_values():
+    bit = NeutroBit(1 / np.sqrt(2), 1 / np.sqrt(2), 0)
+    np.testing.assert_allclose(
+        bit.project_to_qubit_subspace(),
+        np.array([1 / np.sqrt(2), 1 / np.sqrt(2)], dtype=complex),
+    )
+
+
+def test_qubit_projection_rejects_empty_projection_when_normalized():
+    with pytest.raises(ValueError):
+        NeutroBit(0, 0, 1).project_to_qubit_subspace()
+
+
+def test_neutrobit_from_vector_accepts_normalized_construction():
+    bit = NeutroBit.from_vector([2, 0, 0], normalize=True)
+    np.testing.assert_allclose(bit.vector(), np.array([1, 0, 0], dtype=complex))


### PR DESCRIPTION
## Summary
- add an experimental backend-independent `NeutroBit` reference kernel under `qumat/neutrosophic`
- expose explicit three-state carrier normalization and qubit-subspace projection helpers
- add targeted kernel tests without changing production `QumatCircuit` behavior

## Details
This is branch 2 of the experimental neutrosophic series anchored by [apache/mahout#1372](https://github.com/apache/mahout/issues/1372) and the docs foundation PR [#1373](https://github.com/apache/mahout/pull/1373).

This PR keeps the scope intentionally narrow. It introduces only the reference-state carrier and related helpers:
- `NeutroBit` over `|0>`, `|1>`, and `|I>`
- explicit normalization for the local three-state carrier
- measurement-probability extraction over the carrier basis
- projection into the qubit subspace for compatibility checks when the indeterminacy amplitude is absent

What this branch does not do:
- it does not modify `QumatCircuit`
- it does not wire neutrosophic execution into `qiskit`, `cirq`, or `amazon_braket`
- it does not introduce the gate family yet
- it does not claim native 3-state backend support

This keeps phase 2 focused on a clean experimental kernel that later branches can build on while remaining separate from the production backend surface.

Series anchors:
- RFC issue: https://github.com/apache/mahout/issues/1372
- Branch 1 PR: https://github.com/apache/mahout/pull/1373
- Previous branch in series: https://github.com/apache/mahout/pull/1373

## Validation
- `pytest testing/qumat/test_neutrobit_reference_kernel.py -q`

## RFC
- refs apache/mahout#1372
- follows apache/mahout#1373
