### PR TITLE
[ci] Add stale PR workflow

### DIFF
--- a/.github/workflows/stale_pull_request.yml
+++ b/.github/workflows/stale_pull_request.yml
@@ -23,21 +23,20 @@ on:
 
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:
     if: github.repository == 'apache/mahout'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      issues: write
-      pull-requests: write
 
     steps:
       - name: Close Stale Pull Requests
         uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ github.token }}
 
           # Ignore issues.
           days-before-issue-stale: -1

--- a/.github/workflows/stale_pull_request.yml
+++ b/.github/workflows/stale_pull_request.yml
@@ -1,0 +1,73 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+name: Close Stale Pull Requests
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    if: github.repository == 'apache/mahout'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Close Stale Pull Requests
+        uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Ignore issues.
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Pull request stale policy.
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: stale
+          stale-pr-message: |
+            This pull request has been automatically marked as stale because it has not had any activity for 30 days.
+
+            It will be closed in another 7 days if no further activity occurs. Thank you for your contribution. If you'd like to keep this open, leave any comment and the stale label will be removed.
+
+            You can always ask for help on the [Mahout dev mailing list](https://lists.apache.org/list.html?dev@mahout.apache.org) or in [GitHub Discussions](https://github.com/apache/mahout/discussions).
+          close-pr-message: |
+            This pull request has been automatically closed because there has been no more activity in the 7 days since being marked stale.
+
+            Please feel free to reopen or open a new pull request if you'd still like this to be addressed. You can always ask for help on the [Mahout dev mailing list](https://lists.apache.org/list.html?dev@mahout.apache.org) or in [GitHub Discussions](https://github.com/apache/mahout/discussions).
+
+            Thanks again for your contribution!
+          exempt-pr-labels: >
+            weekly-release-blocker,
+            release-blocker,
+            security,
+            not-stale,
+            unstale
+          exempt-all-pr-milestones: true
+
+          # Shared stale action settings.
+          operations-per-run: 500
+          remove-pr-stale-when-updated: true
+          ascending: true


### PR DESCRIPTION
## Summary

Adds a scheduled GitHub Actions workflow that marks inactive pull requests as stale and closes them if they remain inactive.

## Behavior

- Runs daily at 01:30 UTC and can also be started manually.
- Ignores issues entirely.
- Marks pull requests stale after 30 days without activity.
- Closes stale pull requests after another 7 days without activity.
- Removes the stale label when a pull request is updated.
- Exempts release blockers, security PRs, `not-stale`, `unstale`, and all PRs with milestones.

## Context

This keeps the policy close to Apache Iceberg's 30-day stale / 7-day close timing while preserving Ray's PR-only stale-bot shape and Mahout-specific community links.

## Validation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/stale_pull_request.yml"); puts "YAML OK"'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/stale_pull_request.yml`

Note: `uv run pre-commit run check-yaml --files .github/workflows/stale_pull_request.yml` is currently blocked before hook execution by an existing `uv.lock` parse error (`missing field version`).
