### PR TITLE
feat: add local docs versioning validation

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -175,15 +175,19 @@ served as `latest` at `/docs`; the editable current docs are served at `/docs/ne
 When releasing, snapshot the current docs:
 
 ```bash
-npm run docusaurus docs:version <release-version>
+npm run version -- <release-version>
 ```
 
 This creates:
 - `versioned_docs/version-<release-version>/` - Frozen snapshot
 - Updates `versions.json`
+- Validates the generated versioned docs with a production Docusaurus build
 
 `docusaurus.config.ts` reads `versions.json` automatically, so release updates
 should not require editing the Docusaurus version configuration.
+
+The command runs the documentation sync first, so generated Python API reference
+pages are included in the version snapshot before the local build validation.
 
 ## Blog Posts
 

--- a/website/package.json
+++ b/website/package.json
@@ -17,7 +17,7 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "typecheck": "tsc",
-    "version": "docusaurus docs:version"
+    "version": "node scripts/version-docs.js"
   },
   "dependencies": {
     "@docusaurus/core": "3.10.1",

--- a/website/scripts/version-docs.js
+++ b/website/scripts/version-docs.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { spawnSync } = require('child_process');
+
+function usage() {
+  console.error('Usage: npm run version -- <release-version>');
+  console.error('');
+  console.error('Example: npm run version -- 0.7');
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, {
+    cwd: process.cwd(),
+    stdio: 'inherit',
+    shell: process.platform === 'win32',
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    process.exit(result.status);
+  }
+}
+
+function main() {
+  const version = process.argv[2];
+
+  if (!version || version.startsWith('-')) {
+    usage();
+    process.exit(1);
+  }
+
+  console.log(`Preparing versioned docs for ${version}...`);
+  run('npm', ['run', 'sync']);
+  run('npm', ['run', 'docusaurus', '--', 'docs:version', version]);
+  run('npm', ['run', 'build']);
+}
+
+main();


### PR DESCRIPTION
### Related Issues

Closes #1355

### Changes

- [ ] Bug fix
- [x] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

The existing Docusaurus versioning command snapshots whatever is currently present under `website/docs/`. Generated Python API reference pages are produced by the website sync step, so release managers need a deterministic local command that syncs generated API docs before creating a version snapshot and validates the result before any tag-triggered automation is considered.

### How

- Replaced the website `version` npm script with a local wrapper script.
- The wrapper keeps the existing command shape: `npm run version -- <release-version>`.
- The command now runs docs sync, creates the Docusaurus docs version, then runs the production website build for local validation.
- Documented the updated local versioning behavior in `website/README.md`.

This does not add tag-triggered automation, deploy behavior, or CI commits of generated versioned docs.

## Checklist

- [x] Added or updated unit tests for all changes (not applicable: website script/docs change; verified with local command checks)
- [x] Added or updated documentation for all changes

Verification:

- `node --check website/scripts/version-docs.js`
- `git diff --check upstream/main..HEAD`
- `npm run version` (verifies required-version usage error)
- `npm run version -- 1355-local-check` (temporary generated version removed after verification)
