### PR TITLE
docs(qdp): improve generated Markdown rendering

### DIFF
--- a/qdp/qdp-python/qumat_qdp/_backend.py
+++ b/qdp/qdp-python/qumat_qdp/_backend.py
@@ -72,7 +72,7 @@ def get_backend() -> Backend:
     """Return the active backend.
 
     Only the Rust backend is auto-detected.  The PyTorch reference
-    backend must be selected explicitly via :func:`force_backend`.
+    backend must be selected explicitly via ``force_backend()``.
     """
     if _forced_backend is not None:
         return _forced_backend

--- a/qdp/qdp-python/qumat_qdp/api.py
+++ b/qdp/qdp-python/qumat_qdp/api.py
@@ -18,15 +18,18 @@
 Benchmark API: supports Rust-optimized pipeline and PyTorch reference backend.
 
 Usage:
-    from qumat_qdp import QdpBenchmark, ThroughputResult, LatencyResult
 
-    # Rust backend (default):
-    result = (QdpBenchmark(device_id=0).qubits(16).encoding("amplitude")
-              .batches(100, size=64).warmup(2).run_throughput())
+```python
+from qumat_qdp import QdpBenchmark, ThroughputResult, LatencyResult
 
-    # PyTorch reference (must be explicitly selected):
-    result = (QdpBenchmark(device_id=0).backend("pytorch").qubits(16)
-              .encoding("amplitude").batches(100, size=64).run_throughput())
+# Rust backend (default):
+result = (QdpBenchmark(device_id=0).qubits(16).encoding("amplitude")
+          .batches(100, size=64).warmup(2).run_throughput())
+
+# PyTorch reference (must be explicitly selected):
+result = (QdpBenchmark(device_id=0).backend("pytorch").qubits(16)
+          .encoding("amplitude").batches(100, size=64).run_throughput())
+```
 """
 
 from __future__ import annotations
@@ -40,7 +43,7 @@ from typing import Any
 class ThroughputResult:
     """Throughput benchmark measurement.
 
-    Returned by :meth:`QdpBenchmark.run_throughput`.  ``duration_sec`` is the
+    Returned by ``QdpBenchmark.run_throughput()``.  ``duration_sec`` is the
     measured timed section after any configured warmup batches.  ``vectors_per_sec``
     is computed over ``total_batches * batch_size`` encoded input vectors.
     """
@@ -53,7 +56,7 @@ class ThroughputResult:
 class LatencyResult:
     """Latency benchmark measurement.
 
-    Returned by :meth:`QdpBenchmark.run_latency`.  ``duration_sec`` is the same
+    Returned by ``QdpBenchmark.run_latency()``.  ``duration_sec`` is the same
     timed interval used for throughput, and ``latency_ms_per_vector`` is the
     average milliseconds per encoded input vector across the measured batches.
     """
@@ -206,7 +209,7 @@ class QdpBenchmark:
         pipeline with any configured warmup batches; ``"pytorch"`` runs the
         reference encoder loop and synchronizes CUDA timing when applicable.
 
-        :returns: A :class:`ThroughputResult` containing elapsed seconds and
+        :returns: A ``ThroughputResult`` containing elapsed seconds and
             encoded vectors per second.
         :raises ValueError: If required benchmark parameters are missing.
         :raises RuntimeError: If the Rust backend is selected but unavailable.
@@ -223,7 +226,7 @@ class QdpBenchmark:
         method.  The Rust backend reports latency from the native pipeline; the
         PyTorch backend derives average latency from its throughput run.
 
-        :returns: A :class:`LatencyResult` containing elapsed seconds and mean
+        :returns: A ``LatencyResult`` containing elapsed seconds and mean
             milliseconds per encoded vector.
         :raises ValueError: If required benchmark parameters are missing.
         :raises RuntimeError: If the Rust backend is selected but unavailable.

--- a/qdp/qdp-python/qumat_qdp/loader.py
+++ b/qdp/qdp-python/qumat_qdp/loader.py
@@ -18,13 +18,16 @@
 Quantum Data Loader: Python builder for Rust-backed batch iterator.
 
 Usage:
-    from qumat_qdp import QuantumDataLoader
 
-    loader = (QuantumDataLoader(device_id=0).qubits(16).encoding("amplitude")
-              .batches(100, size=64).source_synthetic())
-    for qt in loader:
-        batch = torch.from_dlpack(qt)
-        ...
+```python
+from qumat_qdp import QuantumDataLoader
+
+loader = (QuantumDataLoader(device_id=0).qubits(16).encoding("amplitude")
+          .batches(100, size=64).source_synthetic())
+for qt in loader:
+    batch = torch.from_dlpack(qt)
+    ...
+```
 """
 
 from __future__ import annotations
