### PR TITLE
refactor(qdp): rename validate_tensor to validate_tensor_cpu and drop redundant check

### DIFF
--- a/qdp/qdp-python/src/engine.rs
+++ b/qdp/qdp-python/src/engine.rs
@@ -16,7 +16,7 @@
 
 use crate::pytorch::{
     extract_cuda_tensor_info, get_torch_cuda_stream_ptr, is_cuda_tensor, is_pytorch_tensor,
-    validate_cuda_tensor_for_encoding, validate_shape, validate_tensor,
+    validate_cuda_tensor_for_encoding, validate_shape, validate_tensor_cpu,
 };
 use crate::tensor::QuantumTensor;
 use numpy::{PyReadonlyArray1, PyReadonlyArray2, PyUntypedArrayMethods};
@@ -206,7 +206,7 @@ impl QdpEngine {
         }
 
         // CPU tensor path
-        validate_tensor(data)?;
+        validate_tensor_cpu(data)?;
         // PERF: Avoid Tensor -> Python list -> Vec deep copies.
         //
         // For CPU tensors, `tensor.detach().numpy()` returns a NumPy view that shares the same

--- a/qdp/qdp-python/src/pytorch.rs
+++ b/qdp/qdp-python/src/pytorch.rs
@@ -33,12 +33,12 @@ pub fn is_pytorch_tensor(obj: &Bound<'_, PyAny>) -> PyResult<bool> {
     Ok(module_name == "torch")
 }
 
-/// Helper to validate CPU tensor
-pub fn validate_tensor(tensor: &Bound<'_, PyAny>) -> PyResult<()> {
-    if !is_pytorch_tensor(tensor)? {
-        return Err(PyRuntimeError::new_err("Object is not a PyTorch Tensor"));
-    }
-
+/// Validate that a PyTorch tensor lives on the CPU.
+///
+/// The caller must have already confirmed `tensor` is a `torch.Tensor` (e.g.
+/// via [`is_pytorch_tensor`]). This function only checks device placement, so
+/// it also rejects non-CPU backends such as CUDA, MPS, XLA, and HPU.
+pub fn validate_tensor_cpu(tensor: &Bound<'_, PyAny>) -> PyResult<()> {
     let device = tensor.getattr("device")?;
     let device_type: String = device.getattr("type")?.extract()?;
 


### PR DESCRIPTION
### Related Issues

Closes #907

### Changes

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring
- [ ] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

Follow-up to the review thread on #881. `validate_tensor()` re-checked
`is_pytorch_tensor(tensor)` even though its **only** caller already
guarantees the object is a `torch.Tensor`:

- `validate_tensor` has a single call site: `QdpEngine::encode_from_pytorch`
  (`engine.rs:209`).
- `encode_from_pytorch` is only reached from the `encode()` dispatcher
  (`engine.rs:125`), and that branch is already gated by
  `is_pytorch_tensor(data)?` at `engine.rs:119`.

So the inner check was dead weight on the real execution path. The
function's actual job is validating *device placement* — the
`device.type != "cpu"` guard, which is what already rejects non-CPU
backends (CUDA/MPS/XLA/HPU). The old name `validate_tensor` didn't convey
that, hence the rename suggested in the issue.

### How

- Removed the redundant `is_pytorch_tensor` check (and its now-dead
  `"Object is not a PyTorch Tensor"` error arm) from the helper.
- Renamed `validate_tensor` → `validate_tensor_cpu`, with a doc comment
  stating the caller-side contract (caller has already confirmed it is a
  `torch.Tensor`) and that it rejects non-CPU backends.
- Updated the import and call site in `engine.rs`.

No behavior change on any supported path. Verified with
`cargo check` (`--cfg qdp_no_cuda`) and `cargo fmt --check`.

## Checklist

- [ ] Added or updated unit tests for all changes — N/A, behavior-preserving rename; existing tests still cover the CPU-tensor path
- [x] Added or updated documentation for all changes — doc comment on `validate_tensor_cpu`
