### PR TITLE
[Feature] Generate Python API docs from module discovery

### DIFF
--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -38,6 +38,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: website/package-lock.json
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
       - name: Install dependencies
         working-directory: website
         run: npm ci

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -42,6 +42,9 @@ jobs:
           cache: 'npm'
           cache-dependency-path: website/package-lock.json
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+
       - name: Install dependencies
         working-directory: website
         run: npm ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ This document describes **repository-wide** setup and workflow. For **subproject
 - [Quick Start](#quick-start)
 - [Development Workflow](#development-workflow)
 - [Testing](#testing)
+- [API Documentation](#api-documentation)
 - [Project-Specific Guides](#project-specific-guides)
 - [Troubleshooting](#troubleshooting)
 - [References](#references)
@@ -130,6 +131,19 @@ You can also run subsets from the repo root:
 | `make test_python` | Python tests via pytest and pytest-cov (syncs dev deps; builds QDP extension if GPU present, then runs full suite). HTML report: `htmlcov/index.html` at repo root. |
 
 See [testing/README.md](testing/README.md) for more options and details.
+
+---
+
+## API Documentation
+
+API reference documentation is generated from source code. To update the Python API reference content, edit the relevant Python docstrings. Use `docs/api/` only for generation settings, page metadata, or other API documentation structure changes. The generated pages are written under `website/docs/api/` for the Docusaurus site.
+
+**Preview documentation locally:**
+
+```bash
+cd website
+npm run start
+```
 
 ---
 

--- a/docs/api/qumat_qdp.yml
+++ b/docs/api/qumat_qdp.yml
@@ -25,22 +25,14 @@ loaders:
       - qumat_qdp.loader
       - qumat_qdp.triton_amd
 
-# TODO: Trim this filter once the Python package exposes a cleaner public
-# surface for documentation generation.
+# Generated QDP docs intentionally load implementation modules so pydoc-markdown
+# can render full class and method details. Source docstrings define the public
+# reference surface: documented public objects are rendered, undocumented fields
+# and internal helpers are omitted.
 processors:
   - type: filter
-    documented_only: false
+    documented_only: true
     skip_empty_modules: true
-    expression: >-
-      (not name.startswith('_') or name == '__init__')
-      and name not in (
-        'annotations', 'Mapping', 'import_module', 'ModuleType', 'Any',
-        'dataclass', 'time', 'math', 'os', 'sys', 'warnings', 'Iterator',
-        'TYPE_CHECKING', 'CudaBackendEngine', 'AmdBackendEngine', 'lru_cache',
-        'enum', 'field', 'torch_mod', 'triton_mod', 'triton_lang', 'get_qdp',
-        'get_torch', 'get_backend', 'require_backend'
-      )
-      and default()
   - type: smart
 
 renderer:
@@ -50,11 +42,9 @@ renderer:
   add_module_prefix: false
   add_method_class_prefix: false
   render_toc: false
+  render_module_header: false
   header_level_by_type:
-    Module: 2
     Class: 3
     Function: 3
     Variable: 3
     Method: 4
-  render_module_header_template: |
-    ## {module_name}

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -41,7 +41,7 @@ const config: Config = {
       'classic',
       {
         docs: {
-          path: '../docs/',
+          path: './docs/',
           sidebarPath: './sidebars.ts',
           editUrl: 'https://github.com/apache/mahout/tree/main/docs/',
           remarkPlugins: [remarkMath],

--- a/website/scripts/sync-docs.js
+++ b/website/scripts/sync-docs.js
@@ -217,8 +217,6 @@ function runCommand(command, args, options = {}) {
  * Generate Python API reference docs with pydoc-markdown.
  */
 function generateApiDocs() {
-  console.log('\nGenerating Python API reference...');
-
   fs.rmSync(API_DEST_DIR, { recursive: true, force: true });
   ensureDir(API_DEST_DIR);
 
@@ -315,6 +313,7 @@ function main() {
   console.log('\nSyncing blog posts from /docs/blog...');
   const blogStats = syncDirectory(BLOG_SOURCE_DIR, BLOG_DEST_DIR);
 
+  console.log('\nGenerating Python API reference...');
   generateApiDocs();
 
   console.log(`\nSync complete!`);

--- a/website/scripts/sync-docs.js
+++ b/website/scripts/sync-docs.js
@@ -16,12 +16,16 @@
 
 const fs = require('fs');
 const path = require('path');
+const { execFileSync } = require('child_process');
 
 // Configuration
+const REPO_ROOT = path.resolve(__dirname, '../..');
 const SOURCE_DIR = path.resolve(__dirname, '../../docs');
 const DEST_DIR = path.resolve(__dirname, '../docs');
 const BLOG_SOURCE_DIR = path.resolve(__dirname, '../../docs/blog');
 const BLOG_DEST_DIR = path.resolve(__dirname, '../blog');
+const API_SOURCE_DIR = path.resolve(__dirname, '../../docs/api');
+const API_DEST_DIR = path.resolve(__dirname, '../docs/api');
 
 // Files that should be preserved during sync (not deleted)
 const PRESERVE_FILES = ['.gitignore'];
@@ -33,6 +37,7 @@ const EXCLUDE_PATTERNS = [
   /\.pyc$/,
   /^__pycache__$/,
   /^blog$/, // Blog is synced separately to website/blog
+  /^api$/, // API generator config is rendered separately into website/docs/api
 ];
 
 /**
@@ -198,6 +203,56 @@ function copyFile(srcPath, destPath) {
 }
 
 /**
+ * Run a repository-level command and inherit stdio by default.
+ */
+function runCommand(command, args, options = {}) {
+  return execFileSync(command, args, {
+    cwd: REPO_ROOT,
+    stdio: options.capture ? 'pipe' : 'inherit',
+    encoding: options.capture ? 'utf-8' : undefined,
+  });
+}
+
+/**
+ * Generate Python API reference docs with pydoc-markdown.
+ */
+function generateApiDocs() {
+  console.log('\nGenerating Python API reference...');
+
+  fs.rmSync(API_DEST_DIR, { recursive: true, force: true });
+  ensureDir(API_DEST_DIR);
+
+  copyFile(path.join(API_SOURCE_DIR, 'index.md'), path.join(API_DEST_DIR, 'index.md'));
+
+  const pages = [
+    {
+      header: 'qumat_header.md',
+      config: 'qumat.yml',
+      output: 'qumat.md',
+    },
+    {
+      header: 'qumat_qdp_header.md',
+      config: 'qumat_qdp.yml',
+      output: 'qumat_qdp.md',
+    },
+  ];
+
+  runCommand('uv', ['sync', '--group', 'dev']);
+
+  for (const page of pages) {
+    const outputPath = path.join(API_DEST_DIR, page.output);
+    copyFile(path.join(API_SOURCE_DIR, page.header), outputPath);
+
+    const generated = runCommand(
+      'uv',
+      ['run', '--group', 'dev', 'pydoc-markdown', path.join('docs/api', page.config)],
+      { capture: true },
+    );
+    fs.appendFileSync(outputPath, generated);
+  }
+}
+
+/**
  * Recursively sync a directory
  */
 function syncDirectory(srcDir, destDir, stats = { files: 0, dirs: 0 }) {
@@ -259,6 +314,8 @@ function main() {
 
   console.log('\nSyncing blog posts from /docs/blog...');
   const blogStats = syncDirectory(BLOG_SOURCE_DIR, BLOG_DEST_DIR);
+
+  generateApiDocs();
 
   console.log(`\nSync complete!`);
   console.log(`  Docs: ${docsStats.files} files, ${docsStats.dirs} directories`);

--- a/website/scripts/sync-docs.js
+++ b/website/scripts/sync-docs.js
@@ -237,7 +237,7 @@ function generateApiDocs() {
     },
   ];
 
-  runCommand('uv', ['sync', '--group', 'dev']);
+  runCommand('uv', ['sync', '--frozen', '--group', 'dev']);
 
   for (const page of pages) {
     const outputPath = path.join(API_DEST_DIR, page.output);
@@ -245,7 +245,7 @@ function generateApiDocs() {
 
     const generated = runCommand(
       'uv',
-      ['run', '--group', 'dev', 'pydoc-markdown', path.join('docs/api', page.config)],
+      ['run', '--frozen', '--group', 'dev', 'pydoc-markdown', path.join('docs/api', page.config)],
       { capture: true },
     );
     fs.appendFileSync(outputPath, generated);

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -58,6 +58,16 @@ const sidebars: SidebarsConfig = {
     },
     {
       type: 'category',
+      label: 'API Reference (experiments)',
+      collapsed: true,
+      link: {type: 'doc', id: 'api/index'},
+      items: [
+        'api/qumat',
+        'api/qumat_qdp',
+      ],
+    },
+    {
+      type: 'category',
       label: 'Quantum Computing Primer',
       collapsed: true,
       link: {type: 'doc', id: 'learning/quantum-computing-primer/index'},


### PR DESCRIPTION
### Related Issues

Closes #1347
previous PR #1381 (merge first)

### Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

The Python API reference should be generated from the agreed public module surface instead of maintaining pydoc-markdown module lists by hand. Manual lists can drift from the current `qumat` and `qumat_qdp` source tree, while a deterministic generation path makes the website API docs easier to refresh and review as the Python packages evolve.

This keeps `/docs/api` as the source for API documentation generation settings and metadata, while publishing the rendered API pages through the Docusaurus website docs tree.

### How

- Update the website docs sync script so it skips copying raw `docs/api` generator config directly and instead renders API pages into `website/docs/api`.
- Add the Python API generation step to `website/scripts/sync-docs.js`, including the `qumat` and `qumat_qdp` pydoc-markdown configs.
- Switch the Docusaurus docs source to `website/docs` so the generated API pages are included with the synced website docs.
- Add an experimental API Reference sidebar section for the generated `qumat` and `qumat_qdp` pages.
- Document the local website preview command in `CONTRIBUTING.md`.

### Screenshot

<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/a1e8ab5a-6b32-4d03-b7fd-847ad387dced" />


<img width="1920" height="959" alt="image" src="https://github.com/user-attachments/assets/fc1aca9d-6be4-4b59-95de-8d51c5f02685" />


## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
