### PR TITLE
ci(wheel-build): tighten and speed up wheel build workflow

### DIFF
--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -19,11 +19,28 @@ name: Wheel Build
 on:
   push:
     branches: [main]
+    paths:
+      - "qumat/**"
+      - "qdp/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/wheel-build.yml"
   pull_request:
+    paths:
+      - "qumat/**"
+      - "qdp/**"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/workflows/wheel-build.yml"
   workflow_dispatch:
 
 permissions:
   contents: read
+
+# Cancel superseded runs on PR updates; let main/dispatch runs finish.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   # Pure Python wheel (qumat)
@@ -41,18 +58,24 @@ jobs:
           pip install uv
           uv build
 
+      - name: Validate distributions
+        run: uvx twine check dist/*
+
+      - name: Smoke-test wheel
+        run: |
+          uv venv /tmp/qumat-smoke
+          VIRTUAL_ENV=/tmp/qumat-smoke uv pip install dist/*.whl
+          /tmp/qumat-smoke/bin/python -c "import qumat; print('qumat import OK')"
+
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
           name: qumat
           path: dist/*
 
-  # CUDA extension wheels (qumat-qdp) for each Python version
+  # CUDA extension wheels (qumat-qdp) for all supported Python versions.
+  # Built in one job so the CUDA toolkit is installed only once.
   build-qdp:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -61,29 +84,39 @@ jobs:
           working-directory: qdp/qdp-python
           command: build
           target: x86_64
-          args: --release --out dist --interpreter python${{ matrix.python-version }}
+          args: --release --out dist -i python3.10 -i python3.11 -i python3.12
           manylinux: 2_28
           before-script-linux: |
+            CUDA_VER=12.5
+            CUDA_PKG_VER=12-5
             # Install gcc 13 (CUDA 12.5 requires gcc <= 13)
             dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++
             export CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc
             export CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
-            # Try to install the CUDA 12.5 toolkit for kernel compilation.
-            # If the external NVIDIA repo is temporarily unavailable, fall back
-            # to a no-CUDA smoke build instead of failing the PR wheel job.
+            # Install the CUDA toolkit for kernel compilation. No fallback:
+            # a wheel that did not compile real CUDA kernels must never
+            # pass this job.
             dnf install -y 'dnf-command(config-manager)'
-            if dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo \
-              && dnf install -y cuda-nvcc-12-5 cuda-cudart-devel-12-5; then
-              export CUDA_PATH=/usr/local/cuda-12.5
-              export PATH=/usr/local/cuda-12.5/bin:$PATH
-              nvcc --version
-            else
-              echo "CUDA repo unavailable; continuing with QDP_NO_CUDA=1 smoke build."
-              export QDP_NO_CUDA=1
-            fi
+            dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
+            dnf install -y cuda-nvcc-${CUDA_PKG_VER} cuda-cudart-devel-${CUDA_PKG_VER}
+            export CUDA_PATH=/usr/local/cuda-${CUDA_VER}
+            export PATH=/usr/local/cuda-${CUDA_VER}/bin:$PATH
+            nvcc --version
           sccache: true
+
+      - name: Validate and smoke-test wheels
+        working-directory: qdp/qdp-python
+        run: |
+          pip install uv
+          uvx twine check dist/*.whl
+          for py in 3.10 3.11 3.12; do
+            tag="cp${py/./}"
+            uv venv --python "$py" "/tmp/qdp-smoke-$tag"
+            VIRTUAL_ENV="/tmp/qdp-smoke-$tag" uv pip install dist/*"$tag"*.whl
+            "/tmp/qdp-smoke-$tag/bin/python" -c "from qumat_qdp._backend import get_qdp; assert get_qdp() is not None, 'Rust extension failed to load'; print('$py: qumat_qdp import OK')"
+          done
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5
         with:
-          name: qumat-qdp-cp${{ matrix.python-version }}
+          name: qumat-qdp-wheels
           path: qdp/qdp-python/dist/*.whl

--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -24,6 +24,9 @@ on:
       - "qdp/**"
       - "pyproject.toml"
       - "uv.lock"
+      # README.md and LICENSE are packaged into the qumat distributions
+      - "README.md"
+      - "LICENSE"
       - ".github/workflows/wheel-build.yml"
   pull_request:
     paths:
@@ -31,6 +34,9 @@ on:
       - "qdp/**"
       - "pyproject.toml"
       - "uv.lock"
+      # README.md and LICENSE are packaged into the qumat distributions
+      - "README.md"
+      - "LICENSE"
       - ".github/workflows/wheel-build.yml"
   workflow_dispatch:
 
@@ -88,7 +94,7 @@ jobs:
           manylinux: 2_28
           before-script-linux: |
             CUDA_VER=12.5
-            CUDA_PKG_VER=12-5
+            CUDA_PKG_VER="${CUDA_VER//./-}"
             # Install gcc 13 (CUDA 12.5 requires gcc <= 13)
             dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++
             export CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc

--- a/.github/workflows/wheel-build.yml
+++ b/.github/workflows/wheel-build.yml
@@ -24,7 +24,6 @@ on:
       - "qdp/**"
       - "pyproject.toml"
       - "uv.lock"
-      # README.md and LICENSE are packaged into the qumat distributions
       - "README.md"
       - "LICENSE"
       - ".github/workflows/wheel-build.yml"
@@ -34,7 +33,6 @@ on:
       - "qdp/**"
       - "pyproject.toml"
       - "uv.lock"
-      # README.md and LICENSE are packaged into the qumat distributions
       - "README.md"
       - "LICENSE"
       - ".github/workflows/wheel-build.yml"
@@ -43,7 +41,6 @@ on:
 permissions:
   contents: read
 
-# Cancel superseded runs on PR updates; let main/dispatch runs finish.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
@@ -78,12 +75,18 @@ jobs:
           name: qumat
           path: dist/*
 
-  # CUDA extension wheels (qumat-qdp) for all supported Python versions.
-  # Built in one job so the CUDA toolkit is installed only once.
+  # CUDA extension wheels (qumat-qdp) for all supported Python versions
   build-qdp:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: |
+            3.10
+            3.11
+            3.12
 
       - uses: PyO3/maturin-action@v1
         with:
@@ -99,9 +102,7 @@ jobs:
             dnf install -y gcc-toolset-13-gcc gcc-toolset-13-gcc-c++
             export CC=/opt/rh/gcc-toolset-13/root/usr/bin/gcc
             export CXX=/opt/rh/gcc-toolset-13/root/usr/bin/g++
-            # Install the CUDA toolkit for kernel compilation. No fallback:
-            # a wheel that did not compile real CUDA kernels must never
-            # pass this job.
+            # Install the CUDA toolkit for kernel compilation (no fallback)
             dnf install -y 'dnf-command(config-manager)'
             dnf config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/rhel8/x86_64/cuda-rhel8.repo
             dnf install -y cuda-nvcc-${CUDA_PKG_VER} cuda-cudart-devel-${CUDA_PKG_VER}


### PR DESCRIPTION
## What

Improvements to the `wheel-build.yml` workflow:

- **`paths` filters** on `push`/`pull_request`: wheel builds only run when `qumat/**`, `qdp/**`, `pyproject.toml`, `uv.lock`, or the workflow itself changes. Website/docs-only PRs no longer trigger the expensive CUDA build. (`.asf.yaml` defines no required status checks, so skipped runs don't block PRs.)
- **`concurrency` group**: pushing new commits to a PR cancels the superseded run; `main`/`workflow_dispatch` runs are never cancelled.
- **Single build job instead of a 3-version matrix**: one maturin invocation builds all three interpreters (`-i python3.10 -i python3.11 -i python3.12`, same as the release workflow), so the CUDA toolkit and gcc-toolset are installed once instead of three times.
- **Removed the silent `QDP_NO_CUDA` fallback**: previously, if the NVIDIA repo install failed, CI built a no-CUDA smoke wheel and uploaded it under the same artifact name with a green check. Now the job fails instead — green always means real kernels were compiled. Inspection of all recent runs with retained logs showed the fallback path has never actually fired; the CUDA repo install succeeds consistently.
- **Artifact validation before upload**:
  - `twine check` on all distributions in both jobs
  - `import qumat` smoke test for the pure-Python wheel
  - each `qumat-qdp` wheel is installed into a matching per-version venv and the test asserts the Rust extension actually loads (`get_qdp() is not None`), guarding against the graceful-degradation path in `qumat_qdp/_backend.py` masking a broken extension. This is safe on GPU-less runners because cudarc loads CUDA libraries lazily at runtime.
- **CUDA version defined once** at the top of the build script instead of hard-coded in five places.

## Notes

- The qdp artifact is now a single `qumat-qdp-wheels` artifact containing all three wheels, instead of three `qumat-qdp-cpX.Y` artifacts.
- `release.yml` is intentionally untouched.