@@ -333,7 +336,7 @@ class QuantumDataLoader:
         ``"iqp"``, ``"iqp-z"``, and ``"phase"``.  Use these canonical
         lowercase names because the selected backend receives the string exactly
         as supplied.  The PyTorch reference backend supports the same methods as
-        :mod:`qumat_qdp.torch_ref`; use the native backend for methods that are
+        ``qumat_qdp.torch_ref``; use the native backend for methods that are
         not available in the reference path.
 
         :param method: Encoding method name.
@@ -415,7 +418,7 @@ class QuantumDataLoader:
         Remote ``s3://`` and ``gs://`` paths are accepted when the native remote
         I/O feature is enabled; remote query strings and fragments are rejected.
 
-        Element precision is controlled by :meth:`dtype`. By default file input is
+        Element precision is controlled by ``dtype()``. By default file input is
         loaded as ``float64`` (lossless). Selecting ``dtype("float32")`` narrows f64
         file contents to f32 on load; values outside the f32 range become ``±Inf``.
         ``basis`` encoding is exempt: its values are integer state indices, so it is
@@ -450,9 +453,9 @@ class QuantumDataLoader:
     def dtype(self, name: str) -> QuantumDataLoader:
         """Set the element precision used when loading file sources.
 
-        Applies to the native :meth:`source_file` path. ``"float64"`` (the default)
+        Applies to the native ``source_file()`` path. ``"float64"`` (the default)
         loads file contents losslessly; ``"float32"`` narrows them to f32 on load.
-        See :meth:`source_file` for the cast caveats, including the ``basis``
+        See ``source_file()`` for the cast caveats, including the ``basis``
         exemption.
 
         :param name: ``"float32"``/``"f32"`` or ``"float64"``/``"f64"`` (case-insensitive).

--- a/qdp/qdp-python/qumat_qdp/tensor.py
+++ b/qdp/qdp-python/qumat_qdp/tensor.py
@@ -85,5 +85,5 @@ class QdpTensor:
         return torch.from_dlpack(self)
 
 
-#: Backward-compatible alias for :class:`QdpTensor`.
+#: Backward-compatible alias for ``QdpTensor``.
 QuantumTensor = QdpTensor


### PR DESCRIPTION
### Related Issues

Part of #1358  
Related to #1361

### Changes

- [ ] Bug fix
- [ ] New feature
- [ ] Refactoring
- [x] Documentation
- [ ] Test
- [ ] CI/CD pipeline
- [ ] Other

### Why

QDP source docstrings contain reStructuredText roles and unfenced usage examples that do not render cleanly in the generated Docusaurus API reference.

This causes references such as `:meth:` and `:class:` to appear literally and makes Python usage examples harder to distinguish from surrounding prose.

### How

- Replace reStructuredText roles with Markdown-compatible inline code in QDP docstrings.
- Wrap the `QdpBenchmark` usage example in a fenced Python code block.
- Wrap the `QuantumDataLoader` usage example in a fenced Python code block.
- Keep the changes documentation-only without modifying runtime behavior or the public API surface.

The changes are limited to:

- `qdp/qdp-python/qumat_qdp/_backend.py`
- `qdp/qdp-python/qumat_qdp/api.py`
- `qdp/qdp-python/qumat_qdp/loader.py`
- `qdp/qdp-python/qumat_qdp/tensor.py`

### Validation

- Generated the QDP Python API reference with `pydoc-markdown`.
- Confirmed the usage examples render as Python code blocks.
- Confirmed reStructuredText role markers no longer appear in the generated Markdown.
- Existing QDP Python tests: 7 passed, 6 skipped because the native extension was not built.

## Checklist

- [ ] Added or updated unit tests for all changes — not applicable; documentation-only change
- [x] Added or updated documentation for all changes