### PR TITLE
perf(qdp): inline norm calculation in phase kernel loop for 5% speedup

### DIFF
--- a/qdp/qdp-kernels/src/phase.cu
+++ b/qdp/qdp-kernels/src/phase.cu
@@ -53,13 +53,15 @@ __global__ void phase_encode_kernel(
 
     // φ(idx) = Σ_k phases[k] * b_k,  b_k = (idx >> k) & 1
     double phi = 0.0;
+    double norm = 1.0 ;
     for (unsigned int bit = 0; bit < num_qubits; ++bit) {
         if ((idx >> bit) & 1U) {
             phi += phases[bit];
         }
+        
+        norm *= M_SQRT1_2;
     }
 
-    double norm = phase_norm(num_qubits);
     double re, im;
     sincos(phi, &im, &re);   // re = cos(φ), im = sin(φ)
 

--- a/qdp/qdp-kernels/src/phase.cu
+++ b/qdp/qdp-kernels/src/phase.cu
@@ -58,7 +58,6 @@ __global__ void phase_encode_kernel(
         if ((idx >> bit) & 1U) {
             phi += phases[bit];
         }
-        
         norm *= M_SQRT1_2;
     }
 

--- a/qdp/qdp-kernels/src/phase.cu
+++ b/qdp/qdp-kernels/src/phase.cu
@@ -53,7 +53,7 @@ __global__ void phase_encode_kernel(
 
     // φ(idx) = Σ_k phases[k] * b_k,  b_k = (idx >> k) & 1
     double phi = 0.0;
-    double norm = 1.0 ;
+    double norm = 1.0;
     for (unsigned int bit = 0; bit < num_qubits; ++bit) {
         if ((idx >> bit) & 1U) {
             phi += phases[bit];


### PR DESCRIPTION
### Related Issues

Relates to #1227

### Changes

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

This PR aims to strengthen the CUDA kernel implementation of `phase.cu` by optimizing the norm calculation.

Through PTX analysis and empirical benchmarks, I found that combining the norm multiplication into the existing loop yields a better performance improvement than using `pow()` or solely focusing on branch divergence.

### How

#### Optimization Details & Insights:   norm Calculation Optimization (The Real Winner 🚀)
- **Hypothesis**: Using `pow(M_SQRT1_2, num_qubits)` via SFU would speed up the normalization factor.
- **Benchmark Reality**: `pow()` actually introduced overhead and slowed down the execution.
- **The Better Solution**: Embedding the norm scaling `(norm *= M_SQRT1_2;)` directly into the loop alongside the phase accumulation achieved the best results. This allows the compiler to pipelining the instructions effectively.

#### Benchmark Results

- **Environment**: RunPod GPU instance (CUDA 12.8, NVVM 7.0.1)
- **Configuration**: Grid size: 2048, Block size: 512

| Implementation | Execution Time (ms) | Speedup |
| :--- | :--- | :--- |
| **Original** | 0.4434 ms | Baseline |
| **Inline Norm in Loop (This PR)** | **0.3995 ms** | **~5% Performance Gain** |

## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes