### PR TITLE
[MAHOUT-1438][Docs] Update QDP CUDA tensor dtype guidance for float32 angle and basis

### DIFF
--- a/docs/qdp/getting-started.md
+++ b/docs/qdp/getting-started.md
@@ -121,7 +121,7 @@ Notes:
 ## Tips
 
 - Default `precision` is `"float32"`; pass `precision="float64"` for higher precision: `QdpEngine(device_id=0, precision="float64")`.
-- NumPy inputs must be `float64` dtype. CUDA `torch.Tensor` inputs accept `float32` or `float64` for amplitude; angle and IQP methods require `float64` for batched inputs.
+- NumPy inputs must be `float64` dtype. CUDA `torch.Tensor` inputs support `float32` or `float64` for `amplitude` and `angle` single-sample or batched inputs; `basis` accepts `int64` or `float32` single-sample or batched index tensors. `iqp` and `iqp-z` CUDA tensor inputs require `float64`, and `phase` currently requires host input.
 - Backend selection is explicit; valid values are `"cuda"` and `"amd"` (with `"triton_amd"` accepted as an alias for `"amd"`).
 
 ## Troubleshooting

--- a/qdp/qdp-python/README.md
+++ b/qdp/qdp-python/README.md
@@ -89,12 +89,14 @@ Backend support boundary:
 ### Pipeline / loader dtype (Rust internals)
 
 `QuantumDataLoader` and `run_throughput_pipeline` build a Rust `PipelineConfig` with an
-`encoding` plus a `dtype` (float32 vs float64). The prefetch thread can only keep an
+`encoding` plus a `dtype` (float32 vs float64). The prefetch thread can keep an
 end-to-end **float32 host batch** for encodings whose GPU stack implements the batch **f32**
-path (`encode_batch_f32`). **Today that is amplitude only.** Angle and basis still fall back
-to float64 for that loop until their batch f32 implementations exist. The eventual full
-matrix (e.g. angle/basis under `supports_f32` once kernels are wired) is broader than what
-the pipeline uses today.
+path (`encode_batch_f32`): `amplitude`, `angle`, and `basis`. IQP-family and phase
+encodings still normalize to float64 in this loop.
+
+For streaming basis files, the loader reads basis indices as float64 even when float32 is
+requested, because basis values are integer state indices and float32 cannot represent
+large indices exactly.
 
 ## Input Sources
 


### PR DESCRIPTION
### Related Issues

Closes #1438 

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

The docs were behind the current QDP CUDA tensor implementation. Angle and basis now have float32 single-sample and batched CUDA tensor paths, but the docs still described older limitations.

### How

- Updated `qdp/qdp-python/README.md` to list `amplitude`, `angle`, and `basis` as encodings with batch f32 pipeline support.
- Added the streaming basis caveat: basis file indices are read as float64 when streaming because float32 may not exactly represent large integer indices.
- Updated `docs/qdp/getting-started.md` with the current CUDA tensor dtype guidance for amplitude, angle, basis, IQP-family, and phase.

## Checklist

- [ ] Added or updated unit tests for all changes
- [x] Added or updated documentation for all changes
