### PR TITLE
[QDP] validate website build for API docs changes

### DIFF
--- a/.github/workflows/website-build.yml
+++ b/.github/workflows/website-build.yml
@@ -22,7 +22,12 @@ on:
     paths:
       - 'website/**'
       - 'docs/**'
+      - 'qumat/**'
+      - 'qdp/qdp-python/qumat_qdp/**'
       - '.github/workflows/website-build.yml'
+
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
### Related Issues

Closes #1353

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] Test
- [x] CI/CD pipeline
- [ ] Other

### Why

The website build check already validates the Docusaurus build, and `npm run build` already generates the Python API docs through the website `prebuild` script. However, the workflow was only triggered by website/docs path changes, so Python API source changes that affect generated API documentation did not necessarily run the website validation check.

The API docs validation workflow should stay read-only and avoid deploy/write behavior.

### How

- Added Python API source paths to the existing website build check trigger:
  - `qumat/**`
  - `qdp/qdp-python/qumat_qdp/**`
- Set explicit `contents: read` permissions for the validation workflow.
- Kept the existing website build behavior unchanged; `npm run build` continues to generate API docs via `prebuild`.

## Checklist

- [x] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
