### PR TITLE
[Docs] Add source docstrings for QDP constructor and alias API entries

### DIFF
--- a/qdp/qdp-python/qumat_qdp/backend.py
+++ b/qdp/qdp-python/qumat_qdp/backend.py
@@ -93,6 +93,14 @@ class QdpEngine:
         precision: str = "float32",
         backend: str = "cuda",
     ) -> None:
+        """Create a backend-selecting QDP engine facade.
+
+        :param device_id: GPU device ordinal to use.
+        :param precision: Numeric precision requested from the backend.
+        :param backend: Backend selector, either ``"cuda"``, ``"amd"``, or
+            ``"triton_amd"``.
+        :raises ValueError: If ``backend`` is not supported.
+        """
         self.device_id = device_id
         self.precision = precision
         self.backend, self._engine_adapter = _select_engine_adapter(

--- a/qdp/qdp-python/qumat_qdp/loader.py
+++ b/qdp/qdp-python/qumat_qdp/loader.py
@@ -271,6 +271,16 @@ class QuantumDataLoader:
         encoding_method: str = "amplitude",
         seed: int | None = None,
     ) -> None:
+        """Create a loader builder with default synthetic batching settings.
+
+        :param device_id: GPU device ordinal used by native and PyTorch backends.
+        :param num_qubits: Number of qubits in each encoded output state.
+        :param batch_size: Number of samples per emitted batch.
+        :param total_batches: Maximum number of batches to emit.
+        :param encoding_method: Encoding method name.
+        :param seed: Optional synthetic data seed.
+        :raises ValueError: If any initial setting is invalid.
+        """
         _validate_loader_args(
             device_id=device_id,
             num_qubits=num_qubits,

--- a/qdp/qdp-python/qumat_qdp/tensor.py
+++ b/qdp/qdp-python/qumat_qdp/tensor.py
@@ -85,4 +85,5 @@ class QdpTensor:
         return torch.from_dlpack(self)
 
 
+#: Backward-compatible alias for :class:`QdpTensor`.
 QuantumTensor = QdpTensor


### PR DESCRIPTION
### Related Issues

Closes #1348

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

QDP Python API reference content is generated from source docstrings. A few
public entries had no source-level documentation for constructor parameters or
alias intent, which left the generated API surface less clear than the source
code can support.

### How

Added focused source documentation for:

- `QdpEngine.__init__`, including constructor parameters and the unsupported
  backend error.
- `QuantumDataLoader.__init__`, including default batching settings and
  validation behavior.
- `QuantumTensor`, documenting it as a backward-compatible alias for
  `QdpTensor`.

## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
