### PR TITLE
[Bug][QDP] Align Iris GPU training path with sibling pipelines (real dtype + leaf weights)

### DIFF
--- a/qdp/qdp-python/benchmark/encoding_benchmarks/qdp_pipeline/iris_amplitude.py
+++ b/qdp/qdp-python/benchmark/encoding_benchmarks/qdp_pipeline/iris_amplitude.py
@@ -322,9 +322,12 @@ def _run_training_gpu(
 ) -> dict[str, Any]:
     """GPU path: lightning.gpu + PyTorch interface, data stays on GPU. Optional early stop every 100 steps."""
     device = encoded_train.device
-    dtype = encoded_train.dtype
-    Y_train_t = torch.tensor(Y_train, dtype=dtype, device=device)
-    Y_test_t = torch.tensor(Y_test, dtype=dtype, device=device)
+    # Encoded data may be complex (from QDP); use real dtype for weights, bias and labels.
+    real_dtype = (
+        torch.float64 if encoded_train.dtype == torch.complex128 else torch.float32
+    )
+    Y_train_t = torch.tensor(Y_train, dtype=real_dtype, device=device)
+    Y_test_t = torch.tensor(Y_test, dtype=real_dtype, device=device)
 
     @qml.qnode(dev_qml, interface="torch", diff_method="adjoint")
     def circuit(weights, state_vector):
@@ -342,9 +345,9 @@ def _run_training_gpu(
 
     torch.manual_seed(seed)
     weights = 0.01 * torch.randn(
-        num_layers, NUM_QUBITS, 3, device=device, dtype=dtype, requires_grad=True
+        num_layers, NUM_QUBITS, 3, device=device, dtype=real_dtype, requires_grad=True
     )
-    bias = torch.tensor(0.0, device=device, dtype=dtype, requires_grad=True)
+    bias = torch.tensor(0.0, device=device, dtype=real_dtype, requires_grad=True)
     opt = torch.optim.SGD([weights, bias], lr=lr, momentum=0.9, nesterov=True)
 
     t0 = time.perf_counter()

--- a/qdp/qdp-python/benchmark/encoding_benchmarks/qdp_pipeline/iris_amplitude.py
+++ b/qdp/qdp-python/benchmark/encoding_benchmarks/qdp_pipeline/iris_amplitude.py
@@ -344,8 +344,10 @@ def _run_training_gpu(
         return torch.mean((Y_batch - preds) ** 2)
 
     torch.manual_seed(seed)
-    weights = 0.01 * torch.randn(
-        num_layers, NUM_QUBITS, 3, device=device, dtype=real_dtype, requires_grad=True
+    weights = (
+        (0.01 * torch.randn(num_layers, NUM_QUBITS, 3, device=device, dtype=real_dtype))
+        .detach()
+        .requires_grad_(True)
     )
     bias = torch.tensor(0.0, device=device, dtype=real_dtype, requires_grad=True)
     opt = torch.optim.SGD([weights, bias], lr=lr, momentum=0.9, nesterov=True)


### PR DESCRIPTION
### Related Issues

Closes #1160

### Changes

- [x] Bug fix

### Why

The Iris amplitude-encoding GPU training path (`_run_training_gpu`) had
drifted from its sibling pipelines (`mnist_amplitude.py`, `svhn_iqp.py`)
in two ways, both of which break it:

1. **Complex dtype leaks into trainable params/labels (issue #1160).**
   `dtype = encoded_train.dtype` is `complex64`/`complex128` from the QDP
   amplitude encoding. That complex dtype was inherited by the weights
   (used as `qml.Rot` angles), the bias, and the ±1 labels — all of
   which must be real.

2. **Non-leaf weight tensor.** `weights = 0.01 * torch.randn(..., requires_grad=True)`
   is a non-leaf tensor (the multiply has a `grad_fn`), so
   `torch.optim.SGD` rejects it with `can't optimize a non-leaf Tensor`,
   crashing the path before training starts.

Both are already handled correctly in the sibling pipelines; Iris was
simply not aligned.

### How

Mirror the siblings:
- Derive a real dtype: `real_dtype = torch.float64 if encoded_train.dtype == torch.complex128 else torch.float32`, used for weights, bias and labels (encoded state vector stays complex for `StatePrep`).
- Initialise weights as a leaf: `(0.01 * torch.randn(...)).detach().requires_grad_(True)`.

Split into two commits so each fix can be reviewed independently.

### Verification

`qumat_qdp` / `lightning.gpu` / CUDA were not available in my environment,
so I exercised the real `_run_training_gpu` directly on CPU with
`default.qubit` and a synthetic **complex64** state-vector batch (stubbing
the unused `qumat_qdp` import). Before/after:

| | weights dtype | optimizer | training |
|---|---|---|---|
| before | `complex64` | rejects (non-leaf) | crashes |
| after  | `float32`   | accepts (leaf)     | runs 10 epochs, returns results |

Note: this confirms the **code path executes with correct real dtypes and
gradients flow**; it does not validate model accuracy (synthetic input, not
real QDP-encoded Iris). End-to-end accuracy validation still needs the
`qumat_qdp` extension + a CUDA/`lightning.gpu` stack.

## Checklist

- [ ] Added or updated unit tests for all changes
- [ ] Added or updated documentation for all changes

<sub>No automated tests exist for these benchmark pipelines (the GPU path needs CUDA + lightning.gpu); verified manually as described above.</sub>
